### PR TITLE
avoid lots of conversions

### DIFF
--- a/src/include/bnd_fields.hxx
+++ b/src/include/bnd_fields.hxx
@@ -8,8 +8,5 @@
 
 struct BndFieldsBase
 {
-  virtual void fill_ghosts_E(MfieldsBase& mflds_base) = 0;
-  virtual void fill_ghosts_H(MfieldsBase& mflds_base) = 0;
-  virtual void add_ghosts_J(MfieldsBase& mflds_base) = 0;
 };
 

--- a/src/include/bnd_particles.hxx
+++ b/src/include/bnd_particles.hxx
@@ -8,6 +8,5 @@
 
 struct BndParticlesBase
 {
-  virtual void exchange_particles(MparticlesBase& mprts_base) = 0;
 };
 

--- a/src/include/bnd_particles_impl.hxx
+++ b/src/include/bnd_particles_impl.hxx
@@ -243,14 +243,4 @@ struct BndParticles_ : BndParticlesCommon<MP>
     //psc_mfields_put_as(mflds, psc->flds, JXI, JXI + 3);
   }
 
-  // ----------------------------------------------------------------------
-  // exchange_particles
-
-  void exchange_particles(MparticlesBase& mprts_base) override
-  {
-    auto& mprts = mprts_base.get_as<Mparticles>();
-    (*this)(mprts);
-    mprts_base.put_as(mprts);
-  }
-
 };

--- a/src/include/bnd_particles_ordered_impl.hxx
+++ b/src/include/bnd_particles_ordered_impl.hxx
@@ -180,7 +180,7 @@ struct psc_bnd_particles_ordered : BndParticles_<MP>, bnd_particles_policy_order
   // ----------------------------------------------------------------------
   // exchange_particles
 
-  void exchange_particles(MparticlesBase& mprts_base)
+  void operator()(Mparticles& mprts)
   {
     static int pr_A, pr_B;
     if (!pr_A) {

--- a/src/include/collision.hxx
+++ b/src/include/collision.hxx
@@ -8,7 +8,5 @@
 
 class CollisionBase
 {
-public:
-  virtual void operator()(MparticlesBase& mprts_base) = 0;
 };
 

--- a/src/include/heating.hxx
+++ b/src/include/heating.hxx
@@ -11,6 +11,5 @@
 
 struct HeatingBase
 {
-  virtual void run(MparticlesBase& mprts_base) = 0;
 };
 

--- a/src/include/inject.hxx
+++ b/src/include/inject.hxx
@@ -15,8 +15,6 @@ struct InjectBase
     : interval(interval), tau(tau), kind_n(kind_n)
   {}
 
-  virtual void run(MparticlesBase& mprts_base, MfieldsBase& mflds_base) = 0;
-  
   // param
   const int interval; // inject every so many steps
   const int tau; // in steps

--- a/src/include/inject_impl.hxx
+++ b/src/include/inject_impl.hxx
@@ -61,16 +61,6 @@ struct Inject_ : InjectBase
     mres.put_as(mf_n, 0, 0);
   }
 
-  // ----------------------------------------------------------------------
-  // run
-
-  void run(MparticlesBase& mprts_base, MfieldsBase& mflds_base) override
-  {
-    auto& mprts = mprts_base.get_as<Mparticles>();
-    (*this)(mprts);
-    mprts_base.put_as(mprts);
-  }
-
 private:
   Target_t target_;
   ItemMoment_t moment_n_;

--- a/src/include/sort.hxx
+++ b/src/include/sort.hxx
@@ -12,24 +12,5 @@
 
 struct SortBase
 {
-  virtual void run(MparticlesBase& mprts_base) = 0;
-};
-
-// ======================================================================
-// SortConvert
-
-template<typename Sort_t>
-struct SortConvert : Sort_t, SortBase
-{
-  using Base = Sort_t;
-  using Mparticles = typename Sort_t::Mparticles;
-  using Base::Base;
-
-  void run(MparticlesBase& mprts_base) override
-  {
-    auto& mprts = mprts_base.get_as<Mparticles>();
-    (*this)(mprts);
-    mprts_base.put_as(mprts);
-  }
 };
 

--- a/src/libpsc/cuda/bnd_cuda_2_impl.hxx
+++ b/src/libpsc/cuda/bnd_cuda_2_impl.hxx
@@ -61,9 +61,10 @@ struct BndCuda2 : BndBase
       balance_generation_cnt_ = psc_balance_generation_cnt;
       reset(mflds.grid());
     }
