### PR TITLE
initial particle id work

### DIFF
--- a/src/include/injector_simple.hxx
+++ b/src/include/injector_simple.hxx
@@ -29,7 +29,7 @@ struct InjectorSimple
       auto prt = Particle{{real_t(new_prt.x[0] - patch.xb[0]), real_t(new_prt.x[1] - patch.xb[1]), real_t(new_prt.x[2] - patch.xb[2])},
 			  {real_t(new_prt.u[0]), real_t(new_prt.u[1]), real_t(new_prt.u[2])},
 			  real_t(new_prt.w * mprts_.grid().kinds[new_prt.kind].q),
-			  new_prt.kind, -1};
+			  new_prt.kind, new_prt.id};
       mprts_[p_].push_back(prt);
     }
     

--- a/src/include/injector_simple.hxx
+++ b/src/include/injector_simple.hxx
@@ -29,7 +29,7 @@ struct InjectorSimple
       auto prt = Particle{{real_t(new_prt.x[0] - patch.xb[0]), real_t(new_prt.x[1] - patch.xb[1]), real_t(new_prt.x[2] - patch.xb[2])},
 			  {real_t(new_prt.u[0]), real_t(new_prt.u[1]), real_t(new_prt.u[2])},
 			  real_t(new_prt.w * mprts_.grid().kinds[new_prt.kind].q),
-			  new_prt.kind};
+			  new_prt.kind, -1};
       mprts_[p_].push_back(prt);
     }
     

--- a/src/include/particle_simple.hxx
+++ b/src/include/particle_simple.hxx
@@ -15,7 +15,7 @@ struct ParticleSimple
 
   ParticleSimple() = default;
 
-  KG_INLINE ParticleSimple(Real3 x, Real3 u, real_t qni_wni, int kind)
+  KG_INLINE ParticleSimple(Real3 x, Real3 u, real_t qni_wni, int kind, int id)
     : x{x},
       u{u},
       kind{kind},
@@ -29,6 +29,8 @@ struct ParticleSimple
   }
 
   KG_INLINE bool operator!=(const ParticleSimple& other) const { return !(*this == other); }
+
+  KG_INLINE bool id()  const { return 0; }
 
 public:
   Real3 x;

--- a/src/include/particle_with_id.h
+++ b/src/include/particle_with_id.h
@@ -15,11 +15,12 @@ struct ParticleWithId
 
   ParticleWithId() = default;
 
-  KG_INLINE ParticleWithId(Real3 x, Real3 u, real_t qni_wni, int kind)
+  KG_INLINE ParticleWithId(Real3 x, Real3 u, real_t qni_wni, int kind, int id)
     : x{x},
       u{u},
       kind{kind},
-      qni_wni{qni_wni}
+      qni_wni{qni_wni},
+      id_{id}
   {}
 
   KG_INLINE bool operator==(const ParticleWithId& other) const
@@ -30,12 +31,14 @@ struct ParticleWithId
 
   KG_INLINE bool operator!=(const ParticleWithId& other) const { return !(*this == other); }
 
+  KG_INLINE int id() const { return id_; }
+
 public:
   Real3 x;
   Real3 u;
   int kind;
   real_t qni_wni;
-  int id;
+  int id_;
 };
 
 template <typename R>
@@ -55,7 +58,7 @@ public:
     func("uz", [](Particle& prt) { return &prt.u[2]; });
     func("kind", [](Particle& prt) { return &prt.kind; });
     func("qni_wni", [](Particle& prt) { return &prt.qni_wni; });
-    func("id", [](Particle& prt) { return &prt.id; });
+    func("id", [](Particle& prt) { return &prt.id_; });
   }
 };
 

--- a/src/include/particle_with_id.h
+++ b/src/include/particle_with_id.h
@@ -1,0 +1,61 @@
+
+#pragma once
+
+#include "cuda_compat.h"
+#include "particles.hxx"
+
+// ======================================================================
+// ParticleWithId
+
+template<typename _Real>
+struct ParticleWithId
+{
+  using real_t = _Real;
+  using Real3 = Vec3<real_t>;
+
+  ParticleWithId() = default;
+
+  KG_INLINE ParticleWithId(Real3 x, Real3 u, real_t qni_wni, int kind)
+    : x{x},
+      u{u},
+      kind{kind},
+      qni_wni{qni_wni}
+  {}
+
+  KG_INLINE bool operator==(const ParticleWithId& other) const
+  {
+    return (x == other.x && qni_wni == other.qni_wni &&
+	    u == other.u && kind == other.kind && id == other.id);
+  }
+
+  KG_INLINE bool operator!=(const ParticleWithId& other) const { return !(*this == other); }
+
+public:
+  Real3 x;
+  Real3 u;
+  int kind;
+  real_t qni_wni;
+  int id;
+};
+
+template <typename R>
+class ForComponents<ParticleWithId<R>>
+{
+public:
+  using Particle = ParticleWithId<R>;
+
+  template <typename FUNC>
+  static void run(FUNC&& func)
+  {
+    func("x", [](Particle& prt) { return &prt.x[0]; });
+    func("y", [](Particle& prt) { return &prt.x[1]; });
+    func("z", [](Particle& prt) { return &prt.x[2]; });
+    func("ux", [](Particle& prt) { return &prt.u[0]; });
+    func("uy", [](Particle& prt) { return &prt.u[1]; });
+    func("uz", [](Particle& prt) { return &prt.u[2]; });
+    func("kind", [](Particle& prt) { return &prt.kind; });
+    func("qni_wni", [](Particle& prt) { return &prt.qni_wni; });
+    func("id", [](Particle& prt) { return &prt.id; });
+  }
+};
+

