### PR TITLE
cuda: fix output / get_as,put_as

### DIFF
--- a/src/libpsc/cuda/psc_fields_cuda.cxx
+++ b/src/libpsc/cuda/psc_fields_cuda.cxx
@@ -16,10 +16,16 @@
 
 static void psc_mfields_cuda_copy_from_c(MfieldsBase& mflds_cuda, MfieldsBase& mflds_c, int mb, int me)
 {
+  if (mb == 0 && me == 0) {
+    return;
+  }
   auto& mf_cuda = dynamic_cast<MfieldsCuda&>(mflds_cuda);
   auto& mf_c = dynamic_cast<MfieldsC&>(mflds_c);
   auto h_mf_cuda = hostMirror(mf_cuda);
 
+  if (!(mb == 0 && me == mflds_cuda._n_comps())) {
+    copy(mf_cuda, h_mf_cuda);
+  }
   for (int p = 0; p < mf_cuda.n_patches(); p++) {
     auto flds = h_mf_cuda[p];
     auto flds_c = mf_c[p];
@@ -61,10 +67,16 @@ static void psc_mfields_cuda_copy_to_c(MfieldsBase& mflds_cuda, MfieldsBase& mfl
 
 static void psc_mfields_state_cuda_copy_from_c(MfieldsStateBase& mflds_cuda, MfieldsStateBase& mflds_c, int mb, int me)
 {
+  if (mb == 0 && me == 0) {
+    return;
+  }
   auto& mf_cuda = dynamic_cast<MfieldsStateCuda&>(mflds_cuda);
   auto& mf_c = dynamic_cast<MfieldsStateDouble&>(mflds_c);
   auto h_mf_cuda = hostMirror(mf_cuda);
 
+  if (!(mb == 0 && me == mflds_cuda._n_comps())) {
+    copy(mf_cuda, h_mf_cuda);
+  }
   for (int p = 0; p < mf_cuda.n_patches(); p++) {
     auto flds = h_mf_cuda[p];
     auto flds_c = mf_c[p];
@@ -109,10 +121,16 @@ static void psc_mfields_state_cuda_copy_to_c(MfieldsStateBase& mflds_cuda, Mfiel
 
 static void psc_mfields_cuda_copy_from_single(MfieldsBase& mflds_cuda, MfieldsBase& mflds_single, int mb, int me)
 {
+  if (mb == 0 && me == 0) {
+    return;
+  }
   auto& mf_cuda = dynamic_cast<MfieldsCuda&>(mflds_cuda);
   auto& mf_single = dynamic_cast<MfieldsSingle&>(mflds_single);
   auto h_mf_cuda = hostMirror(mf_cuda);
   
+  if (!(mb == 0 && me == mflds_cuda._n_comps())) {
+    copy(mf_cuda, h_mf_cuda);
+  }
   for (int p = 0; p < mf_cuda.n_patches(); p++) {
     auto flds = h_mf_cuda[p];
     auto flds_s = mf_single[p];
@@ -132,10 +150,16 @@ static void psc_mfields_cuda_copy_from_single(MfieldsBase& mflds_cuda, MfieldsBa
 
 static void psc_mfields_state_cuda_copy_from_single(MfieldsStateBase& mflds_cuda, MfieldsStateBase& mflds_single, int mb, int me)
 {
+  if (mb == 0 && me == 0) {
+    return;
+  }
   auto& mf_cuda = dynamic_cast<MfieldsStateCuda&>(mflds_cuda);
   auto& mf_single = dynamic_cast<MfieldsStateSingle&>(mflds_single);
   auto h_mf_cuda = hostMirror(mf_cuda);
   
+  if (!(mb == 0 && me == mflds_cuda._n_comps())) {
+    copy(mf_cuda, h_mf_cuda);
+  }
   for (int p = 0; p < mf_cuda.n_patches(); p++) {
     auto flds = h_mf_cuda[p];
     auto flds_s = mf_single[p];


### PR DESCRIPTION
This fixes #55. However, something else looks iffy in the test I've just done, but that may not be fun to track down.

To explain what happened (embarrassing as it is). I broke this recently when assimilating cuda and regular fields data structures, and I broke things pretty badly. The main idea was that I'd essentially use the same data structure for multi-d arrays, the only difference being that in the CUDA case the data actually lives on the GPU, but all the indexing etc is shared. However, sometimes one really wants the data on the CPU, e.g., to do output. The traditional way to get this done works like
```
auto& mflds = mflds_cuda.get_as<MfieldsSingle>(EX, EX+3);
...
mflds_cuda.put_as(mflds, 0, 0);
```
This creates a MfieldsSingle field on the CPU, and copies EX..EZ into it. When one is done, the `put_as` call frees that temporary data structure again, and potentially could copy updated fields back to the GPU (but not in the output case). I've been working on getting rid of that whole put_as/get_as stuff, though, as it's rather complex, and rather just have a host version of the same data structure, and just functionality to copy the whole thing. Anyway, in the current master, it's a bit of both, and what happened is that it would copy only EX..EZ into MfieldsSingle (good), but then, when copying back, it would make a new host version of the cuda fields, copy nothing into it, and then copy that whole thing back to the GPU, overwriting all the fields completely with zero. So that's why the subsequent H and J outputs would be zero, but that wasn't just an output problem, it would really zero the actual simulation fields :(((

I guess the one good piece of news is that in further work I've done since, I pretty much got rid of put_as and get_as completely for fields, so this problem got fixed in my dev branch without me realizing it. Which goes to show that reducing code complexity really does help getting rid of subtle but bad bugs.