-    auto& mflds_single = mflds.template get_as<MfieldsSingle>(mb, me);
-    mrc_ddc_add_ghosts(ddc_, mb, me, &mflds_single);
-    mflds.put_as(mflds_single, mb, me);
+    auto h_mflds = hostMirror(mflds);
+    copy(mflds, h_mflds);
+    mrc_ddc_add_ghosts(ddc_, mb, me, &h_mflds);
+    copy(h_mflds, mflds);
   }
 
   // ----------------------------------------------------------------------
@@ -78,9 +79,10 @@ struct BndCuda2 : BndBase
     // FIXME
     // I don't think we need as many points, and only stencil star
     // rather then box
-    auto& mflds_single = mflds.template get_as<MfieldsSingle>(mb, me);
-    mrc_ddc_fill_ghosts(ddc_, mb, me, &mflds_single);
-    mflds.put_as(mflds_single, mb, me);
+    auto h_mflds = hostMirror(mflds);
+    copy(mflds, h_mflds);
+    mrc_ddc_fill_ghosts(ddc_, mb, me, &h_mflds);
+    copy(h_mflds, mflds);
   }
 
   // ----------------------------------------------------------------------
@@ -89,7 +91,7 @@ struct BndCuda2 : BndBase
   static void copy_to_buf(int mb, int me, int p, int ilo[3], int ihi[3],
 			  void *_buf, void *ctx)
   {
-    auto& mf = *static_cast<MfieldsSingle*>(ctx);
+    auto& mf = *static_cast<HMFields*>(ctx);
     auto F = mf[p];
     real_t *buf = static_cast<real_t*>(_buf);
     
@@ -107,7 +109,7 @@ struct BndCuda2 : BndBase
   static void add_from_buf(int mb, int me, int p, int ilo[3], int ihi[3],
 			   void *_buf, void *ctx)
   {
-    auto& mf = *static_cast<MfieldsSingle*>(ctx);
+    auto& mf = *static_cast<HMFields*>(ctx);
     auto F = mf[p];
     real_t *buf = static_cast<real_t*>(_buf);
     
@@ -126,7 +128,7 @@ struct BndCuda2 : BndBase
   static void copy_from_buf(int mb, int me, int p, int ilo[3], int ihi[3],
 			    void *_buf, void *ctx)
   {
-    auto& mf = *static_cast<MfieldsSingle*>(ctx);
+    auto& mf = *static_cast<HMFields*>(ctx);
     auto F = mf[p];
     real_t *buf = static_cast<real_t*>(_buf);
     

--- a/src/libpsc/cuda/bnd_particles_cuda_impl.cu
+++ b/src/libpsc/cuda/bnd_particles_cuda_impl.cu
@@ -62,16 +62,5 @@ void BndParticlesCuda<Mparticles, DIM>::operator()(Mparticles& mprts)
   prof_stop(pr_time_step_no_comm);
 }
 
-// ----------------------------------------------------------------------
-// exchange_particles
-
-template<typename Mparticles, typename DIM>
-void BndParticlesCuda<Mparticles, DIM>::exchange_particles(MparticlesBase& mprts_base)
-{
-  auto& mprts = mprts_base.get_as<Mparticles>();
-  (*this)(mprts);
-  mprts_base.put_as(mprts);
-}
-
 template struct BndParticlesCuda<MparticlesCuda<BS144>, dim_yz>;
 template struct BndParticlesCuda<MparticlesCuda<BS444>, dim_xyz>;

--- a/src/libpsc/cuda/bnd_particles_cuda_impl.hxx
+++ b/src/libpsc/cuda/bnd_particles_cuda_impl.hxx
@@ -16,7 +16,6 @@ struct BndParticlesCuda : BndParticlesCommon<Mparticles>
 
   void reset(const Grid_t& grid);
   void operator()(Mparticles& mprts);
-  void exchange_particles(MparticlesBase& mprts_base) override;
 
 private:
   cuda_bndp<typename Mparticles::CudaMparticles, DIM>* cbndp_;

--- a/src/libpsc/cuda/collision_cuda_host_impl.hxx
+++ b/src/libpsc/cuda/collision_cuda_host_impl.hxx
@@ -20,8 +20,6 @@ public:
   
   CollisionCudaHost(MPI_Comm comm, int interval, double nu);
   
-  virtual void run(MparticlesBase& mprts_base) { assert(0); }
-
   void operator()(Mparticles& mprts)
   {
     auto& mprts = _mprts.template get_as<MparticlesSingle>();

--- a/src/libpsc/cuda/collision_cuda_impl.hxx
+++ b/src/libpsc/cuda/collision_cuda_impl.hxx
@@ -18,8 +18,6 @@ struct CollisionCuda : CollisionBase
   using Mparticles = MP;
 
   CollisionCuda(const Grid_t& grid, int interval, double nu);
-
-  void operator()(MparticlesBase& mprts_base) override { assert(0); }
   void operator()(Mparticles& _mprts);
   int interval() const;
 

--- a/src/libpsc/cuda/cuda_mfields_iface.cu
+++ b/src/libpsc/cuda/cuda_mfields_iface.cu
@@ -80,9 +80,9 @@ int MfieldsCuda::index(int m, int i, int j, int k, int p) const
 
 void MfieldsCuda::write_as_mrc_fld(mrc_io *io, const std::string& name, const std::vector<std::string>& comp_names)
 {
-  auto& mflds = get_as<MfieldsSingle>(0, n_comps());
-  mflds.write_as_mrc_fld(io, name, comp_names);
-  put_as(mflds, 0, 0);
+  auto h_mflds = hostMirror(*this);
+  copy(*this, h_mflds);
+  MrcIo::write_mflds(io, h_mflds, grid(), name, comp_names);
 }
 
 MfieldsCuda::Patch::Patch(MfieldsCuda& mflds, int p)

--- a/src/libpsc/cuda/heating_cuda_impl.hxx
+++ b/src/libpsc/cuda/heating_cuda_impl.hxx
@@ -22,16 +22,6 @@ struct HeatingCuda : HeatingBase
 
   void operator()(MparticlesCuda<BS>& mprts);
   
-  // ----------------------------------------------------------------------
-  // run
-
-  void run(MparticlesBase& mprts_base) override
-  {
-    auto& mprts = mprts_base.get_as<MparticlesCuda<BS>>();
-    (*this)(mprts);
-    mprts_base.put_as(mprts);
-  }
-
 private:
   cuda_heating_foil* foil_;
   int balance_generation_cnt_;

--- a/src/libpsc/cuda/sort_cuda_impl.hxx
+++ b/src/libpsc/cuda/sort_cuda_impl.hxx
@@ -5,8 +5,6 @@ template<typename BS>
 class SortCuda : SortBase
 {
 public:
-  virtual void run(MparticlesBase& mprts_base) { assert(0); }
-
   void operator()(MparticlesCuda<BS>& _mprts)
   {
     // nothing to be done, since MparticlesCuda are kept sorted anyway...

--- a/src/libpsc/psc_bnd_fields/psc_bnd_fields_impl.hxx
+++ b/src/libpsc/psc_bnd_fields/psc_bnd_fields_impl.hxx
@@ -64,14 +64,6 @@ struct BndFields_ : BndFieldsBase
     }
   }
 
-  void fill_ghosts_E(MfieldsBase& mflds_base) override
-  {
-    // OPT, if we don't need to do anything, we don't need to get
-    auto& mflds = mflds_base.get_as<Mfields>(EX, EX + 3);
-    fill_ghosts_E(mflds);
-    mflds_base.put_as(mflds, EX, EX + 3);
-  }
-  
   // ----------------------------------------------------------------------
   // fill_ghosts_H
 
@@ -117,14 +109,6 @@ struct BndFields_ : BndFieldsBase
     }
   }
 
-  void fill_ghosts_H(MfieldsBase& mflds_base) override
-  {
-    // OPT, if we don't need to do anything, we don't need to get
-    auto& mflds = mflds_base.get_as<Mfields>(HX, HX + 3);
-    fill_ghosts_H(mflds);
-    mflds_base.put_as(mflds, HX, HX + 3);
-  }
-  
   // ----------------------------------------------------------------------
   // add_ghosts_J
 
@@ -166,14 +150,6 @@ struct BndFields_ : BndFieldsBase
     }
   }
 