--- a/src/include/psc_particles.h
+++ b/src/include/psc_particles.h
@@ -16,6 +16,7 @@ struct particle_inject
   double u[3];
   double w;
   int kind;
+  int id;
 };
 
 #define MP_DONT_COPY (0x1)

--- a/src/libpsc/psc_particles_impl.cxx
+++ b/src/libpsc/psc_particles_impl.cxx
@@ -1,6 +1,7 @@
 
 #include "psc_particles_single.h"
 #include "psc_particles_double.h"
+#include "particle_with_id.h"
 
 template<typename MP_FROM, typename MP_TO>
 struct Convert
@@ -69,6 +70,12 @@ template<> const MparticlesBase::Convert MparticlesSingle::convert_from_ = {
 // ======================================================================
 // psc_mparticles: subclass "double"
 
-template<> const MparticlesBase::Convert MparticlesDouble::convert_to_{};
-template<> const MparticlesBase::Convert MparticlesDouble::convert_from_{};
+template<> const MparticlesBase::Convert MparticlesDouble::convert_to_ = {};
+template<> const MparticlesBase::Convert MparticlesDouble::convert_from_ = {};
+
+// ======================================================================
+// MparticlesSimple<ParticleWithId<float>>
+
+template<> const MparticlesBase::Convert MparticlesSimple<ParticleWithId<float>>::convert_to_ = {};
+template<> const MparticlesBase::Convert MparticlesSimple<ParticleWithId<float>>::convert_from_ = {};
 

--- a/src/libpsc/psc_particles_impl.cxx
+++ b/src/libpsc/psc_particles_impl.cxx
@@ -17,7 +17,7 @@ struct Convert
     using Real3 = typename MparticlesTo::Real3;
     
     return {Real3(prt_from.x), Real3(prt_from.u),
-	    real_t(prt_from.qni_wni), prt_from.kind};
+	real_t(prt_from.qni_wni), prt_from.kind, prt_from.id()};
   }
 };
 

--- a/src/libpsc/vpic/psc_particles_vpic.cxx
+++ b/src/libpsc/vpic/psc_particles_vpic.cxx
@@ -49,7 +49,7 @@ void copy_to(MparticlesBase& mprts_from_base, MparticlesBase& mprts_to_base)
 	auto u = Vec3<float>{vprt.ux, vprt.uy, vprt.uz};
 	auto kind = sp->id;
 	auto qni_wni = float(vprt.w * dVi) * float(mprts_to.grid().kinds[kind].q);
-	mprts_to[p].push_back({x, u, qni_wni, kind});
+	mprts_to[p].push_back({x, u, qni_wni, kind, 0});
       }
     }
   }

--- a/src/psc_flatfoil_yz.cxx
+++ b/src/psc_flatfoil_yz.cxx
@@ -111,10 +111,22 @@ public:
 // EDIT to change order / floating point type / cuda / 2d/3d
 
 using Dim = dim_yz;
+
+#if 1
 #ifdef USE_CUDA
 using PscConfig = PscConfig1vbecCuda<Dim>;
 #else
 using PscConfig = PscConfig1vbecSingle<Dim>;
+#endif
+
+#else
+
+#include "particle_with_id.h"
+
+using PscConfig =
+  PscConfig_<Dim, MparticlesSimple<ParticleWithId<float>>, MfieldsStateSingle,
+             MfieldsSingle, PscConfigPushParticles1vbec>;
+
 #endif
 
 // ----------------------------------------------------------------------


### PR DESCRIPTION
This implements a new variant of `ParticleSimple` that includes an `id` member. It's not used by default, but if turned on it survives basic testing. It's not particularly useful yet, because there is no code that
actually sets the id to a unique value, nor is it output (except in checkpoints).
