### PR TITLE
heating/balance: fix a compilation error just introduced in the cuda code

### DIFF
--- a/src/libpsc/cuda/bnd_particles_cuda_impl.cu
+++ b/src/libpsc/cuda/bnd_particles_cuda_impl.cu
@@ -38,7 +38,7 @@ template<typename Mparticles, typename DIM>
 void BndParticlesCuda<Mparticles, DIM>::operator()(Mparticles& mprts)
 {
   if (psc_balance_generation_cnt > this->balance_generation_cnt_) {
-    balance_generation_cnt_ = psc_balance_generation_cnt;
+    this->balance_generation_cnt_ = psc_balance_generation_cnt;
     reset(mprts.grid());
   }
   


### PR DESCRIPTION
I wish I wouldn't make these stupid mistakes, or at least catch them before merging a PR.

Having the CI compile test the cuda version would be helpful..