### PR TITLE
assorted updates/fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,8 +36,8 @@ if(USE_CUDA)
   list(REMOVE_ITEM CMAKE_CUDA_FLAGS "-std c++14")
 endif()
 
+set(MPI_CXX_SKIP_MPICXX ON)
 find_package(MPI REQUIRED)
-add_definitions(-DOMPI_SKIP_MPICXX)
 
 # ADIOS2
 if(PSC_USE_ADIOS2 STREQUAL AUTO)

--- a/src/include/OutputFieldsDefault.h
+++ b/src/include/OutputFieldsDefault.h
@@ -81,6 +81,7 @@ public:
                           timestep == 0);
 
     if (!do_pfield && !doaccum_tfield) {
+      prof_stop(pr);
       return;
     }
 

--- a/src/kg/CMakeLists.txt
+++ b/src/kg/CMakeLists.txt
@@ -6,6 +6,7 @@ target_include_directories(kg INTERFACE include)
 target_include_directories(kg INTERFACE ${CMAKE_SOURCE_DIR}/src/libmrc/include)
 # FIXME, hack for vec3.h; PscConfig.h
 target_include_directories(kg INTERFACE ${CMAKE_SOURCE_DIR}/src/include)
+target_link_libraries(kg INTERFACE MPI::MPI_CXX)
 
 if (PSC_HAVE_ADIOS2)
   target_link_libraries(kg INTERFACE adios2::adios2)

--- a/src/libpsc/CMakeLists.txt
+++ b/src/libpsc/CMakeLists.txt
@@ -22,6 +22,7 @@ add_library(psc
   )
 target_include_directories(psc PUBLIC ../include)
 target_link_libraries(psc PUBLIC kg mrc)
+target_link_libraries(psc PUBLIC kg MPI::MPI_CXX)
 target_compile_features(psc PUBLIC cxx_std_11)
 
 if (USE_CUDA)

--- a/src/libpsc/cuda/cuda_collision.cuh
+++ b/src/libpsc/cuda/cuda_collision.cuh
@@ -88,7 +88,7 @@ struct CudaCollision
       uint beg = d_off[bidx];
       uint end = d_off[bidx + 1];
       real_t nudt1 =
-        nudt0 * (end - beg & ~1); // somewhat counteract that we don't collide
+        nudt0 * (end - beg) * (end - beg) / ((end - beg) & ~1); // somewhat counteract that we don't collide
                                   // the last particle if odd
       for (uint n = beg + 2 * threadIdx.x; n + 1 < end;
            n += 2 * THREADS_PER_BLOCK) {

--- a/src/libpsc/psc_output_particles/output_particles_hdf5_impl.hxx
+++ b/src/libpsc/psc_output_particles/output_particles_hdf5_impl.hxx
@@ -552,6 +552,9 @@ struct OutputParticlesHdf5
                    (char*)params.romio_ds_write);
     }
     H5Pset_fapl_mpio(plist, comm_, mpi_info);
+#else
+    mprintf("ERROR: particle output requires parallel hdf5\n");
+    abort();
 #endif
 
     hid_t file = H5Fcreate(filename.c_str(), H5F_ACC_TRUNC, H5P_DEFAULT, plist);


### PR DESCRIPTION
These are just relatively minor bits, including
- cmake MPI_CXX handling
- fix missing profiling `pr_stop`
- warn if trying to use serial HDF5 for particle output
- fix up collision frequency correctly when # particles in the cell is odd