### PR TITLE
testing updates

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,6 +24,7 @@ endfunction()
 
 option(USE_CUDA "Build CUDA components" OFF)
 option(USE_VPIC "Interface with VPIC" OFF)
+option(USE_GTEST_DISCOVER_TESTS "Run tests to discover contained googletest cases" OFF)
 psc_option(ADIOS2 "Build with adios2 support" AUTO)
 
 # CUDA

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,7 +13,7 @@ add_subdirectory(src/libmrc)
 
 project(PSC)
 
-enable_testing()
+include(CTest)
 
 function(psc_option name description default)
   set(PSC_USE_${name} ${default} CACHE STRING "${description}")
@@ -72,7 +72,10 @@ include_directories(${CMAKE_CURRENT_BINARY_DIR}/src/include)
 include_directories(${CMAKE_CURRENT_BINARY_DIR}/src/libmrc/include)
 
 add_subdirectory(external)
-include(GoogleTest)
+if (BUILD_TESTING)
+  include(GoogleTest)
+endif()
+
 add_subdirectory(src)
 
 

--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -1,3 +1,5 @@
 
-add_subdirectory(GTest)
+if (BUILD_TESTING)
+  add_subdirectory(GTest)
+endif()
 

--- a/src/kg/CMakeLists.txt
+++ b/src/kg/CMakeLists.txt
@@ -11,4 +11,6 @@ if (PSC_HAVE_ADIOS2)
   target_link_libraries(kg INTERFACE adios2::adios2)
 endif()
 
-add_subdirectory(testing)
+if (BUILD_TESTING)
+  add_subdirectory(testing)
+endif()

--- a/src/kg/testing/CMakeLists.txt
+++ b/src/kg/testing/CMakeLists.txt
@@ -2,7 +2,11 @@
 macro(add_kg_test name src)
   add_executable(${name} ${src})
   target_link_libraries(${name} GTest::GTest GTest::Main kg)
-  gtest_discover_tests(${name})
+  if (USE_GTEST_DISCOVER_TESTS)
+    gtest_discover_tests(${name})
+  else()
+    gtest_add_tests(TARGET ${name})
+  endif()
 endmacro()
 
 add_kg_test(TestVec3 TestVec3.cxx)

--- a/src/libpsc/CMakeLists.txt
+++ b/src/libpsc/CMakeLists.txt
@@ -77,4 +77,6 @@ if (USE_VPIC)
   target_link_libraries(psc PUBLIC VPIC::VPIC)
 endif()
 
-add_subdirectory(tests)
+if (BUILD_TESTING)
+  add_subdirectory(tests)
+endif()

--- a/src/libpsc/tests/CMakeLists.txt
+++ b/src/libpsc/tests/CMakeLists.txt
@@ -7,7 +7,11 @@ set(MPIEXEC_COMMAND
 macro(add_psc_test name)
   add_executable(${name} ${name}.cxx)
   target_link_libraries(${name} psc GTest::GTest)
-  gtest_discover_tests(${name} EXEC_WRAPPER ${MPIEXEC_COMMAND})
+  if (USE_GTEST_DISCOVER_TESTS)
+    gtest_discover_tests(${name} EXEC_WRAPPER ${MPIEXEC_COMMAND})
+  else()
+    gtest_add_tests(TARGET ${name} EXEC_WRAPPER ${MPIEXEC_COMMAND})
+  endif()
 endmacro()
 
 add_psc_test(test_grid)

--- a/src/libpsc/tests/test_grid_2.cxx
+++ b/src/libpsc/tests/test_grid_2.cxx
@@ -11,7 +11,7 @@ int mpi_rank, mpi_size;
 // MPI test (to be run on 2 procs)
 
 #if 0
-TEST(Grid, CtorComplete)
+TEST(Grid2, CtorComplete)
 {
   EXPECT_EQ(mpi_size, 2);
   
@@ -47,7 +47,7 @@ TEST(Grid, CtorComplete)
   }
 }
 
-TEST(Grid, MoveCtor)
+TEST(Grid2, MoveCtor)
 {
   auto domain = Grid_t::Domain{{8, 4, 2},
 			       {80.,  40., 20.}, {-40., -20., 0.},
@@ -63,7 +63,7 @@ TEST(Grid, MoveCtor)
   auto grid2 = std::move(grid);
 }
   
-TEST(Grid, MoveAssign)
+TEST(Grid2, MoveAssign)
 {
   auto domain = Grid_t::Domain{{8, 4, 2},
 			       {80.,  40., 20.}, {-40., -20., 0.},
@@ -81,7 +81,7 @@ TEST(Grid, MoveAssign)
   grid2 = std::move(grid);
 }
   
-TEST(Grid, Kinds)
+TEST(Grid2, Kinds)
 {
   auto kinds = Grid_t::Kinds{};
   kinds.emplace_back(Grid_t::Kind(1., 1., "test_species"));
@@ -90,7 +90,7 @@ TEST(Grid, Kinds)
 #endif
 
 #ifdef PSC_HAVE_ADIOS2
-TEST(Grid, adios2_write)
+TEST(Grid2, adios2_write)
 {
   auto io = kg::io::IOAdios2{};
 


### PR DESCRIPTION
Adds two options to help with testing support on supercomputers:

The standard cmake option `BUILD_TESTING` will determine whether to build the test executables at all.

The new option `USE_GTEST_DISCOVER_TESTS` (default OFF) determines whether to use `gtest_discover_tests` (as opposed to `gtest_add_tests`) as the method of detecting the tests contained within the googletests framework. The former option requires running the executables at build time, which may cause issues on supercomputers where MPI executables can only be run within the batch system, so it's off by default now.