### PR TITLE
OutputFields: separate moments and fields

### DIFF
--- a/src/include/OutputFieldsDefault.h
+++ b/src/include/OutputFieldsDefault.h
@@ -24,8 +24,8 @@ struct OutputFieldsParams
 
   int tfield_interval = 0;
   int tfield_first = 0;
-  int tfield_length = 1000000;
-  int tfield_every = 1;
+  int tfield_average_length = 1000000;
+  int tfield_average_every = 1;
 
   Int3 rn = {};
   Int3 rx = {1000000, 1000000, 100000};
@@ -76,8 +76,8 @@ public:
     bool do_pfield = pfield_interval > 0 && timestep >= pfield_next_;
     bool do_tfield = tfield_interval > 0 && timestep >= tfield_next_;
     bool doaccum_tfield =
-      tfield_interval > 0 && (((timestep >= (tfield_next_ - tfield_length + 1)) &&
-                           timestep % tfield_every == 0) ||
+      tfield_interval > 0 && (((timestep >= (tfield_next_ - tfield_average_length + 1)) &&
+                           timestep % tfield_average_every == 0) ||
                           timestep == 0);
 
     if (!do_pfield && !doaccum_tfield) {

--- a/src/include/OutputFieldsDefault.h
+++ b/src/include/OutputFieldsDefault.h
@@ -19,10 +19,10 @@ struct OutputFieldsParams
 {
   const char* data_dir = {"."};
 
-  int pfield_step = 0;
+  int pfield_interval = 0;
   int pfield_first = 0;
 
-  int tfield_step = 0;
+  int tfield_interval = 0;
   int tfield_first = 0;
   int tfield_length = 1000000;
   int tfield_every = 1;
@@ -50,10 +50,10 @@ public:
       pfield_next_{pfield_first},
       tfield_next_{tfield_first}
   {
-    if (pfield_step > 0) {
+    if (pfield_interval > 0) {
       io_pfd_.reset(new MrcIo{"pfd", data_dir});
     }
-    if (tfield_step > 0) {
+    if (tfield_interval > 0) {
       io_tfd_.reset(new MrcIo{"tfd", data_dir});
     }
   }
@@ -73,10 +73,10 @@ public:
     prof_start(pr);
 
     auto timestep = grid.timestep();
-    bool do_pfield = pfield_step > 0 && timestep >= pfield_next_;
-    bool do_tfield = tfield_step > 0 && timestep >= tfield_next_;
+    bool do_pfield = pfield_interval > 0 && timestep >= pfield_next_;
+    bool do_tfield = tfield_interval > 0 && timestep >= tfield_next_;
     bool doaccum_tfield =
-      tfield_step > 0 && (((timestep >= (tfield_next_ - tfield_length + 1)) &&
+      tfield_interval > 0 && (((timestep >= (tfield_next_ - tfield_length + 1)) &&
                            timestep % tfield_every == 0) ||
                           timestep == 0);
 
@@ -90,7 +90,7 @@ public:
 
     if (do_pfield) {
       mpi_printf(grid.comm(), "***** Writing PFD output\n");
-      pfield_next_ += pfield_step;
+      pfield_next_ += pfield_interval;
 
       io_pfd_->open(grid, rn, rx);
       _write_pfd(pfd_jeh);
@@ -106,7 +106,7 @@ public:
     }
     if (do_tfield) {
       mpi_printf(grid.comm(), "***** Writing TFD output\n");
-      tfield_next_ += tfield_step;
+      tfield_next_ += tfield_interval;
 
       io_tfd_->open(grid, rn, rx);
       _write_tfd(tfd_jeh_, pfd_jeh);

--- a/src/include/OutputFieldsDefault.h
+++ b/src/include/OutputFieldsDefault.h
@@ -102,9 +102,17 @@ public:
   {
     const auto& grid = mflds._grid();
 
-    static int pr;
+    static int pr, pr_field, pr_moment, pr_field_calc, pr_moment_calc, pr_field_write, pr_moment_write, pr_field_acc, pr_moment_acc;
     if (!pr) {
-      pr = prof_register("output_c_field", 1., 0, 0);
+      pr = prof_register("outf", 1., 0, 0);
+      pr_field = prof_register("outf_field", 1., 0, 0);
+      pr_moment = prof_register("outf_moment", 1., 0, 0);
+      pr_field_calc = prof_register("outf_field_calc", 1., 0, 0);
+      pr_moment_calc = prof_register("outf_moment_calc", 1., 0, 0);
+      pr_field_write = prof_register("outf_field_write", 1., 0, 0);
+      pr_moment_write = prof_register("outf_moment_write", 1., 0, 0);
+      pr_field_acc = prof_register("outf_field_acc", 1., 0, 0);
+      pr_moment_acc = prof_register("outf_moment_acc", 1., 0, 0);
     }
     prof_start(pr);
 
@@ -117,31 +125,41 @@ public:
                           timestep == 0);
 
     if (do_pfield || doaccum_tfield) {
+      prof_start(pr_field);
+      prof_start(pr_field_calc);
       Item_jeh<MfieldsState> pfd_jeh{mflds};
+      prof_stop(pr_field_calc);
       
       if (do_pfield) {
 	mpi_printf(grid.comm(), "***** Writing PFD output\n");
 	pfield_next_ += pfield_interval;
 	
+	prof_start(pr_field_write);
 	io_pfd_->open(grid, rn, rx);
 	_write_pfd(*io_pfd_, pfd_jeh);
 	io_pfd_->close();
+	prof_stop(pr_field_write);
       }
 
       if (doaccum_tfield) {
 	// tfd += pfd
+	prof_start(pr_field_acc);
 	tfd_jeh_ += pfd_jeh;
+	prof_stop(pr_field_acc);
 	naccum_++;
       }
       if (do_tfield) {
 	mpi_printf(grid.comm(), "***** Writing TFD output\n");
 	tfield_next_ += tfield_interval;
 
+	prof_start(pr_field_write);
 	io_tfd_->open(grid, rn, rx);
 	_write_tfd(*io_tfd_, tfd_jeh_, pfd_jeh, naccum_);
 	io_tfd_->close();
 	naccum_ = 0;
+	prof_stop(pr_field_write);
       }
+      prof_stop(pr_field);
     }
 
     bool do_pfield_moments = pfield_moments_interval > 0 && timestep >= pfield_moments_next_;
@@ -152,31 +170,41 @@ public:
 				       timestep == 0);
     
     if (do_pfield_moments || doaccum_tfield_moments) {
+      prof_start(pr_moment);
+      prof_start(pr_moment_calc);
       FieldsItem_Moments_1st_cc<Mparticles> pfd_moments{mprts};
+      prof_stop(pr_moment_calc);
       
       if (do_pfield_moments) {
 	mpi_printf(grid.comm(), "***** Writing PFD moment output\n");
 	pfield_moments_next_ += pfield_moments_interval;
 	
+	prof_start(pr_moment_write);
 	io_pfd_moments_->open(grid, rn, rx);
 	_write_pfd(*io_pfd_moments_, pfd_moments);
 	io_pfd_moments_->close();
+	prof_stop(pr_moment_write);
       }
 
       if (doaccum_tfield_moments) {
 	// tfd += pfd
+	prof_start(pr_moment_acc);
 	tfd_moments_ += pfd_moments;
+	prof_stop(pr_moment_acc);
 	naccum_moments_++;
       }
       if (do_tfield_moments) {
 	mpi_printf(grid.comm(), "***** Writing TFD moment output\n");
 	tfield_moments_next_ += tfield_moments_interval;
 
+	prof_start(pr_moment_write);
 	io_tfd_moments_->open(grid, rn, rx);
 	_write_tfd(*io_tfd_moments_, tfd_moments_, pfd_moments, naccum_moments_);
 	io_tfd_moments_->close();
+	prof_stop(pr_moment_write);
 	naccum_moments_ = 0;
       }
+      prof_stop(pr_moment);
     }
 
     prof_stop(pr);

--- a/src/include/OutputFieldsDefault.h
+++ b/src/include/OutputFieldsDefault.h
@@ -22,10 +22,18 @@ struct OutputFieldsParams
   int pfield_interval = 0;
   int pfield_first = 0;
 
+  int pfield_moments_interval = -1;
+  int pfield_moments_first = -1;
+
   int tfield_interval = 0;
   int tfield_first = 0;
   int tfield_average_length = 1000000;
   int tfield_average_every = 1;
+
+  int tfield_moments_interval = -1;
+  int tfield_moments_first = -1;
+  int tfield_moments_average_length = -1;
+  int tfield_moments_average_every = -1;
 
   Int3 rn = {};
   Int3 rx = {1000000, 1000000, 100000};
@@ -45,16 +53,44 @@ public:
 
   OutputFields(const Grid_t& grid, const OutputFieldsParams& prm)
     : OutputFieldsParams{prm},
-      tfd_jeh_{grid, Item_jeh<MfieldsFake>::n_comps(), grid.ibn},
+      tfd_jeh_{grid, Item_jeh<MfieldsFake>::n_comps(), {}},
       tfd_moments_{grid, FieldsItem_Moments_1st_cc<MparticlesFake>::n_comps(grid), grid.ibn},
       pfield_next_{pfield_first},
-      tfield_next_{tfield_first}
+      pfield_moments_next_{pfield_moments_first},
+      tfield_next_{tfield_first},
+      tfield_moments_next_{tfield_moments_first}
   {
+    if (pfield_moments_interval < 0) {
+      pfield_moments_interval = pfield_interval;
+    }
+    if (pfield_moments_first < 0) {
+      pfield_moments_first = pfield_first;
+    }
+    
+    if (tfield_moments_interval < 0) {
+      tfield_moments_interval = tfield_interval;
+    }
+    if (tfield_moments_first < 0) {
+      tfield_moments_first = tfield_first;
+    }
+    if (tfield_moments_average_length < 0) {
+      tfield_moments_average_length = tfield_average_length;
+    }
+    if (tfield_moments_average_every < 0) {
+      tfield_moments_average_every = tfield_average_every;
+    }
+    
     if (pfield_interval > 0) {
       io_pfd_.reset(new MrcIo{"pfd", data_dir});
     }
+    if (pfield_moments_interval > 0) {
+      io_pfd_moments_.reset(new MrcIo{"pfd_moments", data_dir});
+    }
     if (tfield_interval > 0) {
       io_tfd_.reset(new MrcIo{"tfd", data_dir});
+    }
+    if (tfield_moments_interval > 0) {
+      io_tfd_moments_.reset(new MrcIo{"tfd_moments", data_dir});
     }
   }
 
@@ -82,22 +118,19 @@ public:
 
     if (do_pfield || doaccum_tfield) {
       Item_jeh<MfieldsState> pfd_jeh{mflds};
-      FieldsItem_Moments_1st_cc<Mparticles> pfd_moments{mprts};
       
       if (do_pfield) {
 	mpi_printf(grid.comm(), "***** Writing PFD output\n");
 	pfield_next_ += pfield_interval;
 	
 	io_pfd_->open(grid, rn, rx);
-	_write_pfd(pfd_jeh);
-	_write_pfd(pfd_moments);
+	_write_pfd(*io_pfd_, pfd_jeh);
 	io_pfd_->close();
       }
 
       if (doaccum_tfield) {
 	// tfd += pfd
 	tfd_jeh_ += pfd_jeh;
-	tfd_moments_ += pfd_moments;
 	naccum_++;
       }
       if (do_tfield) {
@@ -105,10 +138,44 @@ public:
 	tfield_next_ += tfield_interval;
 
 	io_tfd_->open(grid, rn, rx);
-	_write_tfd(tfd_jeh_, pfd_jeh);
-	_write_tfd(tfd_moments_, pfd_moments);
+	_write_tfd(*io_tfd_, tfd_jeh_, pfd_jeh, naccum_);
 	io_tfd_->close();
 	naccum_ = 0;
+      }
+    }
+
+    bool do_pfield_moments = pfield_moments_interval > 0 && timestep >= pfield_moments_next_;
+    bool do_tfield_moments = tfield_moments_interval > 0 && timestep >= tfield_moments_next_;
+    bool doaccum_tfield_moments =
+      tfield_moments_interval > 0 && (((timestep >= (tfield_moments_next_ - tfield_moments_average_length + 1)) &&
+					timestep % tfield_moments_average_every == 0) ||
+				       timestep == 0);
+    
+    if (do_pfield_moments || doaccum_tfield_moments) {
+      FieldsItem_Moments_1st_cc<Mparticles> pfd_moments{mprts};
+      
+      if (do_pfield_moments) {
+	mpi_printf(grid.comm(), "***** Writing PFD moment output\n");
+	pfield_moments_next_ += pfield_moments_interval;
+	
+	io_pfd_moments_->open(grid, rn, rx);
+	_write_pfd(*io_pfd_moments_, pfd_moments);
+	io_pfd_moments_->close();
+      }
+
+      if (doaccum_tfield_moments) {
+	// tfd += pfd
+	tfd_moments_ += pfd_moments;
+	naccum_moments_++;
+      }
+      if (do_tfield_moments) {
+	mpi_printf(grid.comm(), "***** Writing TFD moment output\n");
+	tfield_moments_next_ += tfield_moments_interval;
+
+	io_tfd_moments_->open(grid, rn, rx);
+	_write_tfd(*io_tfd_moments_, tfd_moments_, pfd_moments, naccum_moments_);
+	io_tfd_moments_->close();
+	naccum_moments_ = 0;
       }
     }
 
@@ -117,18 +184,18 @@ public:
 
 private:
   template <typename EXP>
-  void _write_pfd(EXP& pfd)
+  static void _write_pfd(MrcIo& io, EXP& pfd)
   {
-    MrcIo::write_mflds(io_pfd_->io_, adaptMfields(pfd), pfd.grid(), pfd.name(),
+    MrcIo::write_mflds(io.io_, adaptMfields(pfd), pfd.grid(), pfd.name(),
                        pfd.comp_names());
   }
 
   template <typename EXP>
-  void _write_tfd(MfieldsC& tfd, EXP& pfd)
+  static void _write_tfd(MrcIo& io, MfieldsC& tfd, EXP& pfd, int naccum)
   {
     // convert accumulated values to correct temporal mean
-    tfd.scale(1. / naccum_);
-    tfd.write_as_mrc_fld(io_tfd_->io_, pfd.name(), pfd.comp_names());
+    tfd.scale(1. / naccum);
+    tfd.write_as_mrc_fld(io.io_, pfd.name(), pfd.comp_names());
     tfd.zero();
   }
 
@@ -137,7 +204,13 @@ private:
   MfieldsC tfd_jeh_;
   MfieldsC tfd_moments_;
   std::unique_ptr<MrcIo> io_pfd_;
+  std::unique_ptr<MrcIo> io_pfd_moments_;
   std::unique_ptr<MrcIo> io_tfd_;
-  int pfield_next_, tfield_next_;
+  std::unique_ptr<MrcIo> io_tfd_moments_;
+  int pfield_next_;
+  int pfield_moments_next_;
+  int tfield_next_;
+  int tfield_moments_next_;
   int naccum_ = 0;
+  int naccum_moments_ = 0;
 };

--- a/src/libpsc/psc_output_fields/fields_item_fields.hxx
+++ b/src/libpsc/psc_output_fields/fields_item_fields.hxx
@@ -3,7 +3,7 @@
 
 #include "fields_item.hxx"
 #include "psc_fields_c.h"
-
+#include "psc_fields_cuda.h"
 template <typename E>
 struct isSpaceCuda : std::false_type
 {};
@@ -516,6 +516,64 @@ public:
 
 private:
   MfieldsState& mflds_;
+};
+
+// ======================================================================
+// Item_jeh
+//
+// Main fields in their natural staggering
+
+template <>
+class Item_jeh<MfieldsStateCuda> : public MFexpression<Item_jeh<MfieldsStateCuda>>
+{
+  using MfieldsState = MfieldsStateCuda;
+  
+public:
+  using Real = typename MfieldsState::real_t;
+
+  static char const* name() { return "jeh"; }
+  static int n_comps() { return 9; }
+  static std::vector<std::string> comp_names()
+  {
+    return {"jx_ec", "jy_ec", "jz_ec", "ex_ec", "ey_ec",
+            "ez_ec", "hx_fc", "hy_fc", "hz_fc"};
+  }
+
+  Item_jeh(MfieldsState& mflds) : mflds_(mflds.grid(), NR_FIELDS, mflds.grid().ibn)
+  {
+    auto hmflds = hostMirror(mflds);
+    copy(mflds, hmflds);
+    for (int p = 0; p < mflds_.n_patches(); p++) {
+      for (int m = 0; m < mflds_.n_comps(); m++) {
+	mflds_.Foreach_3d(0, 0, [&](int i, int j, int k) {
+	    mflds_[p](m, i, j, k) = hmflds[p](m, i, j, k);
+	  });
+      }
+    }
+  }
+
+  Real operator()(int m, Int3 ijk, int p) const
+  {
+    switch (m) {
+      case 0: return mflds_[p](JXI, ijk[0], ijk[1], ijk[2]);
+      case 1: return mflds_[p](JYI, ijk[0], ijk[1], ijk[2]);
+      case 2: return mflds_[p](JZI, ijk[0], ijk[1], ijk[2]);
+      case 3: return mflds_[p](EX, ijk[0], ijk[1], ijk[2]);
+      case 4: return mflds_[p](EY, ijk[0], ijk[1], ijk[2]);
+      case 5: return mflds_[p](EZ, ijk[0], ijk[1], ijk[2]);
+      case 6: return mflds_[p](HX, ijk[0], ijk[1], ijk[2]);
+      case 7: return mflds_[p](HY, ijk[0], ijk[1], ijk[2]);
+      case 8: return mflds_[p](HZ, ijk[0], ijk[1], ijk[2]);
+      default: std::abort();
+    }
+  }
+
+  const Grid_t& grid() const { return mflds_.grid(); }
+  Int3 ibn() const { return {}; }
+  int n_patches() const { return grid().n_patches(); }
+
+private:
+  mutable MfieldsSingle mflds_; // FIXME!!
 };
 
 // ======================================================================

--- a/src/psc_bubble_yz.cxx
+++ b/src/psc_bubble_yz.cxx
@@ -332,7 +332,7 @@ static void run()
 
   // -- output fields
   OutputFieldsParams outf_params{};
-  outf_params.pfield_step = 200;
+  outf_params.pfield_interval = 200;
   OutputFields outf{grid, outf_params};
 
   // -- output particles

--- a/src/psc_flatfoil_yz.cxx
+++ b/src/psc_flatfoil_yz.cxx
@@ -386,7 +386,7 @@ void run()
 
   // -- output fields
   OutputFieldsParams outf_params{};
-  outf_params.pfield_step = 200;
+  outf_params.pfield_interval = 200;
   OutputFields outf{grid, outf_params};
 
   // -- output particles

--- a/src/psc_harris_xz.cxx
+++ b/src/psc_harris_xz.cxx
@@ -486,7 +486,7 @@ public:
     MPI_Comm comm = grid.comm();
 
     int timestep = grid.timestep();
-    if (outf_.pfield_step > 0 && timestep % outf_.pfield_step == 0) {
+    if (outf_.pfield_interval > 0 && timestep % outf_.pfield_interval == 0) {
       mpi_printf(comm, "***** Writing PFD output\n");
       io_pfd_.open(grid);
 
@@ -790,7 +790,7 @@ void run()
   // -- output fields
   OutputFieldsParams outf_params;
   double output_field_interval = 1.;
-  outf_params.pfield_step = int((output_field_interval / (phys.wci * grid.dt)));
+  outf_params.pfield_interval = int((output_field_interval / (phys.wci * grid.dt)));
   OutputFields outf{grid, outf_params};
 
   OutputParticlesParams outp_params{};

--- a/src/psc_whistler.cxx
+++ b/src/psc_whistler.cxx
@@ -311,7 +311,7 @@ void run()
 
   // -- output fields
   OutputFieldsParams outf_params{};
-  outf_params.pfield_step = 200;
+  outf_params.pfield_interval = 200;
   OutputFields outf{grid, outf_params};
 
   // -- output particles


### PR DESCRIPTION
Moments are much more expensive to calculate than the fields, so this PR separates the output so
that one can choose different output cadences / different averaging options for them, in order to keep costs down.

What really should be done, though, is to move more of this onto the GPU, which would reduce the cost signficicantly.