### PR TITLE
checkpoint cleanup

### DIFF
--- a/src/include/checkpoint.hxx
+++ b/src/include/checkpoint.hxx
@@ -1,0 +1,35 @@
+
+#pragma once
+
+#include "grid.hxx"
+#include "fields3d.inl"
+#include "grid.inl"
+#include "particles_simple.inl"
+#include <kg/io.h>
+
+// ----------------------------------------------------------------------
+// read_checkpoint
+//
+
+template <typename Mparticles, typename MfieldsState>
+inline void read_checkpoint(const std::string& filename, Grid_t& grid,
+                            Mparticles& mprts, MfieldsState& mflds)
+{
+  mpi_printf(grid.comm(), "**** Reading checkpoint...\n");
+  MPI_Barrier(grid.comm()); // not really necessary
+
+#ifdef PSC_HAVE_ADIOS2
+  auto io = kg::io::IOAdios2{};
+  auto reader = io.open(filename, kg::io::Mode::Read);
+  reader.get("grid", grid);
+  reader.get("mflds", mflds);
+  reader.get("mprts", mprts);
+  reader.close();
+
+  // FIXME, when we read back a rebalanced grid, other existing fields will
+  // still have their own parallel distribution, ie, things will go wrong
+#else
+  std::cerr << "write_checkpoint not available without adios2" << std::endl;
+  std::abort();
+#endif
+}

--- a/src/include/checkpoint.hxx
+++ b/src/include/checkpoint.hxx
@@ -1,11 +1,37 @@
 
 #pragma once
 
-#include "grid.hxx"
 #include "fields3d.inl"
+#include "grid.hxx"
 #include "grid.inl"
 #include "particles_simple.inl"
 #include <kg/io.h>
+
+// ----------------------------------------------------------------------
+// write_checkpoint
+//
+
+template <typename Mparticles, typename MfieldsState>
+void write_checkpoint(const Grid_t& grid, Mparticles& mprts, MfieldsState& mflds)
+{
+  mpi_printf(grid.comm(), "**** Writing checkpoint...\n");
+#if defined(PSC_HAVE_ADIOS2) && !defined(VPIC)
+  MPI_Barrier(grid.comm()); // not really necessary
+
+  std::string filename =
+    "checkpoint_" + std::to_string(grid.timestep()) + ".bp";
+
+  auto io = kg::io::IOAdios2{};
+  auto writer = io.open(filename, kg::io::Mode::Write);
+  writer.put("grid", grid);
+  writer.put("mprts", mprts);
+  writer.put("mflds", mflds);
+  writer.close();
+#else
+  std::cerr << "write_checkpoint not available without adios2" << std::endl;
+  std::abort();
+#endif
+}
 
 // ----------------------------------------------------------------------
 // read_checkpoint
@@ -22,8 +48,8 @@ inline void read_checkpoint(const std::string& filename, Grid_t& grid,
   auto io = kg::io::IOAdios2{};
   auto reader = io.open(filename, kg::io::Mode::Read);
   reader.get("grid", grid);
-  reader.get("mflds", mflds);
   reader.get("mprts", mprts);
+  reader.get("mflds", mflds);
   reader.close();
 
   // FIXME, when we read back a rebalanced grid, other existing fields will

--- a/src/include/checkpoint.hxx
+++ b/src/include/checkpoint.hxx
@@ -12,7 +12,8 @@
 //
 
 template <typename Mparticles, typename MfieldsState>
-void write_checkpoint(const Grid_t& grid, Mparticles& mprts, MfieldsState& mflds)
+void write_checkpoint(const Grid_t& grid, Mparticles& mprts,
+                      MfieldsState& mflds)
 {
   mpi_printf(grid.comm(), "**** Writing checkpoint...\n");
 #if defined(PSC_HAVE_ADIOS2) && !defined(VPIC)

--- a/src/include/psc.hxx
+++ b/src/include/psc.hxx
@@ -208,7 +208,7 @@ struct Psc
 
       if (!first_iteration && p_.write_checkpoint_every_step > 0 &&
           grid().timestep() % p_.write_checkpoint_every_step == 0) {
-        write_checkpoint();
+        write_checkpoint(grid(), mprts_, mflds_);
       }
       first_iteration = false;
 
@@ -253,7 +253,7 @@ struct Psc
     }
 
     if (p_.write_checkpoint_every_step > 0) {
-      write_checkpoint();
+      write_checkpoint(grid(), mprts_, mflds_);
     }
 
     // FIXME, merge with existing handling of wallclock time
@@ -656,30 +656,6 @@ private:
 #endif
     psc_stats_log(grid().timestep());
     print_profiling();
-  }
-
-  // ----------------------------------------------------------------------
-  // write_checkpoint
-  //
-
-  void write_checkpoint()
-  {
-#if defined(PSC_HAVE_ADIOS2) && !defined(VPIC)
-    MPI_Barrier(grid().comm());
-
-    std::string filename =
-      "checkpoint_" + std::to_string(grid().timestep()) + ".bp";
-
-    auto io = kg::io::IOAdios2{};
-    auto writer = io.open(filename, kg::io::Mode::Write);
-    writer.put("grid", *grid_);
-    writer.put("mflds", mflds_);
-    writer.put("mprts", mprts_);
-    writer.close();
-#else
-    std::cerr << "write_checkpoint not available without adios2" << std::endl;
-    std::abort();
-#endif
   }
 
 public:

--- a/src/include/psc.hxx
+++ b/src/include/psc.hxx
@@ -12,10 +12,7 @@
 #include <output_particles.hxx>
 #include <push_particles.hxx>
 