-  void add_ghosts_J(MfieldsBase& mflds_base) override
-  {
-    // OPT, if we don't need to do anything, we don't need to get
-    auto& mflds = mflds_base.get_as<Mfields>(JXI, JXI + 3);
-    add_ghosts_J(mflds);
-    mflds_base.put_as(mflds, JXI, JXI + 3);
-  }
-  
   static void fields_t_set_nan(real_t *f)
   {
     *f = std::numeric_limits<real_t>::quiet_NaN();
@@ -651,10 +627,6 @@ struct BndFieldsNone : BndFieldsBase
 {
   using Mfields = MF;
   
-  void fill_ghosts_E(MfieldsBase& mflds_base) override {};
-  void fill_ghosts_H(MfieldsBase& mflds_base) override {};
-  void add_ghosts_J(MfieldsBase& mflds_base) override {};
-
   void fill_ghosts_E(Mfields& mflds) {};
   void fill_ghosts_H(Mfields& mflds) {};
   void add_ghosts_J(Mfields& mflds) {};

--- a/src/libpsc/psc_collision/psc_collision_impl.cxx
+++ b/src/libpsc/psc_collision/psc_collision_impl.cxx
@@ -17,7 +17,8 @@ struct CollisionNone : CollisionBase
 
   CollisionNone(MPI_Comm comm, int interval, double nu) {}
 
-  void operator()(MparticlesBase& mprts_base) override {}
+  template <typename Mparticles>
+  void operator()(Mparticles& mprts_base) {}
 };
 
 void* global_collision; // FIXME

--- a/src/libpsc/psc_heating/psc_heating_impl.hxx
+++ b/src/libpsc/psc_heating/psc_heating_impl.hxx
@@ -78,13 +78,6 @@ struct Heating__ : HeatingBase
     }
   }
   
