### PR TITLE
add CUDA-specific setup_fields

### DIFF
--- a/src/include/setup_fields.hxx
+++ b/src/include/setup_fields.hxx
@@ -63,3 +63,7 @@ void setupFields(MF& mflds, FUNC&& func)
 {
   detail::SetupFields<MF>::run(mflds, std::forward<FUNC>(func));
 }
+
+#ifdef USE_CUDA
+#include "../libpsc/cuda/setup_fields_cuda.hxx"
+#endif


### PR DESCRIPTION
The generic one worked, but very slowly, so that wasn't working as intended.