-#include "fields3d.inl"
-#include "grid.inl"
-#include "particles_simple.inl"
-#include <kg/io.h>
+#include "checkpoint.hxx"
 #ifdef USE_CUDA
 #include "../libpsc/cuda/mparticles_cuda.hxx"
 #include "../libpsc/cuda/mparticles_cuda.inl"
@@ -685,28 +682,7 @@ private:
 #endif
   }
 
-  // ----------------------------------------------------------------------
-  // read_checkpoint
-  //
-
 public:
-  void read_checkpoint(const std::string& filename)
-  {
-#ifdef PSC_HAVE_ADIOS2
-    MPI_Barrier(grid().comm());
-
-    auto io = kg::io::IOAdios2{};
-    auto reader = io.open(filename, kg::io::Mode::Read);
-    reader.get("grid", *grid_);
-    reader.get("mflds", mflds_);
-    reader.get("mprts", mprts_);
-    reader.close();
-#else
-    std::cerr << "write_checkpoint not available without adios2" << std::endl;
-    std::abort();
-#endif
-  }
-
   const Grid_t& grid() { return *grid_; }
 
 private:

--- a/src/psc_bubble_yz.cxx
+++ b/src/psc_bubble_yz.cxx
@@ -356,6 +356,8 @@ static void run()
   if (read_checkpoint_filename.empty()) {
     initializeParticles(balance, grid_ptr, mprts);
     initializeFields(mflds);
+  } else {
+    read_checkpoint(read_checkpoint_filename, *grid_ptr, mprts, mflds);
   }
 
   // ----------------------------------------------------------------------
@@ -364,11 +366,6 @@ static void run()
   auto psc =
     makePscIntegrator<PscConfig>(psc_params, *grid_ptr, mflds, mprts, balance,
                                  collision, checks, marder, diagnostics);
-
-  // FIXME, checkpoint reading should be moved to before the integrator
-  if (!read_checkpoint_filename.empty()) {
-    read_checkpoint(read_checkpoint_filename, *grid_ptr, mprts, mflds);
-  }
 
   psc.integrate();
 }

--- a/src/psc_bubble_yz.cxx
+++ b/src/psc_bubble_yz.cxx
@@ -367,8 +367,7 @@ static void run()
 
   // FIXME, checkpoint reading should be moved to before the integrator
   if (!read_checkpoint_filename.empty()) {
-    mpi_printf(MPI_COMM_WORLD, "**** Reading checkpoint...\n");
-    psc.read_checkpoint(read_checkpoint_filename);
+    read_checkpoint(read_checkpoint_filename, *grid_ptr, mprts, mflds);
   }
 
   psc.integrate();

--- a/src/psc_flatfoil_yz.cxx
+++ b/src/psc_flatfoil_yz.cxx
@@ -480,19 +480,16 @@ void run()
     initializeParticles(setup_particles, balance, grid_ptr, mprts,
                         inject_target);
     initializeFields(mflds);
+  } else {
+    read_checkpoint(read_checkpoint_filename, *grid_ptr, mprts, mflds);
   }
-
+  
   // ----------------------------------------------------------------------
   // hand off to PscIntegrator to run the simulation
 
   auto psc = makePscIntegrator<PscConfig>(psc_params, *grid_ptr, mflds, mprts,
                                           balance, collision, checks, marder,
                                           diagnostics, lf_inject);
-
-  // FIXME, checkpoint reading should be moved to before the integrator
-  if (!read_checkpoint_filename.empty()) {
-    read_checkpoint(read_checkpoint_filename, *grid_ptr, mprts, mflds);
-  }
 
   psc.integrate();
 }

--- a/src/psc_flatfoil_yz.cxx
+++ b/src/psc_flatfoil_yz.cxx
@@ -491,8 +491,7 @@ void run()
 
   // FIXME, checkpoint reading should be moved to before the integrator
   if (!read_checkpoint_filename.empty()) {
-    mpi_printf(MPI_COMM_WORLD, "**** Reading checkpoint...\n");
-    psc.read_checkpoint(read_checkpoint_filename);
+    read_checkpoint(read_checkpoint_filename, *grid_ptr, mprts, mflds);
   }
 
   psc.integrate();

--- a/src/psc_whistler.cxx
+++ b/src/psc_whistler.cxx
@@ -335,6 +335,8 @@ void run()
   if (read_checkpoint_filename.empty()) {
     initializeParticles(balance, grid_ptr, mprts);
     initializeFields(mflds);
+  } else {
+    read_checkpoint(read_checkpoint_filename, *grid_ptr, mprts, mflds);
   }
 
   // ----------------------------------------------------------------------
@@ -343,11 +345,6 @@ void run()
   auto psc =
     makePscIntegrator<PscConfig>(psc_params, *grid_ptr, mflds, mprts, balance,
                                  collision, checks, marder, diagnostics);
-
-  // FIXME, checkpoint reading should be moved to before the integrator
-  if (!read_checkpoint_filename.empty()) {
-    read_checkpoint(read_checkpoint_filename, *grid_ptr, mprts, mflds);
-  }
 
   psc.integrate();
 }

--- a/src/psc_whistler.cxx
+++ b/src/psc_whistler.cxx
@@ -346,8 +346,7 @@ void run()
 
   // FIXME, checkpoint reading should be moved to before the integrator
   if (!read_checkpoint_filename.empty()) {
-    mpi_printf(MPI_COMM_WORLD, "**** Reading checkpoint...\n");
-    psc.read_checkpoint(read_checkpoint_filename);
+    read_checkpoint(read_checkpoint_filename, *grid_ptr, mprts, mflds);
   }
 
   psc.integrate();


### PR DESCRIPTION
This moves the checkpointing read/write and control logic out of the `Psc` class, making it
less convoluted to use from cases.
