### PR TITLE
fix tfd fields output crash

### DIFF
--- a/src/include/fields3d.hxx
+++ b/src/include/fields3d.hxx
@@ -36,6 +36,15 @@ struct MfieldsBase
     instances.push_back(this);
   }
 
+  MfieldsBase(const MfieldsBase&) = delete;
+  MfieldsBase& operator=(const MfieldsBase&) = delete;
+
+  MfieldsBase(MfieldsBase&& o) : MfieldsBase(*o.grid_, o.n_fields_, o.ibn_)
+  {
+  }
+
+  MfieldsBase& operator=(MfieldsBase&& o) = default;
+  
   virtual ~MfieldsBase()
   {
     instances.remove(this);


### PR DESCRIPTION
When doing this, I don't think I had a real good understanding of how to
make safe classes yet, so there ended up being a default move constructor
that forgot to register the field to be rebalanced, and then bad things
happen...