### PR TITLE
rework setup particles

### DIFF
--- a/src/include/inject_impl.hxx
+++ b/src/include/inject_impl.hxx
@@ -51,15 +51,18 @@ struct Inject_ : InjectBase
 
     auto lf_init_npt = [&](int kind, Double3 pos, int p, Int3 idx,
                            psc_particle_npt& npt) {
-      target_.init_npt(kind, pos, npt);
-      npt.n -= mf_n[p](kind_n, idx[0], idx[1], idx[2]);
-      if (npt.n < 0) {
-        npt.n = 0;
+      if (target_.is_inside(pos)) {
+	target_.init_npt(kind, pos, npt);
+	npt.n -= mf_n[p](kind_n, idx[0], idx[1], idx[2]);
+	if (npt.n < 0) {
+	  npt.n = 0;
+	}
+	npt.n *= fac;
       }
-      npt.n *= fac;
     };
 
     auto inj = mprts.injector();
+
     for (int p = 0; p < mprts.n_patches(); ++p) {
       auto ldims = grid.ldims;
       auto injector = inj[p];
@@ -77,10 +80,6 @@ struct Inject_ : InjectBase
               pos[1] = grid.patches[p].y_nc(jy);
             if (grid.isInvar(2) == 1)
               pos[2] = grid.patches[p].z_nc(jz);
-
-            if (!target_.is_inside(pos)) {
-              continue;
-            }
 
             int n_q_in_cell = 0;
             for (int kind = 0; kind < kinds.size(); kind++) {

--- a/src/include/inject_impl.hxx
+++ b/src/include/inject_impl.hxx
@@ -83,16 +83,13 @@ struct Inject_ : InjectBase
 		
 		int n_in_cell;
 		if (kind != setup_particles.neutralizing_population) {
-		  if (grid.timestep() >= 0) {
-		    npt.n -= N(kind_n, jx,jy,jz);
-		    if (npt.n < 0) {
-		      n_in_cell = 0;
-		    } else {
-		      // this rounds down rather than trying to get fractional particles
-		      // statistically right...
-		      n_in_cell = npt.n *fac;		}
+		  npt.n -= N(kind_n, jx,jy,jz);
+		  if (npt.n < 0) {
+		    n_in_cell = 0;
 		  } else {
-		    n_in_cell = setup_particles.get_n_in_cell(grid, &npt);
+		    // this rounds down rather than trying to get fractional particles
+		    // statistically right...
+		    n_in_cell = npt.n * fac;
 		  }
 		  n_q_in_cell += npt.q * n_in_cell;
 		} else {

--- a/src/include/inject_impl.hxx
+++ b/src/include/inject_impl.hxx
@@ -85,12 +85,11 @@ struct Inject_ : InjectBase
 		if (kind != setup_particles.neutralizing_population) {
 		  npt.n -= N(kind_n, jx,jy,jz);
 		  if (npt.n < 0) {
-		    n_in_cell = 0;
-		  } else {
-		    // this rounds down rather than trying to get fractional particles
-		    // statistically right...
-		    n_in_cell = npt.n * fac;
+		    npt.n = 0;
 		  }
+		  // this rounds down rather than trying to get fractional particles
+		  // statistically right...
+		  n_in_cell = npt.n * fac;
 		  n_q_in_cell += npt.q * n_in_cell;
 		} else {
 		  // FIXME, should handle the case where not the last population is neutralizing

--- a/src/include/inject_impl.hxx
+++ b/src/include/inject_impl.hxx
@@ -1,10 +1,10 @@
 
 
-#include <inject.hxx>
-#include <fields.hxx>
-#include <bnd.hxx>
-#include <fields_item.hxx>
 #include "../libpsc/psc_output_fields/fields_item_moments_1st.hxx"
+#include <bnd.hxx>
+#include <fields.hxx>
+#include <fields_item.hxx>
+#include <inject.hxx>
 
 #include <stdlib.h>
 #include <string>
@@ -12,23 +12,21 @@
 // ======================================================================
 // Inject_
 
-template<typename _Mparticles, typename _Mfields, typename Target_t,
-	 typename _ItemMoment>
+template <typename _Mparticles, typename _Mfields, typename Target_t,
+          typename _ItemMoment>
 struct Inject_ : InjectBase
 {
   using Mfields = _Mfields;
   using Mparticles = _Mparticles;
   using real_t = typename Mparticles::real_t;
   using ItemMoment_t = _ItemMoment;
-  
+
   // ----------------------------------------------------------------------
   // ctor
-  
+
   Inject_(const Grid_t& grid, int interval, int tau, int kind_n,
-	  Target_t target)
-    : InjectBase{interval, tau, kind_n},
-      target_{target},
-      moment_n_{grid}
+          Target_t target)
+    : InjectBase{interval, tau, kind_n}, target_{target}, moment_n_{grid}
   {}
 
   // ----------------------------------------------------------------------
@@ -43,121 +41,127 @@ struct Inject_ : InjectBase
     // FIXME, this is taken from and kinda specific to psc_flatfoil_yz.cxx,
     // and really shouldn't be replicated so many times anyway
     setup_particles.fractional_n_particles_per_cell = true;
-    setup_particles.neutralizing_population = 1;// MY_ELECTRON;
-    
+    setup_particles.neutralizing_population = 1; // MY_ELECTRON;
+
     real_t fac = (interval * grid.dt / tau) / (1. + interval * grid.dt / tau);
 
     moment_n_.run(mprts);
     auto& mres = moment_n_.result();
-    auto& mf_n = mres.template get_as<Mfields>(kind_n, kind_n+1);
+    auto& mf_n = mres.template get_as<Mfields>(kind_n, kind_n + 1);
 
-    auto lf_init_npt = [&](int kind, Double3 pos, int p, Int3 idx, psc_particle_npt& npt) {
+    auto lf_init_npt = [&](int kind, Double3 pos, int p, Int3 idx,
+                           psc_particle_npt& npt) {
       target_.init_npt(kind, pos, npt);
       npt.n -= mf_n[p](kind_n, idx[0], idx[1], idx[2]);
       if (npt.n < 0) {
-	npt.n = 0;
+        npt.n = 0;
       }
       npt.n *= fac;
     };
 
     auto inj = mprts.injector();
     for (int p = 0; p < mprts.n_patches(); p++) {
-      const int *ldims = grid.ldims;
+      const int* ldims = grid.ldims;
       auto injector = inj[p];
-      
+
       for (int jz = 0; jz < ldims[2]; jz++) {
-	for (int jy = 0; jy < ldims[1]; jy++) {
-	  for (int jx = 0; jx < ldims[0]; jx++) {
-	    Double3 pos = {grid.patches[p].x_cc(jx), grid.patches[p].y_cc(jy), grid.patches[p].z_cc(jz)};
-	    // FIXME, the issue really is that (2nd order) particle pushers
-	    // don't handle the invariant dim right
-	    if (grid.isInvar(0) == 1) pos[0] = grid.patches[p].x_nc(jx);
-	    if (grid.isInvar(1) == 1) pos[1] = grid.patches[p].y_nc(jy);
-	    if (grid.isInvar(2) == 1) pos[2] = grid.patches[p].z_nc(jz);
-	    
-	    if (!target_.is_inside(pos)) {
-	      continue;
-	    }
-	    
-	    int n_q_in_cell = 0;
-	    for (int kind = 0; kind < kinds.size(); kind++) {
-	      struct psc_particle_npt npt = {};
-	      npt.kind = kind;
-	      npt.q    = kinds[kind].q;
-	      npt.m    = kinds[kind].m;
-	      lf_init_npt(kind, pos, p, {jx, jy, jz}, npt);
-	      
-	      int n_in_cell;
-	      if (kind != setup_particles.neutralizing_population) {
-		n_in_cell = setup_particles.get_n_in_cell(grid, &npt);
-		n_q_in_cell += npt.q * n_in_cell;
-	      } else {
-		// FIXME, should handle the case where not the last population is neutralizing
-		assert(setup_particles.neutralizing_population == kinds.size() - 1);
-		n_in_cell = -n_q_in_cell / npt.q;
-	      }
-	      
-	      for (int cnt = 0; cnt < n_in_cell; cnt++) {
-		assert(setup_particles.fractional_n_particles_per_cell);
-		real_t wni = 1.; // ??? FIXME
-		auto prt = particle_inject{{}, {}, wni, npt.kind};
-		setup_particles.setup_particle(grid, &prt, &npt, p, pos);
-		
-		injector(prt);
-	      }
-	    }
-	  }
-	}
+        for (int jy = 0; jy < ldims[1]; jy++) {
+          for (int jx = 0; jx < ldims[0]; jx++) {
+            Double3 pos = {grid.patches[p].x_cc(jx), grid.patches[p].y_cc(jy),
+                           grid.patches[p].z_cc(jz)};
+            // FIXME, the issue really is that (2nd order) particle pushers
+            // don't handle the invariant dim right
+            if (grid.isInvar(0) == 1)
+              pos[0] = grid.patches[p].x_nc(jx);
+            if (grid.isInvar(1) == 1)
+              pos[1] = grid.patches[p].y_nc(jy);
+            if (grid.isInvar(2) == 1)
+              pos[2] = grid.patches[p].z_nc(jz);
+
+            if (!target_.is_inside(pos)) {
+              continue;
+            }
+
+            int n_q_in_cell = 0;
+            for (int kind = 0; kind < kinds.size(); kind++) {
+              struct psc_particle_npt npt = {};
+              npt.kind = kind;
+              npt.q = kinds[kind].q;
+              npt.m = kinds[kind].m;
+              lf_init_npt(kind, pos, p, {jx, jy, jz}, npt);
+
+              int n_in_cell;
+              if (kind != setup_particles.neutralizing_population) {
+                n_in_cell = setup_particles.get_n_in_cell(grid, &npt);
+                n_q_in_cell += npt.q * n_in_cell;
+              } else {
+                // FIXME, should handle the case where not the last population
+                // is neutralizing
+                assert(setup_particles.neutralizing_population ==
+                       kinds.size() - 1);
+                n_in_cell = -n_q_in_cell / npt.q;
+              }
+
+              for (int cnt = 0; cnt < n_in_cell; cnt++) {
+                assert(setup_particles.fractional_n_particles_per_cell);
+                real_t wni = 1.; // ??? FIXME
+                auto prt = particle_inject{{}, {}, wni, npt.kind};
+                setup_particles.setup_particle(grid, &prt, &npt, p, pos);
+
+                injector(prt);
+              }
+            }
+          }
+        }
       }
     }
-      
+
     mres.put_as(mf_n, 0, 0);
   }
 
   // ----------------------------------------------------------------------
   // run
-  
+
   void run(MparticlesBase& mprts_base, MfieldsBase& mflds_base) override
   {
     auto& mprts = mprts_base.get_as<Mparticles>();
     (*this)(mprts);
     mprts_base.put_as(mprts);
   }
-  
+
 private:
   Target_t target_;
   ItemMoment_t moment_n_;
 };
-
 
 // ======================================================================
 // InjectSelector
 //
 // FIXME, should go away eventually
 
-template<typename Mparticles, typename InjectShape, typename Dim,
-	 typename Enable=void>
+template <typename Mparticles, typename InjectShape, typename Dim,
+          typename Enable = void>
 struct InjectSelector
 {
-  using Inject = Inject_<Mparticles, MfieldsC, InjectShape,
-			 ItemMomentAddBnd<Moment_n_1st<Mparticles, MfieldsC>>>; // FIXME, shouldn't always use MfieldsC
+  using Inject =
+    Inject_<Mparticles, MfieldsC, InjectShape,
+            ItemMomentAddBnd<Moment_n_1st<
+              Mparticles, MfieldsC>>>; // FIXME, shouldn't always use MfieldsC
 };
 
 #ifdef USE_CUDA
 
-#include <psc_fields_single.h>
 #include "../libpsc/cuda/fields_item_moments_1st_cuda.hxx"
+#include <psc_fields_single.h>
 
-// This not particularly pretty template arg specializes InjectSelector for all CUDA
-// Mparticles types
-template<typename Mparticles, typename InjectShape, typename Dim>
+// This not particularly pretty template arg specializes InjectSelector for all
+// CUDA Mparticles types
+template <typename Mparticles, typename InjectShape, typename Dim>
 struct InjectSelector<Mparticles, InjectShape, Dim,
-		      typename std::enable_if<Mparticles::is_cuda::value>::type>
+                      typename std::enable_if<Mparticles::is_cuda::value>::type>
 {
   using Inject = Inject_<Mparticles, MfieldsSingle, InjectShape,
-			 Moment_n_1st_cuda<Mparticles, Dim>>;
+                         Moment_n_1st_cuda<Mparticles, Dim>>;
 };
 
 #endif
-
-

--- a/src/include/inject_impl.hxx
+++ b/src/include/inject_impl.hxx
@@ -51,8 +51,8 @@ struct Inject_ : InjectBase
     auto& mres = moment_n_.result();
     auto& mf_n = mres.template get_as<Mfields>(kind_n, kind_n+1);
 
-    auto lf_init_npt = [&](int kind, double crd[3], int p, Int3 idx, psc_particle_npt& npt) {
-      target_.init_npt(kind, crd, npt);
+    auto lf_init_npt = [&](int kind, Double3 pos, int p, Int3 idx, psc_particle_npt& npt) {
+      target_.init_npt(kind, pos, npt);
       npt.n -= mf_n[p](kind_n, idx[0], idx[1], idx[2]);
       if (npt.n < 0) {
 	npt.n = 0;
@@ -69,14 +69,14 @@ struct Inject_ : InjectBase
 	for (int jz = 0; jz < ldims[2]; jz++) {
 	  for (int jy = 0; jy < ldims[1]; jy++) {
 	    for (int jx = 0; jx < ldims[0]; jx++) {
-	      Vec3<double> xx = {grid.patches[p].x_cc(jx), grid.patches[p].y_cc(jy), grid.patches[p].z_cc(jz)};
+	      Double3 pos = {grid.patches[p].x_cc(jx), grid.patches[p].y_cc(jy), grid.patches[p].z_cc(jz)};
 	      // FIXME, the issue really is that (2nd order) particle pushers
 	      // don't handle the invariant dim right
-	      if (grid.isInvar(0) == 1) xx[0] = grid.patches[p].x_nc(jx);
-	      if (grid.isInvar(1) == 1) xx[1] = grid.patches[p].y_nc(jy);
-	      if (grid.isInvar(2) == 1) xx[2] = grid.patches[p].z_nc(jz);
+	      if (grid.isInvar(0) == 1) pos[0] = grid.patches[p].x_nc(jx);
+	      if (grid.isInvar(1) == 1) pos[1] = grid.patches[p].y_nc(jy);
+	      if (grid.isInvar(2) == 1) pos[2] = grid.patches[p].z_nc(jz);
 	      
-	      if (!target_.is_inside(xx)) {
+	      if (!target_.is_inside(pos)) {
 		continue;
 	      }
 	      
@@ -86,7 +86,7 @@ struct Inject_ : InjectBase
 		npt.kind = kind;
 		npt.q    = kinds[kind].q;
 		npt.m    = kinds[kind].m;
-		lf_init_npt(kind, xx, p, {jx, jy, jz}, npt);
+		lf_init_npt(kind, pos, p, {jx, jy, jz}, npt);
 		
 		int n_in_cell;
 		if (kind != setup_particles.neutralizing_population) {
@@ -102,7 +102,7 @@ struct Inject_ : InjectBase
 		  assert(setup_particles.fractional_n_particles_per_cell);
 		  real_t wni = 1.; // ??? FIXME
 		  auto prt = particle_inject{{}, {}, wni, npt.kind};
-		  setup_particles.setup_particle(grid, &prt, &npt, p, xx);
+		  setup_particles.setup_particle(grid, &prt, &npt, p, pos);
 		  
 		  injector(prt);
 		}

--- a/src/include/inject_impl.hxx
+++ b/src/include/inject_impl.hxx
@@ -60,59 +60,57 @@ struct Inject_ : InjectBase
       npt.n *= fac;
     };
 
-    {
-      auto inj = mprts.injector();
-      for (int p = 0; p < mprts.n_patches(); p++) {
-	const int *ldims = grid.ldims;
-	auto injector = inj[p];
-    
-	for (int jz = 0; jz < ldims[2]; jz++) {
-	  for (int jy = 0; jy < ldims[1]; jy++) {
-	    for (int jx = 0; jx < ldims[0]; jx++) {
-	      Double3 pos = {grid.patches[p].x_cc(jx), grid.patches[p].y_cc(jy), grid.patches[p].z_cc(jz)};
-	      // FIXME, the issue really is that (2nd order) particle pushers
-	      // don't handle the invariant dim right
-	      if (grid.isInvar(0) == 1) pos[0] = grid.patches[p].x_nc(jx);
-	      if (grid.isInvar(1) == 1) pos[1] = grid.patches[p].y_nc(jy);
-	      if (grid.isInvar(2) == 1) pos[2] = grid.patches[p].z_nc(jz);
+    auto inj = mprts.injector();
+    for (int p = 0; p < mprts.n_patches(); p++) {
+      const int *ldims = grid.ldims;
+      auto injector = inj[p];
+      
+      for (int jz = 0; jz < ldims[2]; jz++) {
+	for (int jy = 0; jy < ldims[1]; jy++) {
+	  for (int jx = 0; jx < ldims[0]; jx++) {
+	    Double3 pos = {grid.patches[p].x_cc(jx), grid.patches[p].y_cc(jy), grid.patches[p].z_cc(jz)};
+	    // FIXME, the issue really is that (2nd order) particle pushers
+	    // don't handle the invariant dim right
+	    if (grid.isInvar(0) == 1) pos[0] = grid.patches[p].x_nc(jx);
+	    if (grid.isInvar(1) == 1) pos[1] = grid.patches[p].y_nc(jy);
+	    if (grid.isInvar(2) == 1) pos[2] = grid.patches[p].z_nc(jz);
+	    
+	    if (!target_.is_inside(pos)) {
+	      continue;
+	    }
+	    
+	    int n_q_in_cell = 0;
+	    for (int kind = 0; kind < kinds.size(); kind++) {
+	      struct psc_particle_npt npt = {};
+	      npt.kind = kind;
+	      npt.q    = kinds[kind].q;
+	      npt.m    = kinds[kind].m;
+	      lf_init_npt(kind, pos, p, {jx, jy, jz}, npt);
 	      
-	      if (!target_.is_inside(pos)) {
-		continue;
+	      int n_in_cell;
+	      if (kind != setup_particles.neutralizing_population) {
+		n_in_cell = setup_particles.get_n_in_cell(grid, &npt);
+		n_q_in_cell += npt.q * n_in_cell;
+	      } else {
+		// FIXME, should handle the case where not the last population is neutralizing
+		assert(setup_particles.neutralizing_population == kinds.size() - 1);
+		n_in_cell = -n_q_in_cell / npt.q;
 	      }
 	      
-	      int n_q_in_cell = 0;
-	      for (int kind = 0; kind < kinds.size(); kind++) {
-		struct psc_particle_npt npt = {};
-		npt.kind = kind;
-		npt.q    = kinds[kind].q;
-		npt.m    = kinds[kind].m;
-		lf_init_npt(kind, pos, p, {jx, jy, jz}, npt);
+	      for (int cnt = 0; cnt < n_in_cell; cnt++) {
+		assert(setup_particles.fractional_n_particles_per_cell);
+		real_t wni = 1.; // ??? FIXME
+		auto prt = particle_inject{{}, {}, wni, npt.kind};
+		setup_particles.setup_particle(grid, &prt, &npt, p, pos);
 		
-		int n_in_cell;
-		if (kind != setup_particles.neutralizing_population) {
-		  n_in_cell = setup_particles.get_n_in_cell(grid, &npt);
-		  n_q_in_cell += npt.q * n_in_cell;
-		} else {
-		  // FIXME, should handle the case where not the last population is neutralizing
-		  assert(setup_particles.neutralizing_population == kinds.size() - 1);
-		  n_in_cell = -n_q_in_cell / npt.q;
-		}
-		
-		for (int cnt = 0; cnt < n_in_cell; cnt++) {
-		  assert(setup_particles.fractional_n_particles_per_cell);
-		  real_t wni = 1.; // ??? FIXME
-		  auto prt = particle_inject{{}, {}, wni, npt.kind};
-		  setup_particles.setup_particle(grid, &prt, &npt, p, pos);
-		  
-		  injector(prt);
-		}
+		injector(prt);
 	      }
 	    }
 	  }
 	}
       }
     }
-    
+      
     mres.put_as(mf_n, 0, 0);
   }
 

--- a/src/include/inject_impl.hxx
+++ b/src/include/inject_impl.hxx
@@ -60,76 +60,9 @@ struct Inject_ : InjectBase
     setup_particles.fractional_n_particles_per_cell = true;
     setup_particles.neutralizing_population = 1; // MY_ELECTRON;
 
-    setupParticles(mprts, setup_particles, lf_init_npt);
+    setup_particles.setupParticles(mprts, lf_init_npt);
 
     mres.put_as(mf_n, 0, 0);
-  }
-
-  template <typename FUNC>
-  void setupParticles(Mparticles& mprts,
-                      SetupParticles<Mparticles>& setup_particles, FUNC init_npt)
-  {
-    const auto& grid = mprts.grid();
-    const auto& kinds = grid.kinds;
-
-    auto inj = mprts.injector();
-
-    for (int p = 0; p < mprts.n_patches(); ++p) {
-      auto ldims = grid.ldims;
-      auto injector = inj[p];
-
-      for (int jz = 0; jz < ldims[2]; jz++) {
-        for (int jy = 0; jy < ldims[1]; jy++) {
-          for (int jx = 0; jx < ldims[0]; jx++) {
-            Double3 pos = {grid.patches[p].x_cc(jx), grid.patches[p].y_cc(jy),
-                           grid.patches[p].z_cc(jz)};
-            // FIXME, the issue really is that (2nd order) particle pushers
-            // don't handle the invariant dim right
-            if (grid.isInvar(0) == 1)
-              pos[0] = grid.patches[p].x_nc(jx);
-            if (grid.isInvar(1) == 1)
-              pos[1] = grid.patches[p].y_nc(jy);
-            if (grid.isInvar(2) == 1)
-              pos[2] = grid.patches[p].z_nc(jz);
-
-            int n_q_in_cell = 0;
-            for (int kind = 0; kind < kinds.size(); kind++) {
-              struct psc_particle_npt npt = {};
-              if (kind < kinds.size()) {
-                npt.kind = kind;
-                npt.q = kinds[kind].q;
-                npt.m = kinds[kind].m;
-              }
-              init_npt(kind, pos, p, {jx, jy, jz}, npt);
-
-              int n_in_cell;
-              if (kind != setup_particles.neutralizing_population) {
-                n_in_cell = setup_particles.get_n_in_cell(grid, &npt);
-                n_q_in_cell += npt.q * n_in_cell;
-              } else {
-                // FIXME, should handle the case where not the last population
-                // is neutralizing
-                assert(setup_particles.neutralizing_population ==
-                       kinds.size() - 1);
-                n_in_cell = -n_q_in_cell / npt.q;
-              }
-              for (int cnt = 0; cnt < n_in_cell; cnt++) {
-                real_t wni;
-                if (setup_particles.fractional_n_particles_per_cell) {
-                  wni = 1.;
-                } else {
-                  wni = npt.n / (n_in_cell * grid.norm.cori);
-                }
-                particle_inject prt{{}, {}, wni, npt.kind};
-                setup_particles.setup_particle(grid, &prt, &npt, p, pos);
-
-                injector(prt);
-              }
-            }
-          }
-        }
-      }
-    }
   }
 
   // ----------------------------------------------------------------------

--- a/src/include/inject_impl.hxx
+++ b/src/include/inject_impl.hxx
@@ -45,8 +45,7 @@ struct Inject_ : InjectBase
     setup_particles.fractional_n_particles_per_cell = true;
     setup_particles.neutralizing_population = 1;// MY_ELECTRON;
     
-    real_t fac = 1. / grid.norm.cori * 
-      (interval * grid.dt / tau) / (1. + interval * grid.dt / tau);
+    real_t fac = (interval * grid.dt / tau) / (1. + interval * grid.dt / tau);
 
     moment_n_.run(mprts);
     auto& mres = moment_n_.result();
@@ -87,9 +86,8 @@ struct Inject_ : InjectBase
 		  if (npt.n < 0) {
 		    npt.n = 0;
 		  }
-		  // this rounds down rather than trying to get fractional particles
-		  // statistically right...
-		  n_in_cell = npt.n * fac;
+		  npt.n *= fac;
+		  n_in_cell = setup_particles.get_n_in_cell(grid, &npt);
 		  n_q_in_cell += npt.q * n_in_cell;
 		} else {
 		  // FIXME, should handle the case where not the last population is neutralizing

--- a/src/include/psc_particles.h
+++ b/src/include/psc_particles.h
@@ -10,11 +10,12 @@
 
 struct particle_inject
 {
-  using real_t = double; // FIXME, do we want/need to keep this?
+  using real_t = double;
+  using Real3 = Vec3<real_t>;
   
-  double x[3];
-  double u[3];
-  double w;
+  Real3 x;
+  Real3 u;
+  real_t w;
   int kind;
   int id;
 };

--- a/src/include/setup_particles.hxx
+++ b/src/include/setup_particles.hxx
@@ -42,7 +42,7 @@ struct SetupParticles
   // setup_particle
   
   void setup_particle(const Grid_t& grid, particle_inject *prt, psc_particle_npt *npt,
-		      int p, double xx[3])
+		      int p, Double3 pos)
   {
     auto& kinds = grid.kinds;
     double beta = grid.norm.beta;
@@ -81,9 +81,9 @@ struct SetupParticles
     assert(npt->m == kinds[prt->kind].m);
     /* prt->qni = kinds[prt->kind].q; */
     /* prt->mni = kinds[prt->kind].m; */
-    prt->x[0] = xx[0];
-    prt->x[1] = xx[1];
-    prt->x[2] = xx[2];
+    prt->x[0] = pos[0];
+    prt->x[1] = pos[1];
+    prt->x[2] = pos[2];
     prt->u[0] = pxi;
     prt->u[1] = pyi;
     prt->u[2] = pzi;
@@ -110,14 +110,14 @@ struct SetupParticles
       for (int jz = ilo[2]; jz < ihi[2]; jz++) {
 	for (int jy = ilo[1]; jy < ihi[1]; jy++) {
 	  for (int jx = ilo[0]; jx < ihi[0]; jx++) {
-	    double xx[3] = {grid.patches[p].x_cc(jx),
-			    grid.patches[p].y_cc(jy),
-			    grid.patches[p].z_cc(jz)};
+	    Double3 pos = {grid.patches[p].x_cc(jx),
+			   grid.patches[p].y_cc(jy),
+			   grid.patches[p].z_cc(jz)};
 	    // FIXME, the issue really is that (2nd order) particle pushers
 	    // don't handle the invariant dim right
-	    if (grid.isInvar(0) == 1) xx[0] = grid.patches[p].x_nc(jx);
-	    if (grid.isInvar(1) == 1) xx[1] = grid.patches[p].y_nc(jy);
-	    if (grid.isInvar(2) == 1) xx[2] = grid.patches[p].z_nc(jz);
+	    if (grid.isInvar(0) == 1) pos[0] = grid.patches[p].x_nc(jx);
+	    if (grid.isInvar(1) == 1) pos[1] = grid.patches[p].y_nc(jy);
+	    if (grid.isInvar(2) == 1) pos[2] = grid.patches[p].z_nc(jz);
 	  
 	    int n_q_in_cell = 0;
 	    for (int kind = 0; kind < kinds.size(); kind++) {
@@ -127,7 +127,7 @@ struct SetupParticles
 		npt.q    = kinds[kind].q;
 		npt.m    = kinds[kind].m;
 	      };
-	      func(kind, xx, npt);
+	      func(kind, pos, npt);
 
 	      int n_in_cell;
 	      if (kind != neutralizing_population) {
@@ -147,7 +147,7 @@ struct SetupParticles
 		  wni = npt.n / (n_in_cell * grid.norm.cori);
 		}
 		particle_inject prt{{}, {}, wni, kind};
-		setup_particle(grid, &prt, &npt, p, xx);
+		setup_particle(grid, &prt, &npt, p, pos);
 		//p->lni = particle_label_offset + 1;
 		injector(prt);
 	      }
@@ -176,12 +176,12 @@ struct SetupParticles
       for (int jz = ilo[2]; jz < ihi[2]; jz++) {
 	for (int jy = ilo[1]; jy < ihi[1]; jy++) {
 	  for (int jx = ilo[0]; jx < ihi[0]; jx++) {
-	    double xx[3] = {grid.patches[p].x_cc(jx), grid.patches[p].y_cc(jy), grid.patches[p].z_cc(jz)};
+	    Double3 pos = {grid.patches[p].x_cc(jx), grid.patches[p].y_cc(jy), grid.patches[p].z_cc(jz)};
 	    // FIXME, the issue really is that (2nd order) particle pushers
 	    // don't handle the invariant dim right
-	    if (grid.isInvar(0) == 1) xx[0] = grid.patches[p].x_nc(jx);
-	    if (grid.isInvar(1) == 1) xx[1] = grid.patches[p].y_nc(jy);
-	    if (grid.isInvar(2) == 1) xx[2] = grid.patches[p].z_nc(jz);
+	    if (grid.isInvar(0) == 1) pos[0] = grid.patches[p].x_nc(jx);
+	    if (grid.isInvar(1) == 1) pos[1] = grid.patches[p].y_nc(jy);
+	    if (grid.isInvar(2) == 1) pos[2] = grid.patches[p].z_nc(jz);
 	  
 	    int n_q_in_cell = 0;
 	    for (int kind = 0; kind < kinds.size(); kind++) {
@@ -191,7 +191,7 @@ struct SetupParticles
 		npt.q    = kinds[kind].q;
 		npt.m    = kinds[kind].m;
 	      };
-	      func(kind, xx, npt);
+	      func(kind, pos, npt);
 
 	      int n_in_cell;
 	      if (kind != neutralizing_population) {

--- a/src/include/setup_particles.hxx
+++ b/src/include/setup_particles.hxx
@@ -100,6 +100,16 @@ struct SetupParticles
   void setup_particles(Mparticles& mprts, std::vector<uint>& n_prts_by_patch,
                        FUNC func)
   {
+    setupParticles(mprts, [&](int kind, Double3 pos, int p, Int3 idx,
+                              psc_particle_npt& npt) { func(kind, pos, npt); });
+  }
+
+  // ----------------------------------------------------------------------
+  // setupParticles
+
+  template <typename FUNC>
+  void setupParticles(Mparticles& mprts, FUNC init_npt)
+  {
     const auto& grid = mprts.grid();
     const auto& kinds = grid.kinds;
 
@@ -133,7 +143,7 @@ struct SetupParticles
                 npt.q = kinds[kind].q;
                 npt.m = kinds[kind].m;
               }
-              func(kind, pos, npt);
+              init_npt(kind, pos, p, {jx, jy, jz}, npt);
 
               int n_in_cell;
               if (kind != neutralizing_population) {

--- a/src/include/setup_particles.hxx
+++ b/src/include/setup_particles.hxx
@@ -1,11 +1,12 @@
 
 #pragma once
 
-struct psc_particle_npt {
-  int kind; ///< particle kind
-  double q; ///< charge
-  double m; ///< mass
-  double n; ///< density
+struct psc_particle_npt
+{
+  int kind;    ///< particle kind
+  double q;    ///< charge
+  double m;    ///< mass
+  double n;    ///< density
   double p[3]; ///< momentum
   double T[3]; ///< temperature
 };
@@ -13,25 +14,25 @@ struct psc_particle_npt {
 // ======================================================================
 // SetupParticles
 
-template<typename MP>
+template <typename MP>
 struct SetupParticles
 {
   using Mparticles = MP;
   using real_t = typename MP::real_t;
-  
+
   // ----------------------------------------------------------------------
   // get_n_in_cell
   //
   // helper function for partition / particle setup
-  
-  int get_n_in_cell(const Grid_t& grid, psc_particle_npt *npt)
+
+  int get_n_in_cell(const Grid_t& grid, psc_particle_npt* npt)
   {
     if (fractional_n_particles_per_cell) {
       int n_prts = npt->n / grid.norm.cori;
       float rmndr = npt->n / grid.norm.cori - n_prts;
-      float ran = random() / ((float) RAND_MAX + 1);
+      float ran = random() / ((float)RAND_MAX + 1);
       if (ran < rmndr) {
-	n_prts++;
+        n_prts++;
       }
       return n_prts;
     }
@@ -40,41 +41,44 @@ struct SetupParticles
 
   // ----------------------------------------------------------------------
   // setup_particle
-  
-  void setup_particle(const Grid_t& grid, particle_inject *prt, psc_particle_npt *npt,
-		      int p, Double3 pos)
+
+  void setup_particle(const Grid_t& grid, particle_inject* prt,
+                      psc_particle_npt* npt, int p, Double3 pos)
   {
     auto& kinds = grid.kinds;
     double beta = grid.norm.beta;
-    
+
     float ran1, ran2, ran3, ran4, ran5, ran6;
     do {
-      ran1 = random() / ((float) RAND_MAX + 1);
-      ran2 = random() / ((float) RAND_MAX + 1);
-      ran3 = random() / ((float) RAND_MAX + 1);
-      ran4 = random() / ((float) RAND_MAX + 1);
-      ran5 = random() / ((float) RAND_MAX + 1);
-      ran6 = random() / ((float) RAND_MAX + 1);
-    } while (ran1 >= 1.f || ran2 >= 1.f || ran3 >= 1.f ||
-	     ran4 >= 1.f || ran5 >= 1.f || ran6 >= 1.f);
-	      
-    double pxi = npt->p[0] +
-      sqrtf(-2.f*npt->T[0]/npt->m*sqr(beta)*logf(1.0-ran1)) * cosf(2.f*M_PI*ran2);
-    double pyi = npt->p[1] +
-      sqrtf(-2.f*npt->T[1]/npt->m*sqr(beta)*logf(1.0-ran3)) * cosf(2.f*M_PI*ran4);
-    double pzi = npt->p[2] +
-      sqrtf(-2.f*npt->T[2]/npt->m*sqr(beta)*logf(1.0-ran5)) * cosf(2.f*M_PI*ran6);
+      ran1 = random() / ((float)RAND_MAX + 1);
+      ran2 = random() / ((float)RAND_MAX + 1);
+      ran3 = random() / ((float)RAND_MAX + 1);
+      ran4 = random() / ((float)RAND_MAX + 1);
+      ran5 = random() / ((float)RAND_MAX + 1);
+      ran6 = random() / ((float)RAND_MAX + 1);
+    } while (ran1 >= 1.f || ran2 >= 1.f || ran3 >= 1.f || ran4 >= 1.f ||
+             ran5 >= 1.f || ran6 >= 1.f);
+
+    double pxi = npt->p[0] + sqrtf(-2.f * npt->T[0] / npt->m * sqr(beta) *
+                                   logf(1.0 - ran1)) *
+                               cosf(2.f * M_PI * ran2);
+    double pyi = npt->p[1] + sqrtf(-2.f * npt->T[1] / npt->m * sqr(beta) *
+                                   logf(1.0 - ran3)) *
+                               cosf(2.f * M_PI * ran4);
+    double pzi = npt->p[2] + sqrtf(-2.f * npt->T[2] / npt->m * sqr(beta) *
+                                   logf(1.0 - ran5)) *
+                               cosf(2.f * M_PI * ran6);
 
     if (initial_momentum_gamma_correction) {
       double gam;
       if (sqr(pxi) + sqr(pyi) + sqr(pzi) < 1.) {
-	gam = 1. / sqrt(1. - sqr(pxi) - sqr(pyi) - sqr(pzi));
-	pxi *= gam;
-	pyi *= gam;
-	pzi *= gam;
+        gam = 1. / sqrt(1. - sqr(pxi) - sqr(pyi) - sqr(pzi));
+        pxi *= gam;
+        pyi *= gam;
+        pzi *= gam;
       }
     }
-  
+
     assert(npt->kind >= 0 && npt->kind < kinds.size());
     prt->kind = npt->kind;
     assert(npt->q == kinds[prt->kind].q);
@@ -87,76 +91,79 @@ struct SetupParticles
     prt->u[0] = pxi;
     prt->u[1] = pyi;
     prt->u[2] = pzi;
-  }	      
+  }
 
   // ----------------------------------------------------------------------
   // setup_particles
 
-  template<typename FUNC>
+  template <typename FUNC>
   void setup_particles(Mparticles& mprts, std::vector<uint>& n_prts_by_patch,
-		       FUNC func)
+                       FUNC func)
   {
     const auto& grid = mprts.grid();
     const auto& kinds = grid.kinds;
-    
-    //mprts.reserve_all(n_prts_by_patch); FIXME
+
+    // mprts.reserve_all(n_prts_by_patch); FIXME
 
     auto inj = mprts.injector();
-      
+
     for (int p = 0; p < mprts.n_patches(); ++p) {
       Int3 ilo = {}, ihi = grid.ldims;
       auto injector = inj[p];
-  
-      for (int jz = ilo[2]; jz < ihi[2]; jz++) {
-	for (int jy = ilo[1]; jy < ihi[1]; jy++) {
-	  for (int jx = ilo[0]; jx < ihi[0]; jx++) {
-	    Double3 pos = {grid.patches[p].x_cc(jx),
-			   grid.patches[p].y_cc(jy),
-			   grid.patches[p].z_cc(jz)};
-	    // FIXME, the issue really is that (2nd order) particle pushers
-	    // don't handle the invariant dim right
-	    if (grid.isInvar(0) == 1) pos[0] = grid.patches[p].x_nc(jx);
-	    if (grid.isInvar(1) == 1) pos[1] = grid.patches[p].y_nc(jy);
-	    if (grid.isInvar(2) == 1) pos[2] = grid.patches[p].z_nc(jz);
-	  
-	    int n_q_in_cell = 0;
-	    for (int kind = 0; kind < kinds.size(); kind++) {
-	      struct psc_particle_npt npt = {};
-	      if (kind < kinds.size()) {
-		npt.kind = kind;
-		npt.q    = kinds[kind].q;
-		npt.m    = kinds[kind].m;
-	      };
-	      func(kind, pos, npt);
 
-	      int n_in_cell;
-	      if (kind != neutralizing_population) {
-		n_in_cell = get_n_in_cell(grid, &npt);
-		n_q_in_cell += npt.q * n_in_cell;
-	      } else {
-		// FIXME, should handle the case where not the last population is neutralizing
-		assert(neutralizing_population == kinds.size() - 1);
-		n_in_cell = -n_q_in_cell / npt.q;
-	      }
-	      for (int cnt = 0; cnt < n_in_cell; cnt++) {
-		int kind = npt.kind;
-		real_t wni;
-		if (fractional_n_particles_per_cell) {
-		  wni = 1.;
-		} else {
-		  wni = npt.n / (n_in_cell * grid.norm.cori);
-		}
-		particle_inject prt{{}, {}, wni, kind};
-		setup_particle(grid, &prt, &npt, p, pos);
-		//p->lni = particle_label_offset + 1;
-		injector(prt);
-	      }
-	    }
-	  }
-	}
+      for (int jz = ilo[2]; jz < ihi[2]; jz++) {
+        for (int jy = ilo[1]; jy < ihi[1]; jy++) {
+          for (int jx = ilo[0]; jx < ihi[0]; jx++) {
+            Double3 pos = {grid.patches[p].x_cc(jx), grid.patches[p].y_cc(jy),
+                           grid.patches[p].z_cc(jz)};
+            // FIXME, the issue really is that (2nd order) particle pushers
+            // don't handle the invariant dim right
+            if (grid.isInvar(0) == 1)
+              pos[0] = grid.patches[p].x_nc(jx);
+            if (grid.isInvar(1) == 1)
+              pos[1] = grid.patches[p].y_nc(jy);
+            if (grid.isInvar(2) == 1)
+              pos[2] = grid.patches[p].z_nc(jz);
+
+            int n_q_in_cell = 0;
+            for (int kind = 0; kind < kinds.size(); kind++) {
+              struct psc_particle_npt npt = {};
+              if (kind < kinds.size()) {
+                npt.kind = kind;
+                npt.q = kinds[kind].q;
+                npt.m = kinds[kind].m;
+              };
+              func(kind, pos, npt);
+
+              int n_in_cell;
+              if (kind != neutralizing_population) {
+                n_in_cell = get_n_in_cell(grid, &npt);
+                n_q_in_cell += npt.q * n_in_cell;
+              } else {
+                // FIXME, should handle the case where not the last population
+                // is neutralizing
+                assert(neutralizing_population == kinds.size() - 1);
+                n_in_cell = -n_q_in_cell / npt.q;
+              }
+              for (int cnt = 0; cnt < n_in_cell; cnt++) {
+                int kind = npt.kind;
+                real_t wni;
+                if (fractional_n_particles_per_cell) {
+                  wni = 1.;
+                } else {
+                  wni = npt.n / (n_in_cell * grid.norm.cori);
+                }
+                particle_inject prt{{}, {}, wni, kind};
+                setup_particle(grid, &prt, &npt, p, pos);
+                // p->lni = particle_label_offset + 1;
+                injector(prt);
+              }
+            }
+          }
+        }
       }
       if (!fractional_n_particles_per_cell) {
-	//assert(mprts[p].size() == n_prts_by_patch[p]); FIXME
+        // assert(mprts[p].size() == n_prts_by_patch[p]); FIXME
       }
     }
   }
@@ -164,57 +171,62 @@ struct SetupParticles
   // ----------------------------------------------------------------------
   // setup_partition
 
-  template<typename FUNC>
+  template <typename FUNC>
   std::vector<uint> setup_partition(const Grid_t& grid, FUNC func)
   {
     const auto& kinds = grid.kinds;
     std::vector<uint> n_prts_by_patch(grid.n_patches());
-    
+
     for (int p = 0; p < grid.n_patches(); ++p) {
       auto ilo = Int3{}, ihi = grid.ldims;
-  
-      for (int jz = ilo[2]; jz < ihi[2]; jz++) {
-	for (int jy = ilo[1]; jy < ihi[1]; jy++) {
-	  for (int jx = ilo[0]; jx < ihi[0]; jx++) {
-	    Double3 pos = {grid.patches[p].x_cc(jx), grid.patches[p].y_cc(jy), grid.patches[p].z_cc(jz)};
-	    // FIXME, the issue really is that (2nd order) particle pushers
-	    // don't handle the invariant dim right
-	    if (grid.isInvar(0) == 1) pos[0] = grid.patches[p].x_nc(jx);
-	    if (grid.isInvar(1) == 1) pos[1] = grid.patches[p].y_nc(jy);
-	    if (grid.isInvar(2) == 1) pos[2] = grid.patches[p].z_nc(jz);
-	  
-	    int n_q_in_cell = 0;
-	    for (int kind = 0; kind < kinds.size(); kind++) {
-	      struct psc_particle_npt npt = {};
-	      if (kind < kinds.size()) {
-		npt.kind = kind;
-		npt.q    = kinds[kind].q;
-		npt.m    = kinds[kind].m;
-	      };
-	      func(kind, pos, npt);
 
-	      int n_in_cell;
-	      if (kind != neutralizing_population) {
-		n_in_cell = get_n_in_cell(grid, &npt);
-		n_q_in_cell += npt.q * n_in_cell;
-	      } else {
-		// FIXME, should handle the case where not the last population is neutralizing
-		assert(neutralizing_population == kinds.size() - 1);
-		n_in_cell = -n_q_in_cell / npt.q;
-	      }
-	      n_prts_by_patch[p] += n_in_cell;
-	    }
-	  }
-	}
+      for (int jz = ilo[2]; jz < ihi[2]; jz++) {
+        for (int jy = ilo[1]; jy < ihi[1]; jy++) {
+          for (int jx = ilo[0]; jx < ihi[0]; jx++) {
+            Double3 pos = {grid.patches[p].x_cc(jx), grid.patches[p].y_cc(jy),
+                           grid.patches[p].z_cc(jz)};
+            // FIXME, the issue really is that (2nd order) particle pushers
+            // don't handle the invariant dim right
+            if (grid.isInvar(0) == 1)
+              pos[0] = grid.patches[p].x_nc(jx);
+            if (grid.isInvar(1) == 1)
+              pos[1] = grid.patches[p].y_nc(jy);
+            if (grid.isInvar(2) == 1)
+              pos[2] = grid.patches[p].z_nc(jz);
+
+            int n_q_in_cell = 0;
+            for (int kind = 0; kind < kinds.size(); kind++) {
+              struct psc_particle_npt npt = {};
+              if (kind < kinds.size()) {
+                npt.kind = kind;
+                npt.q = kinds[kind].q;
+                npt.m = kinds[kind].m;
+              };
+              func(kind, pos, npt);
+
+              int n_in_cell;
+              if (kind != neutralizing_population) {
+                n_in_cell = get_n_in_cell(grid, &npt);
+                n_q_in_cell += npt.q * n_in_cell;
+              } else {
+                // FIXME, should handle the case where not the last population
+                // is neutralizing
+                assert(neutralizing_population == kinds.size() - 1);
+                n_in_cell = -n_q_in_cell / npt.q;
+              }
+              n_prts_by_patch[p] += n_in_cell;
+            }
+          }
+        }
       }
     }
 
     return n_prts_by_patch;
   }
 
-  // the initial number of particles in a cell for this population will be st so that it achieves neutrality  
-  int neutralizing_population = { -1 };
-  bool fractional_n_particles_per_cell = { false };
-  bool initial_momentum_gamma_correction = { false };
+  // the initial number of particles in a cell for this population will be st so
+  // that it achieves neutrality
+  int neutralizing_population = {-1};
+  bool fractional_n_particles_per_cell = {false};
+  bool initial_momentum_gamma_correction = {false};
 };
-

--- a/src/include/setup_particles.hxx
+++ b/src/include/setup_particles.hxx
@@ -108,12 +108,12 @@ struct SetupParticles
     auto inj = mprts.injector();
 
     for (int p = 0; p < mprts.n_patches(); ++p) {
-      Int3 ilo = {}, ihi = grid.ldims;
+      auto ldims = grid.ldims;
       auto injector = inj[p];
 
-      for (int jz = ilo[2]; jz < ihi[2]; jz++) {
-        for (int jy = ilo[1]; jy < ihi[1]; jy++) {
-          for (int jx = ilo[0]; jx < ihi[0]; jx++) {
+      for (int jz = 0; jz < ldims[2]; jz++) {
+        for (int jy = 0; jy < ldims[1]; jy++) {
+          for (int jx = 0; jx < ldims[0]; jx++) {
             Double3 pos = {grid.patches[p].x_cc(jx), grid.patches[p].y_cc(jy),
                            grid.patches[p].z_cc(jz)};
             // FIXME, the issue really is that (2nd order) particle pushers
@@ -132,7 +132,7 @@ struct SetupParticles
                 npt.kind = kind;
                 npt.q = kinds[kind].q;
                 npt.m = kinds[kind].m;
-              };
+              }
               func(kind, pos, npt);
 
               int n_in_cell;
@@ -146,16 +146,14 @@ struct SetupParticles
                 n_in_cell = -n_q_in_cell / npt.q;
               }
               for (int cnt = 0; cnt < n_in_cell; cnt++) {
-                int kind = npt.kind;
                 real_t wni;
                 if (fractional_n_particles_per_cell) {
                   wni = 1.;
                 } else {
                   wni = npt.n / (n_in_cell * grid.norm.cori);
                 }
-                particle_inject prt{{}, {}, wni, kind};
+                particle_inject prt{{}, {}, wni, npt.kind};
                 setup_particle(grid, &prt, &npt, p, pos);
-                // p->lni = particle_label_offset + 1;
                 injector(prt);
               }
             }

--- a/src/include/setup_particles.hxx
+++ b/src/include/setup_particles.hxx
@@ -23,18 +23,18 @@ struct SetupParticles
   //
   // helper function for partition / particle setup
 
-  int get_n_in_cell(const Grid_t& grid, psc_particle_npt* npt)
+  int get_n_in_cell(const Grid_t& grid, const psc_particle_npt& npt)
   {
     if (fractional_n_particles_per_cell) {
-      int n_prts = npt->n / grid.norm.cori;
-      float rmndr = npt->n / grid.norm.cori - n_prts;
+      int n_prts = npt.n / grid.norm.cori;
+      float rmndr = npt.n / grid.norm.cori - n_prts;
       float ran = random() / ((float)RAND_MAX + 1);
       if (ran < rmndr) {
         n_prts++;
       }
       return n_prts;
     }
-    return npt->n / grid.norm.cori + .5;
+    return npt.n / grid.norm.cori + .5;
   }
 
   // ----------------------------------------------------------------------
@@ -138,7 +138,7 @@ struct SetupParticles
 
             int n_q_in_cell = 0;
             for (int kind = 0; kind < kinds.size(); kind++) {
-              struct psc_particle_npt npt = {};
+              psc_particle_npt npt{};
               if (kind < kinds.size()) {
                 npt.kind = kind;
               }
@@ -146,7 +146,7 @@ struct SetupParticles
 
               int n_in_cell;
               if (kind != neutralizing_population) {
-                n_in_cell = get_n_in_cell(grid, &npt);
+                n_in_cell = get_n_in_cell(grid, npt);
                 n_q_in_cell += kinds[npt.kind].q * n_in_cell;
               } else {
                 // FIXME, should handle the case where not the last population
@@ -202,7 +202,7 @@ struct SetupParticles
 
             int n_q_in_cell = 0;
             for (int kind = 0; kind < kinds.size(); kind++) {
-              struct psc_particle_npt npt = {};
+              psc_particle_npt npt{};
               if (kind < kinds.size()) {
                 npt.kind = kind;
               };
@@ -210,7 +210,7 @@ struct SetupParticles
 
               int n_in_cell;
               if (kind != neutralizing_population) {
-                n_in_cell = get_n_in_cell(grid, &npt);
+                n_in_cell = get_n_in_cell(grid, npt);
                 n_q_in_cell += kinds[npt.kind].q * n_in_cell;
               } else {
                 // FIXME, should handle the case where not the last population

--- a/src/kg/include/kg/Vec3.h
+++ b/src/kg/include/kg/Vec3.h
@@ -194,5 +194,7 @@ KG_INLINE Vec3<T> operator/(const Vec3<T>& v, const Vec3<T>& w)
 
 using Int3 = Vec3<int>;
 using UInt3 = Vec3<unsigned int>;
+using Float3 = Vec3<float>;
+using Double3 = Vec3<double>;
 
 #endif

--- a/src/libpsc/tests/test_inject.cxx
+++ b/src/libpsc/tests/test_inject.cxx
@@ -135,7 +135,7 @@ TYPED_TEST(InjectTest, Test1)
     grid.Foreach_3d(0, 0, [&](int i, int j, int k) {
 	double xx[3] = {grid.patches[p].x_cc(i), grid.patches[p].y_cc(j), grid.patches[p].z_cc(k)};
 	real_t n_expected = target.is_inside(xx) ? n_injected : 0.;
-	EXPECT_NEAR(mflds_n[p](0, i,j,k), n_expected, eps) << "ijk " << i << ":" << j << ":" << k;
+	EXPECT_NEAR(mflds_n[p](0, i,j,k), n_expected, 2.*grid.norm.cori) << "ijk " << i << ":" << j << ":" << k;
       });
   }
 }


### PR DESCRIPTION
Mostly just cleaning and refactoring, but also adds the option to specify the number of populations that init_npt will be called for (by default, for each particle kind).