### PR TITLE
flatfoil: fix a bug causing crash in the injection

### DIFF
--- a/src/include/psc.hxx
+++ b/src/include/psc.hxx
@@ -125,7 +125,7 @@ struct Psc
   Psc(const PscParams& params, Grid_t& grid, MfieldsState& mflds,
       Mparticles& mprts, Balance& balance, Collision& collision, Checks& checks,
       Marder& marder, Diagnostics& diagnostics,
-      InjectParticles inject_particles)
+      InjectParticles& inject_particles)
     : p_{params},
       grid_{&grid},
       mflds_{mflds},


### PR DESCRIPTION
I think it looks rather unclear why this would have been wrong, but so
I think the main lesson is to make sure that objects that shouldn't
be copieed can't be copied. And eventually, we may really want to
handle storing refs vs moving the object, too.