-  void run(MparticlesBase& mprts_base) override
-  {
-    auto& mprts = mprts_base.get_as<Mparticles>();
-    (*this)(mprts);
-    mprts_base.put_as(mprts);
-  }
-  
 private:
   int kind_;
   real_t heating_dt_;

--- a/src/libpsc/vpic/bnd_fields_vpic.hxx
+++ b/src/libpsc/vpic/bnd_fields_vpic.hxx
@@ -9,9 +9,5 @@ struct BndFieldsVpic : BndFieldsBase
   void fill_ghosts_E(MfieldsState& mflds) {}
   void fill_ghosts_H(MfieldsState& mflds) {}
   void add_ghosts_J(MfieldsState& mflds) {}
-
-  void fill_ghosts_E(MfieldsBase& mflds_base) override {}
-  void fill_ghosts_H(MfieldsBase& mflds_base) override {}
-  void add_ghosts_J(MfieldsBase& mflds_base) override {}
 };
 

--- a/src/libpsc/vpic/bnd_particles_vpic.hxx
+++ b/src/libpsc/vpic/bnd_particles_vpic.hxx
@@ -9,6 +9,5 @@ struct BndParticlesVpic : BndParticlesBase
   BndParticlesVpic(const Grid_t& grid) {}
 
   void operator()(Mparticles& mprts) {}
-  void exchange_particles(MparticlesBase& mprts_base) override {}
 };
 

--- a/src/libpsc/vpic/collision_vpic.hxx
+++ b/src/libpsc/vpic/collision_vpic.hxx
@@ -16,7 +16,8 @@ public:
     : interval_{interval}
   {}
 
-  void operator()(MparticlesBase& mprts_base) override
+  template <typename Mparticles>
+  void operator()(Mparticles& mprts_base)
   {
 #if 0
     // Note: Particles should not have moved since the last performance sort


### PR DESCRIPTION
We want to get to a place where we template with the actual type, so conversions / abstract base classes should eventually all go away.
