### PR TITLE
use regular sort in dim_yz bnd particles

### DIFF
--- a/src/libpsc/cuda/cuda_bndp.cu
+++ b/src/libpsc/cuda/cuda_bndp.cu
@@ -1,7 +1,7 @@
 
+#include "cuda_bits.h"
 #include "cuda_bndp.h"
 #include "cuda_mparticles.cuh"
-#include "cuda_bits.h"
 
 #include <thrust/device_vector.h>
 #include <thrust/host_vector.h>
@@ -13,6 +13,7 @@
 
 #define THREADS_PER_BLOCK 256
 
+// clang-format off
 // layout of the spine
 //     lt             self             rb        # from left-top .. self .. right-bottom 
 //     0   1   2   3   4   5   6   7   8   NEW
@@ -24,6 +25,7 @@
 
 //    |   |   |   |   |   |   |   |   |   |   |   |   | ... |   | # oob
 //     b0  b1  b2  b3                                        bn
+// clang-format on
 
 #include <cstdio>
 #include <cassert>
@@ -31,7 +33,7 @@
 // ----------------------------------------------------------------------
 // ctor
 
-template<typename CudaMparticles, typename DIM>
+template <typename CudaMparticles, typename DIM>
 cuda_bndp<CudaMparticles, DIM>::cuda_bndp(const Grid_t& grid)
   : cuda_mparticles_indexer<BS>(grid)
 {
@@ -46,22 +48,22 @@ cuda_bndp<CudaMparticles, DIM>::cuda_bndp(const Grid_t& grid)
 // ----------------------------------------------------------------------
 // prep
 
-template<typename CudaMparticles, typename DIM>
+template <typename CudaMparticles, typename DIM>
 auto cuda_bndp<CudaMparticles, DIM>::prep(CudaMparticles* cmprts) -> BndBuffers&
 {
   static int pr_A, pr_B, pr_D, pr_B0, pr_B1;
   if (!pr_A) {
     pr_A = prof_register("xchg_bidx", 1., 0, 0);
-    pr_B0= prof_register("xchg_reduce", 1., 0, 0);
-    pr_B1= prof_register("xchg_n_send", 1., 0, 0);
+    pr_B0 = prof_register("xchg_reduce", 1., 0, 0);
+    pr_B1 = prof_register("xchg_n_send", 1., 0, 0);
     pr_B = prof_register("xchg_scan_send", 1., 0, 0);
     pr_D = prof_register("xchg_from_dev", 1., 0, 0);
   }
 
-  //prof_start(pr_A);
-  //cuda_mprts_find_block_keys(mprts);
-  //prof_stop(pr_A);
-  
+  // prof_start(pr_A);
+  // cuda_mprts_find_block_keys(mprts);
+  // prof_stop(pr_A);
+
   prof_start(pr_B0);
   spine_reduce(cmprts);
   prof_stop(pr_B0);
@@ -84,14 +86,14 @@ auto cuda_bndp<CudaMparticles, DIM>::prep(CudaMparticles* cmprts) -> BndBuffers&
 // ----------------------------------------------------------------------
 // post
 
-template<typename CudaMparticles, typename DIM>
+template <typename CudaMparticles, typename DIM>
 void cuda_bndp<CudaMparticles, DIM>::post(CudaMparticles* cmprts)
 {
   static int pr_A, pr_D, pr_E, pr_D1;
   if (!pr_A) {
     pr_A = prof_register("xchg_to_dev", 1., 0, 0);
     pr_D = prof_register("xchg_sort", 1., 0, 0);
-    pr_D1= prof_register("xchg_upd_off", 1., 0, 0);
+    pr_D1 = prof_register("xchg_upd_off", 1., 0, 0);
     pr_E = prof_register("xchg_reorder", 1., 0, 0);
   }
 
@@ -108,7 +110,7 @@ void cuda_bndp<CudaMparticles, DIM>::post(CudaMparticles* cmprts)
   prof_start(pr_D1);
   update_offsets(cmprts);
   prof_stop(pr_D1);
-  
+
   prof_start(pr_E);
 #if 0
   cmprts->reorder(cmprts);
@@ -122,14 +124,13 @@ void cuda_bndp<CudaMparticles, DIM>::post(CudaMparticles* cmprts)
 // ----------------------------------------------------------------------
 // find_n_send
 
-template<typename CudaMparticles, typename DIM>
-uint cuda_bndp<CudaMparticles, DIM>::find_n_send(CudaMparticles *cmprts)
+template <typename CudaMparticles, typename DIM>
+uint cuda_bndp<CudaMparticles, DIM>::find_n_send(CudaMparticles* cmprts)
 {
   thrust::host_vector<uint> h_spine_sums(n_blocks + 1);
 
   thrust::copy(d_spine_sums.data() + n_blocks * 10,
-	       d_spine_sums.data() + n_blocks * 11 + 1,
-	       h_spine_sums.begin());
+               d_spine_sums.data() + n_blocks * 11 + 1, h_spine_sums.begin());
 
   uint off = 0;
   for (int p = 0; p < n_patches(); p++) {
@@ -143,16 +144,20 @@ uint cuda_bndp<CudaMparticles, DIM>::find_n_send(CudaMparticles *cmprts)
 // ----------------------------------------------------------------------
 // copy_from_dev_and_convert
 
-template<typename CudaMparticles, typename DIM>
-void cuda_bndp<CudaMparticles, DIM>::copy_from_dev_and_convert(CudaMparticles *cmprts, uint n_prts_send)
+template <typename CudaMparticles, typename DIM>
+void cuda_bndp<CudaMparticles, DIM>::copy_from_dev_and_convert(
+  CudaMparticles* cmprts, uint n_prts_send)
 {
   uint n_prts = cmprts->n_prts;
   HMparticlesCudaStorage h_bnd_storage{n_prts_send};
 
-  assert(cmprts->storage.xi4.begin() + n_prts + n_prts_send == cmprts->storage.xi4.end());
+  assert(cmprts->storage.xi4.begin() + n_prts + n_prts_send ==
+         cmprts->storage.xi4.end());
 
-  thrust::copy(cmprts->storage.xi4.begin()  + n_prts, cmprts->storage.xi4.end(), h_bnd_storage.xi4.begin());
-  thrust::copy(cmprts->storage.pxi4.begin() + n_prts, cmprts->storage.pxi4.end(), h_bnd_storage.pxi4.begin());
+  thrust::copy(cmprts->storage.xi4.begin() + n_prts, cmprts->storage.xi4.end(),
+               h_bnd_storage.xi4.begin());
+  thrust::copy(cmprts->storage.pxi4.begin() + n_prts,
+               cmprts->storage.pxi4.end(), h_bnd_storage.pxi4.begin());
 
   uint off = 0;
   for (int p = 0; p < n_patches(); p++) {
@@ -172,8 +177,9 @@ void cuda_bndp<CudaMparticles, DIM>::copy_from_dev_and_convert(CudaMparticles *c
 // ----------------------------------------------------------------------
 // convert_and_copy_to_dev
 
-template<typename CudaMparticles, typename DIM>
-uint cuda_bndp<CudaMparticles, DIM>::convert_and_copy_to_dev(CudaMparticles *cmprts)
+template <typename CudaMparticles, typename DIM>
+uint cuda_bndp<CudaMparticles, DIM>::convert_and_copy_to_dev(
+  CudaMparticles* cmprts)
 {
   uint n_recv = 0;
   for (int p = 0; p < n_patches(); p++) {
@@ -185,14 +191,15 @@ uint cuda_bndp<CudaMparticles, DIM>::convert_and_copy_to_dev(CudaMparticles *cmp
   thrust::host_vector<uint> h_bnd_off(n_recv);
 
   thrust::host_vector<uint> h_bnd_cnt(n_blocks, 0);
-  
+
   uint off = 0;
   for (int p = 0; p < n_patches(); p++) {
     int n_recv = bufs[p].size();
     n_recvs[p] = n_recv;
-    
+
     for (int n = 0; n < n_recv; n++) {
-      h_bnd_storage.store(bufs[p][n], n + off);;
+      h_bnd_storage.store(bufs[p][n], n + off);
+      ;
       checkInPatchMod(&h_bnd_storage.xi4[n + off].x);
       uint b = blockIndex(h_bnd_storage.xi4[n + off], p);
       assert(b < n_blocks);
@@ -204,14 +211,18 @@ uint cuda_bndp<CudaMparticles, DIM>::convert_and_copy_to_dev(CudaMparticles *cmp
 
   cmprts->resize(cmprts->n_prts + n_recv);
 
-  thrust::copy(h_bnd_storage.xi4.begin(), h_bnd_storage.xi4.end(), cmprts->storage.xi4.begin() + cmprts->n_prts);
-  thrust::copy(h_bnd_storage.pxi4.begin(), h_bnd_storage.pxi4.end(), cmprts->storage.pxi4.begin() + cmprts->n_prts);
+  thrust::copy(h_bnd_storage.xi4.begin(), h_bnd_storage.xi4.end(),
+               cmprts->storage.xi4.begin() + cmprts->n_prts);
+  thrust::copy(h_bnd_storage.pxi4.begin(), h_bnd_storage.pxi4.end(),
+               cmprts->storage.pxi4.begin() + cmprts->n_prts);
 
   // for consistency, use same block indices that we counted earlier
   // OPT unneeded?
-  thrust::copy(h_bnd_idx.begin(), h_bnd_idx.end(), cmprts->by_block_.d_idx.begin() + cmprts->n_prts);
+  thrust::copy(h_bnd_idx.begin(), h_bnd_idx.end(),
+               cmprts->by_block_.d_idx.begin() + cmprts->n_prts);
   // slight abuse of the now unused last part of spine_cnts
-  thrust::copy(h_bnd_cnt.begin(), h_bnd_cnt.end(), d_spine_cnts.begin() + 10 * n_blocks);
+  thrust::copy(h_bnd_cnt.begin(), h_bnd_cnt.end(),
+               d_spine_cnts.begin() + 10 * n_blocks);
 
   d_bnd_off.resize(n_recv);
   thrust::copy(h_bnd_off.begin(), h_bnd_off.end(), d_bnd_off.begin());
@@ -222,30 +233,31 @@ uint cuda_bndp<CudaMparticles, DIM>::convert_and_copy_to_dev(CudaMparticles *cmp
 // ----------------------------------------------------------------------
 // update_offsets
 
-__global__ static void
-mprts_update_offsets(int nr_total_blocks, uint *d_off, uint *d_spine_sums)
+__global__ static void mprts_update_offsets(int nr_total_blocks, uint* d_off,
+                                            uint* d_spine_sums)
 {
   int bid = threadIdx.x + THREADS_PER_BLOCK * blockIdx.x;
-  
+
   if (bid <= nr_total_blocks) {
     d_off[bid] = d_spine_sums[bid * CUDA_BND_STRIDE + 0];
   }
 }
 
-template<typename CudaMparticles, typename DIM>
-void cuda_bndp<CudaMparticles, DIM>::update_offsets(CudaMparticles *cmprts)
+template <typename CudaMparticles, typename DIM>
+void cuda_bndp<CudaMparticles, DIM>::update_offsets(CudaMparticles* cmprts)
 {
   int dimGrid = (n_blocks + 1 + THREADS_PER_BLOCK - 1) / THREADS_PER_BLOCK;
 
-  mprts_update_offsets<<<dimGrid, THREADS_PER_BLOCK>>>
-    (n_blocks, cmprts->by_block_.d_off.data().get(), d_spine_sums.data().get());
+  mprts_update_offsets<<<dimGrid, THREADS_PER_BLOCK>>>(
+    n_blocks, cmprts->by_block_.d_off.data().get(), d_spine_sums.data().get());
   cuda_sync_if_enabled();
 }
 
-template<typename CudaMparticles, typename DIM>
-void cuda_bndp<CudaMparticles, DIM>::update_offsets_gold(CudaMparticles *cmprts)
+template <typename CudaMparticles, typename DIM>
+void cuda_bndp<CudaMparticles, DIM>::update_offsets_gold(CudaMparticles* cmprts)
 {
-  thrust::host_vector<uint> h_spine_sums(d_spine_sums.data(), d_spine_sums.data() + 1 + n_blocks * (10 + 1));
+  thrust::host_vector<uint> h_spine_sums(
+    d_spine_sums.data(), d_spine_sums.data() + 1 + n_blocks * (10 + 1));
   thrust::host_vector<uint> h_off(n_blocks + 1);
 
   for (int bid = 0; bid <= n_blocks; bid++) {
@@ -258,8 +270,9 @@ void cuda_bndp<CudaMparticles, DIM>::update_offsets_gold(CudaMparticles *cmprts)
 // ----------------------------------------------------------------------
 // convert_and_copy_to_dev
 
-template<typename CudaMparticles>
-uint cuda_bndp<CudaMparticles, dim_xyz>::convert_and_copy_to_dev(CudaMparticles* cmprts)
+template <typename CudaMparticles>
+uint cuda_bndp<CudaMparticles, dim_xyz>::convert_and_copy_to_dev(
+  CudaMparticles* cmprts)
 {
   uint n_recv = 0;
   for (int p = 0; p < n_patches(); p++) {
@@ -269,22 +282,22 @@ uint cuda_bndp<CudaMparticles, dim_xyz>::convert_and_copy_to_dev(CudaMparticles*
   thrust::host_vector<float4> h_bnd_xi4(n_recv);
   thrust::host_vector<float4> h_bnd_pxi4(n_recv);
   thrust::host_vector<uint> h_bnd_idx(n_recv);
-  //thrust::host_vector<uint> h_bnd_off(n_recv);
+  // thrust::host_vector<uint> h_bnd_off(n_recv);
 
   thrust::host_vector<uint> h_bnd_cnt(n_blocks, 0);
-  
+
   uint off = 0;
   for (int p = 0; p < n_patches(); p++) {
     int n_recv = bufs[p].size();
     n_recvs[p] = n_recv;
-    
+
     for (int n = 0; n < n_recv; n++) {
       const auto& prt = bufs[p][n];
 
-      h_bnd_xi4[n + off].x  = prt.x[0];
-      h_bnd_xi4[n + off].y  = prt.x[1];
-      h_bnd_xi4[n + off].z  = prt.x[2];
-      h_bnd_xi4[n + off].w  = cuda_int_as_float(prt.kind);
+      h_bnd_xi4[n + off].x = prt.x[0];
+      h_bnd_xi4[n + off].y = prt.x[1];
+      h_bnd_xi4[n + off].z = prt.x[2];
+      h_bnd_xi4[n + off].w = cuda_int_as_float(prt.kind);
       h_bnd_pxi4[n + off].x = prt.u[0];
       h_bnd_pxi4[n + off].y = prt.u[1];
       h_bnd_pxi4[n + off].z = prt.u[2];
@@ -294,18 +307,22 @@ uint cuda_bndp<CudaMparticles, dim_xyz>::convert_and_copy_to_dev(CudaMparticles*
       uint b = blockIndex(h_bnd_xi4[n + off], p);
       assert(b < n_blocks);
       h_bnd_idx[n + off] = b;
-      //h_bnd_off[n + off] = h_bnd_cnt[b]++;
+      // h_bnd_off[n + off] = h_bnd_cnt[b]++;
     }
     off += n_recv;
   }
 
   cmprts->resize(cmprts->n_prts + n_recv);
 
-  thrust::copy(h_bnd_xi4.begin(), h_bnd_xi4.end(), cmprts->storage.xi4.begin() + cmprts->n_prts);
-  thrust::copy(h_bnd_pxi4.begin(), h_bnd_pxi4.end(), cmprts->storage.pxi4.begin() + cmprts->n_prts);
-  thrust::copy(h_bnd_idx.begin(), h_bnd_idx.end(), cmprts->by_block_.d_idx.begin() + cmprts->n_prts);
+  thrust::copy(h_bnd_xi4.begin(), h_bnd_xi4.end(),
+               cmprts->storage.xi4.begin() + cmprts->n_prts);
+  thrust::copy(h_bnd_pxi4.begin(), h_bnd_pxi4.end(),
+               cmprts->storage.pxi4.begin() + cmprts->n_prts);
+  thrust::copy(h_bnd_idx.begin(), h_bnd_idx.end(),
+               cmprts->by_block_.d_idx.begin() + cmprts->n_prts);
   // // slight abuse of the now unused last part of spine_cnts
-  // thrust::copy(h_bnd_cnt.begin(), h_bnd_cnt.end(), d_spine_cnts.begin() + 10 * n_blocks);
+  // thrust::copy(h_bnd_cnt.begin(), h_bnd_cnt.end(), d_spine_cnts.begin() + 10
+  // * n_blocks);
 
   // d_bnd_off.resize(n_recv);
   // thrust::copy(h_bnd_off.begin(), h_bnd_off.end(), d_bnd_off.begin());
@@ -313,7 +330,7 @@ uint cuda_bndp<CudaMparticles, dim_xyz>::convert_and_copy_to_dev(CudaMparticles*
   return n_recv;
 }
 
-template<typename CudaMparticles>
+template <typename CudaMparticles>
 void cuda_bndp<CudaMparticles, dim_xyz>::post(CudaMparticles* _cmprts)
 {
   auto& cmprts = *_cmprts;
@@ -322,22 +339,25 @@ void cuda_bndp<CudaMparticles, dim_xyz>::post(CudaMparticles* _cmprts)
   auto n_prts_send = d_bidx.size() - cmprts.n_prts;
   auto n_prts_recv = convert_and_copy_to_dev(&cmprts);
   cmprts.n_prts += n_prts_recv;
-  
-  thrust::sequence(cmprts.by_block_.d_id.begin(), cmprts.by_block_.d_id.end());
-  thrust::stable_sort_by_key(d_bidx.begin(), d_bidx.end(), cmprts.by_block_.d_id.begin());
 
-  // drop the previously sent particles, which have been sorted to the end of the array, now
+  thrust::sequence(cmprts.by_block_.d_id.begin(), cmprts.by_block_.d_id.end());
+  thrust::stable_sort_by_key(d_bidx.begin(), d_bidx.end(),
+                             cmprts.by_block_.d_id.begin());
+
+  // drop the previously sent particles, which have been sorted to the end of
+  // the array, now
   cmprts.n_prts -= n_prts_send;
-  // FIXME, this is evil, but done in yz case, too: even though the arrays are still have 6 elements
-  // because they contain previously sent particles (a.k.a., gaps), the actual # particles is only 4,
-  // but they are pointed to correctly by d_id
-  //cmprts.resize(cmprts.n_prts);
+  // FIXME, this is evil, but done in yz case, too: even though the arrays are
+  // still have 6 elements because they contain previously sent particles
+  // (a.k.a., gaps), the actual # particles is only 4, but they are pointed to
+  // correctly by d_id
+  // cmprts.resize(cmprts.n_prts);
 
   // find offsets
   thrust::counting_iterator<uint> search_begin(0);
-  thrust::upper_bound(d_bidx.begin(), d_bidx.end(),
-		      search_begin, search_begin + cmprts.n_blocks,
-		      cmprts.by_block_.d_off.begin() + 1);
+  thrust::upper_bound(d_bidx.begin(), d_bidx.end(), search_begin,
+                      search_begin + cmprts.n_blocks,
+                      cmprts.by_block_.d_off.begin() + 1);
   // d_off[0] was set to zero during d_off initialization
 
   cmprts.need_reorder = true;

--- a/src/libpsc/cuda/cuda_bndp.cu
+++ b/src/libpsc/cuda/cuda_bndp.cu
@@ -30,6 +30,8 @@
 #include <cstdio>
 #include <cassert>
 
+#ifdef CUDA_BNDP_DIM_YZ_SPECIAL
+
 // ----------------------------------------------------------------------
 // ctor
 
@@ -268,6 +270,8 @@ void cuda_bndp<CudaMparticles, dim_yz>::update_offsets_gold(
 
   thrust::copy(h_off.begin(), h_off.end(), cmprts->by_block_.d_off.begin());
 }
+
+#endif
 
 // ----------------------------------------------------------------------
 // convert_and_copy_to_dev

--- a/src/libpsc/cuda/cuda_bndp.cu
+++ b/src/libpsc/cuda/cuda_bndp.cu
@@ -272,8 +272,8 @@ void cuda_bndp<CudaMparticles, dim_yz>::update_offsets_gold(
 // ----------------------------------------------------------------------
 // convert_and_copy_to_dev
 
-template <typename CudaMparticles>
-uint cuda_bndp<CudaMparticles, dim_xyz>::convert_and_copy_to_dev(
+template <typename CudaMparticles, typename DIM>
+uint cuda_bndp<CudaMparticles, DIM>::convert_and_copy_to_dev(
   CudaMparticles* cmprts)
 {
   uint n_recv = 0;
@@ -332,8 +332,8 @@ uint cuda_bndp<CudaMparticles, dim_xyz>::convert_and_copy_to_dev(
   return n_recv;
 }
 
-template <typename CudaMparticles>
-void cuda_bndp<CudaMparticles, dim_xyz>::post(CudaMparticles* _cmprts)
+template <typename CudaMparticles, typename DIM>
+void cuda_bndp<CudaMparticles, DIM>::post(CudaMparticles* _cmprts)
 {
   auto& cmprts = *_cmprts;
   auto& d_bidx = cmprts.by_block_.d_idx;

--- a/src/libpsc/cuda/cuda_bndp.cu
+++ b/src/libpsc/cuda/cuda_bndp.cu
@@ -33,8 +33,8 @@
 // ----------------------------------------------------------------------
 // ctor
 
-template <typename CudaMparticles, typename DIM>
-cuda_bndp<CudaMparticles, DIM>::cuda_bndp(const Grid_t& grid)
+template <typename CudaMparticles>
+cuda_bndp<CudaMparticles, dim_yz>::cuda_bndp(const Grid_t& grid)
   : cuda_mparticles_indexer<BS>(grid)
 {
   d_spine_cnts.resize(1 + n_blocks * (CUDA_BND_STRIDE + 1));
@@ -48,8 +48,9 @@ cuda_bndp<CudaMparticles, DIM>::cuda_bndp(const Grid_t& grid)
 // ----------------------------------------------------------------------
 // prep
 
-template <typename CudaMparticles, typename DIM>
-auto cuda_bndp<CudaMparticles, DIM>::prep(CudaMparticles* cmprts) -> BndBuffers&
+template <typename CudaMparticles>
+auto cuda_bndp<CudaMparticles, dim_yz>::prep(CudaMparticles* cmprts)
+  -> BndBuffers&
 {
   static int pr_A, pr_B, pr_D, pr_B0, pr_B1;
   if (!pr_A) {
@@ -86,8 +87,8 @@ auto cuda_bndp<CudaMparticles, DIM>::prep(CudaMparticles* cmprts) -> BndBuffers&
 // ----------------------------------------------------------------------
 // post
 
-template <typename CudaMparticles, typename DIM>
-void cuda_bndp<CudaMparticles, DIM>::post(CudaMparticles* cmprts)
+template <typename CudaMparticles>
+void cuda_bndp<CudaMparticles, dim_yz>::post(CudaMparticles* cmprts)
 {
   static int pr_A, pr_D, pr_E, pr_D1;
   if (!pr_A) {
@@ -124,8 +125,8 @@ void cuda_bndp<CudaMparticles, DIM>::post(CudaMparticles* cmprts)
 // ----------------------------------------------------------------------
 // find_n_send
 
-template <typename CudaMparticles, typename DIM>
-uint cuda_bndp<CudaMparticles, DIM>::find_n_send(CudaMparticles* cmprts)
+template <typename CudaMparticles>
+uint cuda_bndp<CudaMparticles, dim_yz>::find_n_send(CudaMparticles* cmprts)
 {
   thrust::host_vector<uint> h_spine_sums(n_blocks + 1);
 
@@ -144,8 +145,8 @@ uint cuda_bndp<CudaMparticles, DIM>::find_n_send(CudaMparticles* cmprts)
 // ----------------------------------------------------------------------
 // copy_from_dev_and_convert
 
-template <typename CudaMparticles, typename DIM>
-void cuda_bndp<CudaMparticles, DIM>::copy_from_dev_and_convert(
+template <typename CudaMparticles>
+void cuda_bndp<CudaMparticles, dim_yz>::copy_from_dev_and_convert(
   CudaMparticles* cmprts, uint n_prts_send)
 {
   uint n_prts = cmprts->n_prts;
@@ -177,8 +178,8 @@ void cuda_bndp<CudaMparticles, DIM>::copy_from_dev_and_convert(
 // ----------------------------------------------------------------------
 // convert_and_copy_to_dev
 
-template <typename CudaMparticles, typename DIM>
-uint cuda_bndp<CudaMparticles, DIM>::convert_and_copy_to_dev(
+template <typename CudaMparticles>
+uint cuda_bndp<CudaMparticles, dim_yz>::convert_and_copy_to_dev(
   CudaMparticles* cmprts)
 {
   uint n_recv = 0;
@@ -243,8 +244,8 @@ __global__ static void mprts_update_offsets(int nr_total_blocks, uint* d_off,
   }
 }
 
-template <typename CudaMparticles, typename DIM>
-void cuda_bndp<CudaMparticles, DIM>::update_offsets(CudaMparticles* cmprts)
+template <typename CudaMparticles>
+void cuda_bndp<CudaMparticles, dim_yz>::update_offsets(CudaMparticles* cmprts)
 {
   int dimGrid = (n_blocks + 1 + THREADS_PER_BLOCK - 1) / THREADS_PER_BLOCK;
 
@@ -253,8 +254,9 @@ void cuda_bndp<CudaMparticles, DIM>::update_offsets(CudaMparticles* cmprts)
   cuda_sync_if_enabled();
 }
 
-template <typename CudaMparticles, typename DIM>
-void cuda_bndp<CudaMparticles, DIM>::update_offsets_gold(CudaMparticles* cmprts)
+template <typename CudaMparticles>
+void cuda_bndp<CudaMparticles, dim_yz>::update_offsets_gold(
+  CudaMparticles* cmprts)
 {
   thrust::host_vector<uint> h_spine_sums(
     d_spine_sums.data(), d_spine_sums.data() + 1 + n_blocks * (10 + 1));

--- a/src/libpsc/cuda/cuda_bndp.h
+++ b/src/libpsc/cuda/cuda_bndp.h
@@ -2,11 +2,11 @@
 #ifndef CUDA_BNDP_H
 #define CUDA_BNDP_H
 
-#include "cuda_mparticles_indexer.h"
-#include "cuda_mparticles.cuh"
-#include "mparticles_cuda.hxx"
-#include "ddc_particles.hxx"
 #include "cuda_bits.h"
+#include "cuda_mparticles.cuh"
+#include "cuda_mparticles_indexer.h"
+#include "ddc_particles.hxx"
+#include "mparticles_cuda.hxx"
 
 #include <thrust/device_vector.h>
 #include <thrust/partition.h>
@@ -14,7 +14,7 @@
 // ----------------------------------------------------------------------
 // cuda_bndp
 
-template<typename CudaMparticles, typename DIM>
+template <typename CudaMparticles, typename DIM>
 struct cuda_bndp : cuda_mparticles_indexer<typename CudaMparticles::BS>
 {
   using BS = typename CudaMparticles::BS;
@@ -29,48 +29,50 @@ struct cuda_bndp : cuda_mparticles_indexer<typename CudaMparticles::BS>
   using cuda_mparticles_indexer<BS>::b_mx;
 
   cuda_bndp(const Grid_t& grid);
-  
+
   BndBuffers& prep(CudaMparticles* cmprts);
   void post(CudaMparticles* cmprts);
 
   // pieces for prep
-  void spine_reduce(CudaMparticles *cmprts);
-  uint find_n_send(CudaMparticles *cmprts);
-  void scan_send_buf_total(CudaMparticles *cmprts, uint n_prts_send);
-  void reorder_send_by_id(CudaMparticles *cmprts, uint n_prts_send);
-  void reorder_send_buf_total(CudaMparticles *cmprts, uint n_prts_send);
-  void copy_from_dev_and_convert(CudaMparticles *cmprts, uint n_prts_send);
+  void spine_reduce(CudaMparticles* cmprts);
+  uint find_n_send(CudaMparticles* cmprts);
+  void scan_send_buf_total(CudaMparticles* cmprts, uint n_prts_send);
+  void reorder_send_by_id(CudaMparticles* cmprts, uint n_prts_send);
+  void reorder_send_buf_total(CudaMparticles* cmprts, uint n_prts_send);
+  void copy_from_dev_and_convert(CudaMparticles* cmprts, uint n_prts_send);
 
   // pieces for post
-  uint convert_and_copy_to_dev(CudaMparticles *cmprts);
-  void sort_pairs_device(CudaMparticles *cmprts, uint n_prts_recv);
-  void count_received(CudaMparticles *cmprts);
-  void scan_scatter_received(CudaMparticles *cmprts, uint n_prts_recv);
-  void update_offsets(CudaMparticles *cmprts);
+  uint convert_and_copy_to_dev(CudaMparticles* cmprts);
+  void sort_pairs_device(CudaMparticles* cmprts, uint n_prts_recv);
+  void count_received(CudaMparticles* cmprts);
+  void scan_scatter_received(CudaMparticles* cmprts, uint n_prts_recv);
+  void update_offsets(CudaMparticles* cmprts);
 
   // gold
-  void spine_reduce_gold(CudaMparticles *cmprts);
-  void scan_send_buf_total_gold(CudaMparticles *cmprts, uint n_prts_send);
-  void reorder_send_by_id_gold(CudaMparticles *cmprts, uint n_prts_send);
-  void sort_pairs_gold(CudaMparticles *cmprts, uint n_prts_recv);
-  void count_received_gold(CudaMparticles *cmprts);
-  void scan_scatter_received_gold(CudaMparticles *cmprts, uint n_prts_recv);
-  void update_offsets_gold(CudaMparticles *cmprts);
+  void spine_reduce_gold(CudaMparticles* cmprts);
+  void scan_send_buf_total_gold(CudaMparticles* cmprts, uint n_prts_send);
+  void reorder_send_by_id_gold(CudaMparticles* cmprts, uint n_prts_send);
+  void sort_pairs_gold(CudaMparticles* cmprts, uint n_prts_recv);
+  void count_received_gold(CudaMparticles* cmprts);
+  void scan_scatter_received_gold(CudaMparticles* cmprts, uint n_prts_recv);
+  void update_offsets_gold(CudaMparticles* cmprts);
 
   thrust::device_vector<uint> d_spine_cnts;
   thrust::device_vector<uint> d_spine_sums;
   uint n_prts_send;
   thrust::device_vector<uint> d_bnd_off;
 
-  thrust::device_vector<uint> d_sums; // FIXME, should go away (only used in some gold stuff)
+  thrust::device_vector<uint>
+    d_sums; // FIXME, should go away (only used in some gold stuff)
 
   BndBuffers bufs;
   std::vector<int> n_sends;
   std::vector<int> n_recvs;
 };
 
-template<typename CudaMparticles>
-struct cuda_bndp<CudaMparticles, dim_xyz> : cuda_mparticles_indexer<typename CudaMparticles::BS>
+template <typename CudaMparticles>
+struct cuda_bndp<CudaMparticles, dim_xyz>
+  : cuda_mparticles_indexer<typename CudaMparticles::BS>
 {
   using BS = typename CudaMparticles::BS;
   using BndBuffer = std::vector<typename CudaMparticles::Particle>;
@@ -83,8 +85,7 @@ struct cuda_bndp<CudaMparticles, dim_xyz> : cuda_mparticles_indexer<typename Cud
   using cuda_mparticles_indexer<BS>::blockIndex;
   using cuda_mparticles_indexer<BS>::b_mx;
 
-  cuda_bndp(const Grid_t& grid)
-    : cuda_mparticles_indexer<BS>{grid}
+  cuda_bndp(const Grid_t& grid) : cuda_mparticles_indexer<BS>{grid}
   {
     bufs.resize(n_patches());
     n_sends.resize(n_patches());
@@ -98,8 +99,9 @@ struct cuda_bndp<CudaMparticles, dim_xyz> : cuda_mparticles_indexer<typename Cud
   {
     auto& cmprts = *_cmprts;
     auto& d_bidx = cmprts.by_block_.d_idx;
-    
-    auto oob = thrust::count_if(d_bidx.begin(), d_bidx.end(), is_outside(cmprts.n_blocks));
+
+    auto oob = thrust::count_if(d_bidx.begin(), d_bidx.end(),
+                                is_outside(cmprts.n_blocks));
     auto sz = d_bidx.size();
     assert(cmprts.storage.xi4.size() == sz);
     assert(cmprts.storage.pxi4.size() == sz);
@@ -108,10 +110,12 @@ struct cuda_bndp<CudaMparticles, dim_xyz> : cuda_mparticles_indexer<typename Cud
     cmprts.storage.xi4.resize(sz + oob);
     cmprts.storage.pxi4.resize(sz + oob);
 
-    auto begin = thrust::make_zip_iterator(thrust::make_tuple(d_bidx.begin(), cmprts.storage.xi4.begin(), cmprts.storage.pxi4.begin()));
+    auto begin = thrust::make_zip_iterator(thrust::make_tuple(
+      d_bidx.begin(), cmprts.storage.xi4.begin(), cmprts.storage.pxi4.begin()));
     auto end = begin + sz;
-    
-    auto oob_end = thrust::copy_if(begin, end, begin + sz, is_outside(cmprts.n_blocks));
+
+    auto oob_end =
+      thrust::copy_if(begin, end, begin + sz, is_outside(cmprts.n_blocks));
     assert(oob_end == begin + sz + oob);
 
     n_prts_send = oob;
@@ -123,24 +127,27 @@ struct cuda_bndp<CudaMparticles, dim_xyz> : cuda_mparticles_indexer<typename Cud
 
   // ----------------------------------------------------------------------
   // post
-  
+
   void post(CudaMparticles* _cmprts);
 
   // ----------------------------------------------------------------------
   // copy_from_dev_and_convert
 
-  void copy_from_dev_and_convert(CudaMparticles *cmprts, uint n_prts_send)
+  void copy_from_dev_and_convert(CudaMparticles* cmprts, uint n_prts_send)
   {
     uint n_prts = cmprts->n_prts;
     HMparticlesCudaStorage h_bnd_storage(n_prts_send);
     thrust::host_vector<uint> h_bidx(n_prts_send);
-    
-    assert(cmprts->storage.xi4.begin() + n_prts + n_prts_send == cmprts->storage.xi4.end());
-    
-    thrust::copy(cmprts->storage.xi4.begin()  + n_prts, cmprts->storage.xi4.end(), h_bnd_storage.xi4.begin());
-    thrust::copy(cmprts->storage.pxi4.begin() + n_prts, cmprts->storage.pxi4.end(), h_bnd_storage.pxi4.begin());
-    thrust::copy(cmprts->by_block_.d_idx.begin() + n_prts, cmprts->by_block_.d_idx.end(),
-		 h_bidx.begin());
+
+    assert(cmprts->storage.xi4.begin() + n_prts + n_prts_send ==
+           cmprts->storage.xi4.end());
+
+    thrust::copy(cmprts->storage.xi4.begin() + n_prts,
+                 cmprts->storage.xi4.end(), h_bnd_storage.xi4.begin());
+    thrust::copy(cmprts->storage.pxi4.begin() + n_prts,
+                 cmprts->storage.pxi4.end(), h_bnd_storage.pxi4.begin());
+    thrust::copy(cmprts->by_block_.d_idx.begin() + n_prts,
+                 cmprts->by_block_.d_idx.end(), h_bidx.begin());
 
     for (int p = 0; p < n_patches(); p++) {
       bufs[p].clear();
@@ -154,22 +161,20 @@ struct cuda_bndp<CudaMparticles, dim_xyz> : cuda_mparticles_indexer<typename Cud
     }
   }
 
-  uint convert_and_copy_to_dev(CudaMparticles *cmprts);
+  uint convert_and_copy_to_dev(CudaMparticles* cmprts);
 
   struct is_outside
   {
     is_outside(int n_blocks) : n_blocks_(n_blocks) {}
-    
-    __host__ __device__
-    bool operator()(uint bidx) { return bidx >= n_blocks_; }
-    
-    __host__ __device__
-    bool operator()(thrust::tuple<uint, float4, float4> tup)
+
+    __host__ __device__ bool operator()(uint bidx) { return bidx >= n_blocks_; }
+
+    __host__ __device__ bool operator()(thrust::tuple<uint, float4, float4> tup)
     {
       uint bidx = thrust::get<0>(tup);
       return (*this)(bidx);
     }
-    
+
   private:
     int n_blocks_;
   };
@@ -180,6 +185,5 @@ struct cuda_bndp<CudaMparticles, dim_xyz> : cuda_mparticles_indexer<typename Cud
   BndBuffers bufs_;
   uint n_prts_send;
 };
-  
-#endif
 
+#endif

--- a/src/libpsc/cuda/cuda_bndp.h
+++ b/src/libpsc/cuda/cuda_bndp.h
@@ -129,6 +129,8 @@ struct cuda_bndp : cuda_mparticles_indexer<typename CudaMparticles::BS>
   uint n_prts_send;
 };
 
+#ifdef CUDA_BNDP_DIM_YZ_SPECIAL
+
 // ----------------------------------------------------------------------
 // specialized for dim_yz
 
@@ -188,5 +190,7 @@ struct cuda_bndp<CudaMparticles, dim_yz>
   std::vector<int> n_sends;
   std::vector<int> n_recvs;
 };
+
+#endif
 
 #endif

--- a/src/libpsc/cuda/cuda_bndp.h
+++ b/src/libpsc/cuda/cuda_bndp.h
@@ -15,68 +15,7 @@
 // cuda_bndp
 
 template <typename CudaMparticles, typename DIM>
-struct cuda_bndp;
-
-template <typename CudaMparticles>
-struct cuda_bndp<CudaMparticles, dim_yz>
-  : cuda_mparticles_indexer<typename CudaMparticles::BS>
-{
-  using BS = typename CudaMparticles::BS;
-  using BndBuffer = std::vector<typename CudaMparticles::Particle>;
-  using BndBuffers = typename CudaMparticles::BndBuffers;
-
-  using cuda_mparticles_indexer<BS>::n_blocks;
-  using cuda_mparticles_indexer<BS>::n_blocks_per_patch;
-  using cuda_mparticles_indexer<BS>::n_patches;
-  using cuda_mparticles_indexer<BS>::checkInPatchMod;
-  using cuda_mparticles_indexer<BS>::blockIndex;
-  using cuda_mparticles_indexer<BS>::b_mx;
-
-  cuda_bndp(const Grid_t& grid);
-
-  BndBuffers& prep(CudaMparticles* cmprts);
-  void post(CudaMparticles* cmprts);
-
-  // pieces for prep
-  void spine_reduce(CudaMparticles* cmprts);
-  uint find_n_send(CudaMparticles* cmprts);
-  void scan_send_buf_total(CudaMparticles* cmprts, uint n_prts_send);
-  void reorder_send_by_id(CudaMparticles* cmprts, uint n_prts_send);
-  void reorder_send_buf_total(CudaMparticles* cmprts, uint n_prts_send);
-  void copy_from_dev_and_convert(CudaMparticles* cmprts, uint n_prts_send);
-
-  // pieces for post
-  uint convert_and_copy_to_dev(CudaMparticles* cmprts);
-  void sort_pairs_device(CudaMparticles* cmprts, uint n_prts_recv);
-  void count_received(CudaMparticles* cmprts);
-  void scan_scatter_received(CudaMparticles* cmprts, uint n_prts_recv);
-  void update_offsets(CudaMparticles* cmprts);
-
-  // gold
-  void spine_reduce_gold(CudaMparticles* cmprts);
-  void scan_send_buf_total_gold(CudaMparticles* cmprts, uint n_prts_send);
-  void reorder_send_by_id_gold(CudaMparticles* cmprts, uint n_prts_send);
-  void sort_pairs_gold(CudaMparticles* cmprts, uint n_prts_recv);
-  void count_received_gold(CudaMparticles* cmprts);
-  void scan_scatter_received_gold(CudaMparticles* cmprts, uint n_prts_recv);
-  void update_offsets_gold(CudaMparticles* cmprts);
-
-  thrust::device_vector<uint> d_spine_cnts;
-  thrust::device_vector<uint> d_spine_sums;
-  uint n_prts_send;
-  thrust::device_vector<uint> d_bnd_off;
-
-  thrust::device_vector<uint>
-    d_sums; // FIXME, should go away (only used in some gold stuff)
-
-  BndBuffers bufs;
-  std::vector<int> n_sends;
-  std::vector<int> n_recvs;
-};
-
-template <typename CudaMparticles>
-struct cuda_bndp<CudaMparticles, dim_xyz>
-  : cuda_mparticles_indexer<typename CudaMparticles::BS>
+struct cuda_bndp : cuda_mparticles_indexer<typename CudaMparticles::BS>
 {
   using BS = typename CudaMparticles::BS;
   using BndBuffer = std::vector<typename CudaMparticles::Particle>;
@@ -188,6 +127,66 @@ struct cuda_bndp<CudaMparticles, dim_xyz>
   std::vector<int> n_recvs;
   BndBuffers bufs_;
   uint n_prts_send;
+};
+
+// ----------------------------------------------------------------------
+// specialized for dim_yz
+
+template <typename CudaMparticles>
+struct cuda_bndp<CudaMparticles, dim_yz>
+  : cuda_mparticles_indexer<typename CudaMparticles::BS>
+{
+  using BS = typename CudaMparticles::BS;
+  using BndBuffer = std::vector<typename CudaMparticles::Particle>;
+  using BndBuffers = typename CudaMparticles::BndBuffers;
+
+  using cuda_mparticles_indexer<BS>::n_blocks;
+  using cuda_mparticles_indexer<BS>::n_blocks_per_patch;
+  using cuda_mparticles_indexer<BS>::n_patches;
+  using cuda_mparticles_indexer<BS>::checkInPatchMod;
+  using cuda_mparticles_indexer<BS>::blockIndex;
+  using cuda_mparticles_indexer<BS>::b_mx;
+
+  cuda_bndp(const Grid_t& grid);
+
+  BndBuffers& prep(CudaMparticles* cmprts);
+  void post(CudaMparticles* cmprts);
+
+  // pieces for prep
+  void spine_reduce(CudaMparticles* cmprts);
+  uint find_n_send(CudaMparticles* cmprts);
+  void scan_send_buf_total(CudaMparticles* cmprts, uint n_prts_send);
+  void reorder_send_by_id(CudaMparticles* cmprts, uint n_prts_send);
+  void reorder_send_buf_total(CudaMparticles* cmprts, uint n_prts_send);
+  void copy_from_dev_and_convert(CudaMparticles* cmprts, uint n_prts_send);
+
+  // pieces for post
+  uint convert_and_copy_to_dev(CudaMparticles* cmprts);
+  void sort_pairs_device(CudaMparticles* cmprts, uint n_prts_recv);
+  void count_received(CudaMparticles* cmprts);
+  void scan_scatter_received(CudaMparticles* cmprts, uint n_prts_recv);
+  void update_offsets(CudaMparticles* cmprts);
+
+  // gold
+  void spine_reduce_gold(CudaMparticles* cmprts);
+  void scan_send_buf_total_gold(CudaMparticles* cmprts, uint n_prts_send);
+  void reorder_send_by_id_gold(CudaMparticles* cmprts, uint n_prts_send);
+  void sort_pairs_gold(CudaMparticles* cmprts, uint n_prts_recv);
+  void count_received_gold(CudaMparticles* cmprts);
+  void scan_scatter_received_gold(CudaMparticles* cmprts, uint n_prts_recv);
+  void update_offsets_gold(CudaMparticles* cmprts);
+
+  thrust::device_vector<uint> d_spine_cnts;
+  thrust::device_vector<uint> d_spine_sums;
+  uint n_prts_send;
+  thrust::device_vector<uint> d_bnd_off;
+
+  thrust::device_vector<uint>
+    d_sums; // FIXME, should go away (only used in some gold stuff)
+
+  BndBuffers bufs;
+  std::vector<int> n_sends;
+  std::vector<int> n_recvs;
 };
 
 #endif

--- a/src/libpsc/cuda/cuda_bndp.h
+++ b/src/libpsc/cuda/cuda_bndp.h
@@ -15,7 +15,11 @@
 // cuda_bndp
 
 template <typename CudaMparticles, typename DIM>
-struct cuda_bndp : cuda_mparticles_indexer<typename CudaMparticles::BS>
+struct cuda_bndp;
+
+template <typename CudaMparticles>
+struct cuda_bndp<CudaMparticles, dim_yz>
+  : cuda_mparticles_indexer<typename CudaMparticles::BS>
 {
   using BS = typename CudaMparticles::BS;
   using BndBuffer = std::vector<typename CudaMparticles::Particle>;

--- a/src/libpsc/cuda/cuda_bndp_scan.cu
+++ b/src/libpsc/cuda/cuda_bndp_scan.cu
@@ -1,4 +1,6 @@
 
+#ifdef CUDA_BNDP_DIM_YZ_SPECIAL
+
 #include "cuda_bits.h"
 #include "cuda_bndp.h"
 #include "cuda_mparticles.cuh"
@@ -238,3 +240,5 @@ void cuda_bndp<CudaMparticles, dim_yz>::scan_send_buf_total_gold(
 }
 
 template struct cuda_bndp<cuda_mparticles<BS144>, dim_yz>;
+
+#endif

--- a/src/libpsc/cuda/cuda_bndp_scan.cu
+++ b/src/libpsc/cuda/cuda_bndp_scan.cu
@@ -1,7 +1,7 @@
 
+#include "cuda_bits.h"
 #include "cuda_bndp.h"
 #include "cuda_mparticles.cuh"
-#include "cuda_bits.h"
 
 #include <thrust/device_vector.h>
 #include <thrust/host_vector.h>
@@ -16,18 +16,18 @@ typedef uint V;
 
 static const int RADIX_BITS = 4;
 
-#include <cstdio>
 #include <cassert>
+#include <cstdio>
 
 #define THREADS_PER_BLOCK 256
 
 // ----------------------------------------------------------------------
 // k_reorder_send_by_id
 
-static void __global__
-k_reorder_send_by_id(uint nr_prts_send, uint *d_xchg_ids,
-		     float4 *d_xi4, float4 *d_pxi4,
-		     float4 *d_xchg_xi4, float4 *d_xchg_pxi4)
+static void __global__ k_reorder_send_by_id(uint nr_prts_send, uint* d_xchg_ids,
+                                            float4* d_xi4, float4* d_pxi4,
+                                            float4* d_xchg_xi4,
+                                            float4* d_xchg_pxi4)
 {
   int n = threadIdx.x + THREADS_PER_BLOCK * blockIdx.x;
   if (n >= nr_prts_send) {
@@ -35,7 +35,7 @@ k_reorder_send_by_id(uint nr_prts_send, uint *d_xchg_ids,
   }
 
   uint id = d_xchg_ids[n];
-  d_xchg_xi4[n]  = d_xi4[id];
+  d_xchg_xi4[n] = d_xi4[id];
   d_xchg_pxi4[n] = d_pxi4[id];
 }
 
@@ -49,38 +49,48 @@ k_reorder_send_by_id(uint nr_prts_send, uint *d_xchg_ids,
 // in: d_xi4, d_pxi4[0:n_prts[
 // out: d_xi4, d_pxi4[n_prts:n_prts_send[
 
-template<typename CudaMparticles, typename DIM>
-void cuda_bndp<CudaMparticles, DIM>::reorder_send_by_id(CudaMparticles* cmprts, uint n_prts_send)
+template <typename CudaMparticles, typename DIM>
+void cuda_bndp<CudaMparticles, DIM>::reorder_send_by_id(CudaMparticles* cmprts,
+                                                        uint n_prts_send)
 {
   cmprts->storage.xi4.resize(cmprts->n_prts + n_prts_send);
   cmprts->storage.pxi4.resize(cmprts->n_prts + n_prts_send);
-  
+
   if (n_prts_send == 0) {
     return;
   }
 
   int dimGrid = (n_prts_send + THREADS_PER_BLOCK - 1) / THREADS_PER_BLOCK;
 
-  k_reorder_send_by_id<<<dimGrid, THREADS_PER_BLOCK>>>
-    (n_prts_send, cmprts->by_block_.d_id.data().get() + cmprts->n_prts - n_prts_send,
-     cmprts->storage.xi4.data().get(), cmprts->storage.pxi4.data().get(),
-     cmprts->storage.xi4.data().get() + cmprts->n_prts, cmprts->storage.pxi4.data().get() + cmprts->n_prts);
+  k_reorder_send_by_id<<<dimGrid, THREADS_PER_BLOCK>>>(
+    n_prts_send,
+    cmprts->by_block_.d_id.data().get() + cmprts->n_prts - n_prts_send,
+    cmprts->storage.xi4.data().get(), cmprts->storage.pxi4.data().get(),
+    cmprts->storage.xi4.data().get() + cmprts->n_prts,
+    cmprts->storage.pxi4.data().get() + cmprts->n_prts);
   cuda_sync_if_enabled();
 }
 
 // ----------------------------------------------------------------------
 // reorder_send_by_id_gold
 
-template<typename CudaMparticles, typename DIM>
-void cuda_bndp<CudaMparticles, DIM>::reorder_send_by_id_gold(CudaMparticles *cmprts, uint n_prts_send)
+template <typename CudaMparticles, typename DIM>
+void cuda_bndp<CudaMparticles, DIM>::reorder_send_by_id_gold(
+  CudaMparticles* cmprts, uint n_prts_send)
 {
-  thrust::host_vector<uint> h_id(cmprts->by_block_.d_id.data(), cmprts->by_block_.d_id.data() + cmprts->n_prts);
-  thrust::host_vector<float4> h_xi4(cmprts->storage.xi4.data(), cmprts->storage.xi4.data() + cmprts->n_prts + n_prts_send);
-  thrust::host_vector<float4> h_pxi4(cmprts->storage.pxi4.data(), cmprts->storage.pxi4.data() + cmprts->n_prts + n_prts_send);
-  
+  thrust::host_vector<uint> h_id(cmprts->by_block_.d_id.data(),
+                                 cmprts->by_block_.d_id.data() +
+                                   cmprts->n_prts);
+  thrust::host_vector<float4> h_xi4(cmprts->storage.xi4.data(),
+                                    cmprts->storage.xi4.data() +
+                                      cmprts->n_prts + n_prts_send);
+  thrust::host_vector<float4> h_pxi4(cmprts->storage.pxi4.data(),
+                                     cmprts->storage.pxi4.data() +
+                                       cmprts->n_prts + n_prts_send);
+
   for (int n = 0; n < n_prts_send; n++) {
     uint id = h_id[cmprts->n_prts - n_prts_send + n];
-    h_xi4[cmprts->n_prts + n]  = h_xi4[id];
+    h_xi4[cmprts->n_prts + n] = h_xi4[id];
     h_pxi4[cmprts->n_prts + n] = h_pxi4[id];
   }
 
@@ -91,11 +101,9 @@ void cuda_bndp<CudaMparticles, DIM>::reorder_send_by_id_gold(CudaMparticles *cmp
 // ----------------------------------------------------------------------
 // k_reorder_send_buf_total
 
-__global__ static void
-k_reorder_send_buf_total(int nr_prts, int nr_total_blocks,
-			     uint *d_bidx, uint *d_sums,
-			     float4 *d_xi4, float4 *d_pxi4,
-			     float4 *d_xchg_xi4, float4 *d_xchg_pxi4)
+__global__ static void k_reorder_send_buf_total(
+  int nr_prts, int nr_total_blocks, uint* d_bidx, uint* d_sums, float4* d_xi4,
+  float4* d_pxi4, float4* d_xchg_xi4, float4* d_xchg_pxi4)
 {
   int i = threadIdx.x + THREADS_PER_BLOCK * blockIdx.x;
   if (i >= nr_prts)
@@ -103,7 +111,7 @@ k_reorder_send_buf_total(int nr_prts, int nr_total_blocks,
 
   if (d_bidx[i] == CUDA_BND_S_OOB) {
     int j = d_sums[i];
-    d_xchg_xi4[j]  = d_xi4[i];
+    d_xchg_xi4[j] = d_xi4[i];
     d_xchg_pxi4[j] = d_pxi4[i];
   }
 }
@@ -111,8 +119,9 @@ k_reorder_send_buf_total(int nr_prts, int nr_total_blocks,
 // ----------------------------------------------------------------------
 // reorder_send_buf_total
 
-template<typename CudaMparticles, typename DIM>
-void cuda_bndp<CudaMparticles, DIM>::reorder_send_buf_total(CudaMparticles *cmprts, uint n_prts_send)
+template <typename CudaMparticles, typename DIM>
+void cuda_bndp<CudaMparticles, DIM>::reorder_send_buf_total(
+  CudaMparticles* cmprts, uint n_prts_send)
 {
   if (n_patches() == 0) {
     return;
@@ -120,16 +129,16 @@ void cuda_bndp<CudaMparticles, DIM>::reorder_send_buf_total(CudaMparticles *cmpr
 
   cmprts->resize(cmprts->n_prts + n_prts_send);
 
-  float4 *xchg_xi4 = cmprts->storage.xi4.data().get() + cmprts->n_prts;
-  float4 *xchg_pxi4 = cmprts->storage.pxi4.data().get() + cmprts->n_prts;
-  
+  float4* xchg_xi4 = cmprts->storage.xi4.data().get() + cmprts->n_prts;
+  float4* xchg_pxi4 = cmprts->storage.pxi4.data().get() + cmprts->n_prts;
+
   dim3 dimBlock(THREADS_PER_BLOCK, 1);
   dim3 dimGrid((cmprts->n_prts + THREADS_PER_BLOCK - 1) / THREADS_PER_BLOCK, 1);
-  
-  k_reorder_send_buf_total<<<dimGrid, dimBlock>>>(cmprts->n_prts, cmprts->n_blocks,
-						  cmprts->by_block_.d_idx.data().get(), d_sums.data().get(),
-						  cmprts->storage.xi4.data().get(), cmprts->storage.pxi4.data().get(),
-						  xchg_xi4, xchg_pxi4);
+
+  k_reorder_send_buf_total<<<dimGrid, dimBlock>>>(
+    cmprts->n_prts, cmprts->n_blocks, cmprts->by_block_.d_idx.data().get(),
+    d_sums.data().get(), cmprts->storage.xi4.data().get(),
+    cmprts->storage.pxi4.data().get(), xchg_xi4, xchg_pxi4);
   cuda_sync_if_enabled();
 }
 
@@ -140,61 +149,56 @@ void cuda_bndp<CudaMparticles, DIM>::reorder_send_buf_total(CudaMparticles *cmpr
 // out: d_spine_sums, d_id[n_prts - n_prts_send: n_prts[
 //
 
-template<typename CudaMparticles, typename DIM>
-void cuda_bndp<CudaMparticles, DIM>::scan_send_buf_total(CudaMparticles* cmprts, uint n_prts_send)
+template <typename CudaMparticles, typename DIM>
+void cuda_bndp<CudaMparticles, DIM>::scan_send_buf_total(CudaMparticles* cmprts,
+                                                         uint n_prts_send)
 {
   // OPT, we could do this from the beginning and adapt find_n_send()
   thrust::exclusive_scan(d_spine_cnts.data() + n_blocks * 10,
-			 d_spine_cnts.data() + n_blocks * 11 + 1,
-			 d_spine_sums.data() + n_blocks * 10,
-			 cmprts->n_prts - n_prts_send);
+                         d_spine_cnts.data() + n_blocks * 11 + 1,
+                         d_spine_sums.data() + n_blocks * 10,
+                         cmprts->n_prts - n_prts_send);
   // OPT, we could somehow not fill in ids for not oob at all
   // this should make sure at least those within bounds don't screw anything up
   thrust::fill(d_spine_sums.data(), d_spine_sums.data() + n_blocks * 10, 0);
 
   Int3 mx = b_mx();
   if (mx[0] == 1 && mx[1] == 4 && mx[2] == 4) {
-    ScanScatterDigits4<K, V, 0, RADIX_BITS, 0,
-		       NopFunctor<K>,
-		       NopFunctor<K>,
-		       4, 4> 
-      <<<n_blocks, B40C_RADIXSORT_THREADS>>>
-      (d_spine_sums.data().get(), cmprts->by_block_.d_idx.data().get(), cmprts->by_block_.d_id.data().get(), cmprts->by_block_.d_off.data().get(), n_blocks);
+    ScanScatterDigits4<K, V, 0, RADIX_BITS, 0, NopFunctor<K>, NopFunctor<K>, 4,
+                       4><<<n_blocks, B40C_RADIXSORT_THREADS>>>(
+      d_spine_sums.data().get(), cmprts->by_block_.d_idx.data().get(),
+      cmprts->by_block_.d_id.data().get(), cmprts->by_block_.d_off.data().get(),
+      n_blocks);
   } else if (mx[0] == 1 && mx[1] == 8 && mx[2] == 8) {
-    ScanScatterDigits4<K, V, 0, RADIX_BITS, 0,
-		       NopFunctor<K>,
-		       NopFunctor<K>,
-		       8, 8> 
-      <<<n_blocks, B40C_RADIXSORT_THREADS>>>
-      (d_spine_sums.data().get(), cmprts->by_block_.d_idx.data().get(), cmprts->by_block_.d_id.data().get(), cmprts->by_block_.d_off.data().get(), n_blocks);
+    ScanScatterDigits4<K, V, 0, RADIX_BITS, 0, NopFunctor<K>, NopFunctor<K>, 8,
+                       8><<<n_blocks, B40C_RADIXSORT_THREADS>>>(
+      d_spine_sums.data().get(), cmprts->by_block_.d_idx.data().get(),
+      cmprts->by_block_.d_id.data().get(), cmprts->by_block_.d_off.data().get(),
+      n_blocks);
   } else if (mx[0] == 1 && mx[1] == 16 && mx[2] == 16) {
-    ScanScatterDigits4<K, V, 0, RADIX_BITS, 0,
-		       NopFunctor<K>,
-		       NopFunctor<K>,
-		       16, 16> 
-      <<<n_blocks, B40C_RADIXSORT_THREADS>>>
-      (d_spine_sums.data().get(), cmprts->by_block_.d_idx.data().get(), cmprts->by_block_.d_id.data().get(), cmprts->by_block_.d_off.data().get(), n_blocks);
+    ScanScatterDigits4<K, V, 0, RADIX_BITS, 0, NopFunctor<K>, NopFunctor<K>, 16,
+                       16><<<n_blocks, B40C_RADIXSORT_THREADS>>>(
+      d_spine_sums.data().get(), cmprts->by_block_.d_idx.data().get(),
+      cmprts->by_block_.d_id.data().get(), cmprts->by_block_.d_off.data().get(),
+      n_blocks);
   } else if (mx[0] == 1 && mx[1] == 32 && mx[2] == 32) {
-    ScanScatterDigits4<K, V, 0, RADIX_BITS, 0,
-		       NopFunctor<K>,
-		       NopFunctor<K>,
-		       32, 32> 
-      <<<n_blocks, B40C_RADIXSORT_THREADS>>>
-      (d_spine_sums.data().get(), cmprts->by_block_.d_idx.data().get(), cmprts->by_block_.d_id.data().get(), cmprts->by_block_.d_off.data().get(), n_blocks);
+    ScanScatterDigits4<K, V, 0, RADIX_BITS, 0, NopFunctor<K>, NopFunctor<K>, 32,
+                       32><<<n_blocks, B40C_RADIXSORT_THREADS>>>(
+      d_spine_sums.data().get(), cmprts->by_block_.d_idx.data().get(),
+      cmprts->by_block_.d_id.data().get(), cmprts->by_block_.d_off.data().get(),
+      n_blocks);
   } else if (mx[0] == 1 && mx[1] == 64 && mx[2] == 64) {
-    ScanScatterDigits4<K, V, 0, RADIX_BITS, 0,
-		       NopFunctor<K>,
-		       NopFunctor<K>,
-		       64, 64> 
-      <<<n_blocks, B40C_RADIXSORT_THREADS>>>
-      (d_spine_sums.data().get(), cmprts->by_block_.d_idx.data().get(), cmprts->by_block_.d_id.data().get(), cmprts->by_block_.d_off.data().get(), n_blocks);
+    ScanScatterDigits4<K, V, 0, RADIX_BITS, 0, NopFunctor<K>, NopFunctor<K>, 64,
+                       64><<<n_blocks, B40C_RADIXSORT_THREADS>>>(
+      d_spine_sums.data().get(), cmprts->by_block_.d_idx.data().get(),
+      cmprts->by_block_.d_id.data().get(), cmprts->by_block_.d_off.data().get(),
+      n_blocks);
   } else if (mx[0] == 1 && mx[1] == 128 && mx[2] == 128) {
-    ScanScatterDigits4<K, V, 0, RADIX_BITS, 0,
-                       NopFunctor<K>,
-                       NopFunctor<K>,
-                       128, 128>
-      <<<n_blocks, B40C_RADIXSORT_THREADS>>>
-      (d_spine_sums.data().get(), cmprts->by_block_.d_idx.data().get(), cmprts->by_block_.d_id.data().get(), cmprts->by_block_.d_off.data().get(), n_blocks);
+    ScanScatterDigits4<K, V, 0, RADIX_BITS, 0, NopFunctor<K>, NopFunctor<K>,
+                       128, 128><<<n_blocks, B40C_RADIXSORT_THREADS>>>(
+      d_spine_sums.data().get(), cmprts->by_block_.d_idx.data().get(),
+      cmprts->by_block_.d_id.data().get(), cmprts->by_block_.d_off.data().get(),
+      n_blocks);
   } else {
     printf("no support for b_mx %d x %d x %d!\n", mx[0], mx[1], mx[2]);
     assert(0);
@@ -207,19 +211,22 @@ void cuda_bndp<CudaMparticles, DIM>::scan_send_buf_total(CudaMparticles* cmprts,
 // ----------------------------------------------------------------------
 // scan_send_buf_total_gold
 
-template<typename CudaMparticles, typename DIM>
-void cuda_bndp<CudaMparticles, DIM>::scan_send_buf_total_gold(CudaMparticles *cmprts, uint n_prts_send)
+template <typename CudaMparticles, typename DIM>
+void cuda_bndp<CudaMparticles, DIM>::scan_send_buf_total_gold(
+  CudaMparticles* cmprts, uint n_prts_send)
 {
   thrust::host_vector<uint> h_off(cmprts->by_block_.d_off);
-  thrust::host_vector<uint> h_bidx(cmprts->by_block_.d_idx.data(), cmprts->by_block_.d_idx.data() + cmprts->n_prts);
+  thrust::host_vector<uint> h_bidx(cmprts->by_block_.d_idx.data(),
+                                   cmprts->by_block_.d_idx.data() +
+                                     cmprts->n_prts);
   thrust::host_vector<uint> h_sums(cmprts->n_prts);
-  
+
   for (uint bid = 0; bid < n_blocks; bid++) {
     uint sum = d_spine_sums[n_blocks * 10 + bid];
-    for (int n = h_off[bid]; n < h_off[bid+1]; n++) {
+    for (int n = h_off[bid]; n < h_off[bid + 1]; n++) {
       if (h_bidx[n] == CUDA_BND_S_OOB) {
-	h_sums[n] = sum;
-	sum++;
+        h_sums[n] = sum;
+        sum++;
       }
     }
   }

--- a/src/libpsc/cuda/cuda_bndp_scan.cu
+++ b/src/libpsc/cuda/cuda_bndp_scan.cu
@@ -49,9 +49,9 @@ static void __global__ k_reorder_send_by_id(uint nr_prts_send, uint* d_xchg_ids,
 // in: d_xi4, d_pxi4[0:n_prts[
 // out: d_xi4, d_pxi4[n_prts:n_prts_send[
 
-template <typename CudaMparticles, typename DIM>
-void cuda_bndp<CudaMparticles, DIM>::reorder_send_by_id(CudaMparticles* cmprts,
-                                                        uint n_prts_send)
+template <typename CudaMparticles>
+void cuda_bndp<CudaMparticles, dim_yz>::reorder_send_by_id(
+  CudaMparticles* cmprts, uint n_prts_send)
 {
   cmprts->storage.xi4.resize(cmprts->n_prts + n_prts_send);
   cmprts->storage.pxi4.resize(cmprts->n_prts + n_prts_send);
@@ -74,8 +74,8 @@ void cuda_bndp<CudaMparticles, DIM>::reorder_send_by_id(CudaMparticles* cmprts,
 // ----------------------------------------------------------------------
 // reorder_send_by_id_gold
 
-template <typename CudaMparticles, typename DIM>
-void cuda_bndp<CudaMparticles, DIM>::reorder_send_by_id_gold(
+template <typename CudaMparticles>
+void cuda_bndp<CudaMparticles, dim_yz>::reorder_send_by_id_gold(
   CudaMparticles* cmprts, uint n_prts_send)
 {
   thrust::host_vector<uint> h_id(cmprts->by_block_.d_id.data(),
@@ -119,8 +119,8 @@ __global__ static void k_reorder_send_buf_total(
 // ----------------------------------------------------------------------
 // reorder_send_buf_total
 
-template <typename CudaMparticles, typename DIM>
-void cuda_bndp<CudaMparticles, DIM>::reorder_send_buf_total(
+template <typename CudaMparticles>
+void cuda_bndp<CudaMparticles, dim_yz>::reorder_send_buf_total(
   CudaMparticles* cmprts, uint n_prts_send)
 {
   if (n_patches() == 0) {
@@ -149,9 +149,9 @@ void cuda_bndp<CudaMparticles, DIM>::reorder_send_buf_total(
 // out: d_spine_sums, d_id[n_prts - n_prts_send: n_prts[
 //
 
-template <typename CudaMparticles, typename DIM>
-void cuda_bndp<CudaMparticles, DIM>::scan_send_buf_total(CudaMparticles* cmprts,
-                                                         uint n_prts_send)
+template <typename CudaMparticles>
+void cuda_bndp<CudaMparticles, dim_yz>::scan_send_buf_total(
+  CudaMparticles* cmprts, uint n_prts_send)
 {
   // OPT, we could do this from the beginning and adapt find_n_send()
   thrust::exclusive_scan(d_spine_cnts.data() + n_blocks * 10,
@@ -211,8 +211,8 @@ void cuda_bndp<CudaMparticles, DIM>::scan_send_buf_total(CudaMparticles* cmprts,
 // ----------------------------------------------------------------------
 // scan_send_buf_total_gold
 
-template <typename CudaMparticles, typename DIM>
-void cuda_bndp<CudaMparticles, DIM>::scan_send_buf_total_gold(
+template <typename CudaMparticles>
+void cuda_bndp<CudaMparticles, dim_yz>::scan_send_buf_total_gold(
   CudaMparticles* cmprts, uint n_prts_send)
 {
   thrust::host_vector<uint> h_off(cmprts->by_block_.d_off);

--- a/src/libpsc/cuda/cuda_bndp_spine.cu
+++ b/src/libpsc/cuda/cuda_bndp_spine.cu
@@ -24,8 +24,8 @@ static const int RADIX_BITS = 4;
 // ----------------------------------------------------------------------
 // spine_reduce
 
-template <typename CudaMparticles, typename DIM>
-void cuda_bndp<CudaMparticles, DIM>::spine_reduce(CudaMparticles* cmprts)
+template <typename CudaMparticles>
+void cuda_bndp<CudaMparticles, dim_yz>::spine_reduce(CudaMparticles* cmprts)
 {
   // OPT?
   thrust::fill(d_spine_cnts.data(),
@@ -82,8 +82,9 @@ void cuda_bndp<CudaMparticles, DIM>::spine_reduce(CudaMparticles* cmprts)
 // ----------------------------------------------------------------------
 // cuda_mprts_spine_reduce_gold
 
-template <typename CudaMparticles, typename DIM>
-void cuda_bndp<CudaMparticles, DIM>::spine_reduce_gold(CudaMparticles* cmprts)
+template <typename CudaMparticles>
+void cuda_bndp<CudaMparticles, dim_yz>::spine_reduce_gold(
+  CudaMparticles* cmprts)
 {
   thrust::fill(d_spine_cnts.data(),
                d_spine_cnts.data() + 1 + n_blocks * (CUDA_BND_STRIDE + 1), 0);
@@ -145,8 +146,8 @@ __global__ static void k_count_received(int nr_total_blocks,
 // ----------------------------------------------------------------------
 // count_received
 
-template <typename CudaMparticles, typename DIM>
-void cuda_bndp<CudaMparticles, DIM>::count_received(CudaMparticles* cmprts)
+template <typename CudaMparticles>
+void cuda_bndp<CudaMparticles, dim_yz>::count_received(CudaMparticles* cmprts)
 {
   k_count_received<<<n_blocks, THREADS_PER_BLOCK>>>(
     n_blocks, d_spine_cnts.data().get() + 10 * n_blocks,
@@ -156,8 +157,9 @@ void cuda_bndp<CudaMparticles, DIM>::count_received(CudaMparticles* cmprts)
 // ----------------------------------------------------------------------
 // count_received_gold
 
-template <typename CudaMparticles, typename DIM>
-void cuda_bndp<CudaMparticles, DIM>::count_received_gold(CudaMparticles* cmprts)
+template <typename CudaMparticles>
+void cuda_bndp<CudaMparticles, dim_yz>::count_received_gold(
+  CudaMparticles* cmprts)
 {
   thrust::host_vector<uint> h_spine_cnts(1 + n_blocks * (10 + 1));
 
@@ -213,8 +215,8 @@ static void __global__ k_scan_scatter_received(uint nr_recv, uint nr_prts_prev,
 // ----------------------------------------------------------------------
 // scan_scatter_received
 
-template <typename CudaMparticles, typename DIM>
-void cuda_bndp<CudaMparticles, DIM>::scan_scatter_received(
+template <typename CudaMparticles>
+void cuda_bndp<CudaMparticles, dim_yz>::scan_scatter_received(
   CudaMparticles* cmprts, uint n_prts_recv)
 {
   if (n_prts_recv == 0) {
@@ -234,8 +236,8 @@ void cuda_bndp<CudaMparticles, DIM>::scan_scatter_received(
 // ----------------------------------------------------------------------
 // scan_scatter_received_gold
 
-template <typename CudaMparticles, typename DIM>
-void cuda_bndp<CudaMparticles, DIM>::scan_scatter_received_gold(
+template <typename CudaMparticles>
+void cuda_bndp<CudaMparticles, dim_yz>::scan_scatter_received_gold(
   CudaMparticles* cmprts, uint n_prts_recv)
 {
   thrust::host_vector<uint> h_bidx(cmprts->n_prts);
@@ -261,9 +263,9 @@ void cuda_bndp<CudaMparticles, DIM>::scan_scatter_received_gold(
 // ----------------------------------------------------------------------
 // sort_pairs_device
 
-template <typename CudaMparticles, typename DIM>
-void cuda_bndp<CudaMparticles, DIM>::sort_pairs_device(CudaMparticles* cmprts,
-                                                       uint n_prts_recv)
+template <typename CudaMparticles>
+void cuda_bndp<CudaMparticles, dim_yz>::sort_pairs_device(
+  CudaMparticles* cmprts, uint n_prts_recv)
 {
   static int pr_A, pr_B, pr_C, pr_D;
   if (!pr_B) {
@@ -336,9 +338,9 @@ void cuda_bndp<CudaMparticles, DIM>::sort_pairs_device(CudaMparticles* cmprts,
   // d_ids now contains the indices to reorder by
 }
 
-template <typename CudaMparticles, typename DIM>
-void cuda_bndp<CudaMparticles, DIM>::sort_pairs_gold(CudaMparticles* cmprts,
-                                                     uint n_prts_recv)
+template <typename CudaMparticles>
+void cuda_bndp<CudaMparticles, dim_yz>::sort_pairs_gold(CudaMparticles* cmprts,
+                                                        uint n_prts_recv)
 {
   thrust::host_vector<uint> h_bidx(cmprts->by_block_.d_idx.data(),
                                    cmprts->by_block_.d_idx.data() +

--- a/src/libpsc/cuda/cuda_bndp_spine.cu
+++ b/src/libpsc/cuda/cuda_bndp_spine.cu
@@ -1,4 +1,6 @@
 
+#ifdef CUDA_BNDP_DIM_YZ_SPECIAL
+
 #include "cuda_bits.h"
 #include "cuda_bndp.h"
 #include "cuda_mparticles.cuh"
@@ -393,3 +395,5 @@ void cuda_bndp<CudaMparticles, dim_yz>::sort_pairs_gold(CudaMparticles* cmprts,
 }
 
 template struct cuda_bndp<cuda_mparticles<BS144>, dim_yz>;
+
+#endif

--- a/src/libpsc/cuda/cuda_bndp_spine.cu
+++ b/src/libpsc/cuda/cuda_bndp_spine.cu
@@ -1,7 +1,7 @@
 
+#include "cuda_bits.h"
 #include "cuda_bndp.h"
 #include "cuda_mparticles.cuh"
-#include "cuda_bits.h"
 
 #include <thrust/device_vector.h>
 #include <thrust/host_vector.h>
@@ -24,42 +24,50 @@ static const int RADIX_BITS = 4;
 // ----------------------------------------------------------------------
 // spine_reduce
 
-template<typename CudaMparticles, typename DIM>
-void cuda_bndp<CudaMparticles, DIM>::spine_reduce(CudaMparticles *cmprts)
+template <typename CudaMparticles, typename DIM>
+void cuda_bndp<CudaMparticles, DIM>::spine_reduce(CudaMparticles* cmprts)
 {
   // OPT?
-  thrust::fill(d_spine_cnts.data(), d_spine_cnts.data() + 1 + n_blocks * (CUDA_BND_STRIDE + 1), 0);
+  thrust::fill(d_spine_cnts.data(),
+               d_spine_cnts.data() + 1 + n_blocks * (CUDA_BND_STRIDE + 1), 0);
 
   const int threads = B40C_RADIXSORT_THREADS;
   Int3 mx = b_mx();
   if (mx[0] == 1 && mx[1] == 2 && mx[2] == 2) {
-    RakingReduction3x<K, V, 0, RADIX_BITS, 0,
-		      NopFunctor<K>, 2, 2> <<<n_blocks, threads>>>
-      (d_spine_cnts.data().get(), cmprts->by_block_.d_idx.data().get(), cmprts->by_block_.d_off.data().get(), n_blocks);
+    RakingReduction3x<K, V, 0, RADIX_BITS, 0, NopFunctor<K>, 2, 2>
+      <<<n_blocks, threads>>>(d_spine_cnts.data().get(),
+                              cmprts->by_block_.d_idx.data().get(),
+                              cmprts->by_block_.d_off.data().get(), n_blocks);
   } else if (mx[0] == 1 && mx[1] == 4 && mx[2] == 4) {
-    RakingReduction3x<K, V, 0, RADIX_BITS, 0,
-		      NopFunctor<K>, 4, 4> <<<n_blocks, threads>>>
-      (d_spine_cnts.data().get(), cmprts->by_block_.d_idx.data().get(), cmprts->by_block_.d_off.data().get(), n_blocks);
+    RakingReduction3x<K, V, 0, RADIX_BITS, 0, NopFunctor<K>, 4, 4>
+      <<<n_blocks, threads>>>(d_spine_cnts.data().get(),
+                              cmprts->by_block_.d_idx.data().get(),
+                              cmprts->by_block_.d_off.data().get(), n_blocks);
   } else if (mx[0] == 1 && mx[1] == 8 && mx[2] == 8) {
-    RakingReduction3x<K, V, 0, RADIX_BITS, 0,
-		      NopFunctor<K>, 8, 8> <<<n_blocks, threads>>>
-      (d_spine_cnts.data().get(), cmprts->by_block_.d_idx.data().get(), cmprts->by_block_.d_off.data().get(), n_blocks);
+    RakingReduction3x<K, V, 0, RADIX_BITS, 0, NopFunctor<K>, 8, 8>
+      <<<n_blocks, threads>>>(d_spine_cnts.data().get(),
+                              cmprts->by_block_.d_idx.data().get(),
+                              cmprts->by_block_.d_off.data().get(), n_blocks);
   } else if (mx[0] == 1 && mx[1] == 16 && mx[2] == 16) {
-    RakingReduction3x<K, V, 0, RADIX_BITS, 0,
-		      NopFunctor<K>, 16, 16> <<<n_blocks, threads>>>
-      (d_spine_cnts.data().get(), cmprts->by_block_.d_idx.data().get(), cmprts->by_block_.d_off.data().get(), n_blocks);
+    RakingReduction3x<K, V, 0, RADIX_BITS, 0, NopFunctor<K>, 16, 16>
+      <<<n_blocks, threads>>>(d_spine_cnts.data().get(),
+                              cmprts->by_block_.d_idx.data().get(),
+                              cmprts->by_block_.d_off.data().get(), n_blocks);
   } else if (mx[0] == 1 && mx[1] == 32 && mx[2] == 32) {
-    RakingReduction3x<K, V, 0, RADIX_BITS, 0,
-		      NopFunctor<K>, 32, 32> <<<n_blocks, threads>>>
-      (d_spine_cnts.data().get(), cmprts->by_block_.d_idx.data().get(), cmprts->by_block_.d_off.data().get(), n_blocks);
+    RakingReduction3x<K, V, 0, RADIX_BITS, 0, NopFunctor<K>, 32, 32>
+      <<<n_blocks, threads>>>(d_spine_cnts.data().get(),
+                              cmprts->by_block_.d_idx.data().get(),
+                              cmprts->by_block_.d_off.data().get(), n_blocks);
   } else if (mx[0] == 1 && mx[1] == 64 && mx[2] == 64) {
-    RakingReduction3x<K, V, 0, RADIX_BITS, 0,
-		      NopFunctor<K>, 64, 64> <<<n_blocks, threads>>>
-      (d_spine_cnts.data().get(), cmprts->by_block_.d_idx.data().get(), cmprts->by_block_.d_off.data().get(), n_blocks);
+    RakingReduction3x<K, V, 0, RADIX_BITS, 0, NopFunctor<K>, 64, 64>
+      <<<n_blocks, threads>>>(d_spine_cnts.data().get(),
+                              cmprts->by_block_.d_idx.data().get(),
+                              cmprts->by_block_.d_off.data().get(), n_blocks);
   } else if (mx[0] == 1 && mx[1] == 128 && mx[2] == 128) {
-    RakingReduction3x<K, V, 0, RADIX_BITS, 0,
-                      NopFunctor<K>, 128, 128> <<<n_blocks, threads>>>
-      (d_spine_cnts.data().get(), cmprts->by_block_.d_idx.data().get(), cmprts->by_block_.d_off.data().get(), n_blocks);
+    RakingReduction3x<K, V, 0, RADIX_BITS, 0, NopFunctor<K>, 128, 128>
+      <<<n_blocks, threads>>>(d_spine_cnts.data().get(),
+                              cmprts->by_block_.d_idx.data().get(),
+                              cmprts->by_block_.d_off.data().get(), n_blocks);
   } else {
     printf("no support for b_mx %d x %d x %d!\n", mx[0], mx[1], mx[2]);
     assert(0);
@@ -67,59 +75,65 @@ void cuda_bndp<CudaMparticles, DIM>::spine_reduce(CudaMparticles *cmprts)
   cuda_sync_if_enabled();
 
   thrust::exclusive_scan(d_spine_cnts.data() + n_blocks * 10,
-			 d_spine_cnts.data() + n_blocks * 10 + n_blocks + 1,
-			 d_spine_sums.data() + n_blocks * 10);
+                         d_spine_cnts.data() + n_blocks * 10 + n_blocks + 1,
+                         d_spine_sums.data() + n_blocks * 10);
 }
 
 // ----------------------------------------------------------------------
 // cuda_mprts_spine_reduce_gold
 
-template<typename CudaMparticles, typename DIM>
-void cuda_bndp<CudaMparticles, DIM>::spine_reduce_gold(CudaMparticles *cmprts)
+template <typename CudaMparticles, typename DIM>
+void cuda_bndp<CudaMparticles, DIM>::spine_reduce_gold(CudaMparticles* cmprts)
 {
-  thrust::fill(d_spine_cnts.data(), d_spine_cnts.data() + 1 + n_blocks * (CUDA_BND_STRIDE + 1), 0);
+  thrust::fill(d_spine_cnts.data(),
+               d_spine_cnts.data() + 1 + n_blocks * (CUDA_BND_STRIDE + 1), 0);
 
-  thrust::host_vector<uint> h_bidx(cmprts->by_block_.d_idx.data(), cmprts->by_block_.d_idx.data() + cmprts->n_prts);
+  thrust::host_vector<uint> h_bidx(cmprts->by_block_.d_idx.data(),
+                                   cmprts->by_block_.d_idx.data() +
+                                     cmprts->n_prts);
   thrust::host_vector<uint> h_off(cmprts->by_block_.d_off);
-  thrust::host_vector<uint> h_spine_cnts(d_spine_cnts.data(), d_spine_cnts.data() + 1 + n_blocks * (CUDA_BND_STRIDE + 1));
+  thrust::host_vector<uint> h_spine_cnts(d_spine_cnts.data(),
+                                         d_spine_cnts.data() + 1 +
+                                           n_blocks * (CUDA_BND_STRIDE + 1));
 
   Int3 mx = b_mx();
   for (int p = 0; p < n_patches(); p++) {
     for (int b = 0; b < n_blocks_per_patch; b++) {
       uint bid = b + p * n_blocks_per_patch;
-      for (int n = h_off[bid]; n < h_off[bid+1]; n++) {
-	uint key = h_bidx[n];
-	if (key < 9) {
-	  int dy = key % 3;
-	  int dz = key / 3;
-	  int by = b % mx[1];
-	  int bz = b / mx[1];
-	  uint bby = by + 1 - dy;
-	  uint bbz = bz + 1 - dz;
-	  uint bb = bbz * mx[1] + bby;
-	  if (bby < mx[1] && bbz < mx[2]) {
-	    h_spine_cnts[(bb + p * n_blocks_per_patch) * 10 + key]++;
-	  } else {
-	    assert(0);
-	  }
-	} else if (key == CUDA_BND_S_OOB) {
-	  h_spine_cnts[mx[1]*mx[2]*n_patches() * 10 + bid]++;
-	}
+      for (int n = h_off[bid]; n < h_off[bid + 1]; n++) {
+        uint key = h_bidx[n];
+        if (key < 9) {
+          int dy = key % 3;
+          int dz = key / 3;
+          int by = b % mx[1];
+          int bz = b / mx[1];
+          uint bby = by + 1 - dy;
+          uint bbz = bz + 1 - dz;
+          uint bb = bbz * mx[1] + bby;
+          if (bby < mx[1] && bbz < mx[2]) {
+            h_spine_cnts[(bb + p * n_blocks_per_patch) * 10 + key]++;
+          } else {
+            assert(0);
+          }
+        } else if (key == CUDA_BND_S_OOB) {
+          h_spine_cnts[mx[1] * mx[2] * n_patches() * 10 + bid]++;
+        }
       }
     }
-  }  
+  }
 
   thrust::copy(h_spine_cnts.begin(), h_spine_cnts.end(), d_spine_cnts.begin());
   thrust::exclusive_scan(d_spine_cnts.data() + n_blocks * 10,
-			 d_spine_cnts.data() + n_blocks * 10 + n_blocks + 1,
-			 d_spine_sums.data() + n_blocks * 10);
+                         d_spine_cnts.data() + n_blocks * 10 + n_blocks + 1,
+                         d_spine_sums.data() + n_blocks * 10);
 }
 
 // ----------------------------------------------------------------------
 // k_count_received
 
-__global__ static void
-k_count_received(int nr_total_blocks, uint *d_n_recv_by_block, uint *d_spine_cnts)
+__global__ static void k_count_received(int nr_total_blocks,
+                                        uint* d_n_recv_by_block,
+                                        uint* d_spine_cnts)
 {
   int bid = threadIdx.x + THREADS_PER_BLOCK * blockIdx.x;
 
@@ -131,22 +145,25 @@ k_count_received(int nr_total_blocks, uint *d_n_recv_by_block, uint *d_spine_cnt
 // ----------------------------------------------------------------------
 // count_received
 
-template<typename CudaMparticles, typename DIM>
-void cuda_bndp<CudaMparticles, DIM>::count_received(CudaMparticles *cmprts)
+template <typename CudaMparticles, typename DIM>
+void cuda_bndp<CudaMparticles, DIM>::count_received(CudaMparticles* cmprts)
 {
-  k_count_received<<<n_blocks, THREADS_PER_BLOCK>>>
-    (n_blocks, d_spine_cnts.data().get() + 10 * n_blocks, d_spine_cnts.data().get());
+  k_count_received<<<n_blocks, THREADS_PER_BLOCK>>>(
+    n_blocks, d_spine_cnts.data().get() + 10 * n_blocks,
+    d_spine_cnts.data().get());
 }
 
 // ----------------------------------------------------------------------
 // count_received_gold
 
-template<typename CudaMparticles, typename DIM>
-void cuda_bndp<CudaMparticles, DIM>::count_received_gold(CudaMparticles *cmprts)
+template <typename CudaMparticles, typename DIM>
+void cuda_bndp<CudaMparticles, DIM>::count_received_gold(CudaMparticles* cmprts)
 {
   thrust::host_vector<uint> h_spine_cnts(1 + n_blocks * (10 + 1));
 
-  thrust::copy(d_spine_cnts.data(), d_spine_cnts.data() + 1 + n_blocks * (10 + 1), h_spine_cnts.begin());
+  thrust::copy(d_spine_cnts.data(),
+               d_spine_cnts.data() + 1 + n_blocks * (10 + 1),
+               h_spine_cnts.begin());
 
   for (int bid = 0; bid < n_blocks; bid++) {
     h_spine_cnts[bid * 10 + CUDA_BND_S_NEW] = h_spine_cnts[10 * n_blocks + bid];
@@ -177,10 +194,10 @@ void cuda_bndp::count_received_v1(CudaMparticles *cmprts)
 // ----------------------------------------------------------------------
 // k_scan_scatter_received
 
-static void __global__
-k_scan_scatter_received(uint nr_recv, uint nr_prts_prev,
-			    uint *d_spine_sums, uint *d_bnd_off,
-			    uint *d_bidx, uint *d_ids)
+static void __global__ k_scan_scatter_received(uint nr_recv, uint nr_prts_prev,
+                                               uint* d_spine_sums,
+                                               uint* d_bnd_off, uint* d_bidx,
+                                               uint* d_ids)
 {
   int n0 = threadIdx.x + THREADS_PER_BLOCK * blockIdx.x;
   if (n0 >= nr_recv) {
@@ -196,36 +213,40 @@ k_scan_scatter_received(uint nr_recv, uint nr_prts_prev,
 // ----------------------------------------------------------------------
 // scan_scatter_received
 
-template<typename CudaMparticles, typename DIM>
-void cuda_bndp<CudaMparticles, DIM>::scan_scatter_received(CudaMparticles *cmprts, uint n_prts_recv)
+template <typename CudaMparticles, typename DIM>
+void cuda_bndp<CudaMparticles, DIM>::scan_scatter_received(
+  CudaMparticles* cmprts, uint n_prts_recv)
 {
   if (n_prts_recv == 0) {
     return;
   }
-  
+
   uint n_prts_prev = cmprts->n_prts - n_prts_recv;
 
   int dimGrid = (n_prts_recv + THREADS_PER_BLOCK - 1) / THREADS_PER_BLOCK;
 
-  k_scan_scatter_received<<<dimGrid, THREADS_PER_BLOCK>>>
-    (n_prts_recv, n_prts_prev, d_spine_sums.data().get(), d_bnd_off.data().get(),
-     cmprts->by_block_.d_idx.data().get(), cmprts->by_block_.d_id.data().get());
+  k_scan_scatter_received<<<dimGrid, THREADS_PER_BLOCK>>>(
+    n_prts_recv, n_prts_prev, d_spine_sums.data().get(), d_bnd_off.data().get(),
+    cmprts->by_block_.d_idx.data().get(), cmprts->by_block_.d_id.data().get());
   cuda_sync_if_enabled();
 }
 
 // ----------------------------------------------------------------------
 // scan_scatter_received_gold
 
-template<typename CudaMparticles, typename DIM>
-void cuda_bndp<CudaMparticles, DIM>::scan_scatter_received_gold(CudaMparticles *cmprts, uint n_prts_recv)
+template <typename CudaMparticles, typename DIM>
+void cuda_bndp<CudaMparticles, DIM>::scan_scatter_received_gold(
+  CudaMparticles* cmprts, uint n_prts_recv)
 {
   thrust::host_vector<uint> h_bidx(cmprts->n_prts);
   thrust::host_vector<uint> h_bnd_off(n_prts_recv);
   thrust::host_vector<uint> h_id(cmprts->n_prts);
   thrust::host_vector<uint> h_spine_sums(1 + n_blocks * (10 + 1));
 
-  thrust::copy(d_spine_sums.data(), d_spine_sums.data() + n_blocks * 11, h_spine_sums.begin());
-  thrust::copy(cmprts->by_block_.d_idx.data(), cmprts->by_block_.d_idx.data() + cmprts->n_prts, h_bidx.begin());
+  thrust::copy(d_spine_sums.data(), d_spine_sums.data() + n_blocks * 11,
+               h_spine_sums.begin());
+  thrust::copy(cmprts->by_block_.d_idx.data(),
+               cmprts->by_block_.d_idx.data() + cmprts->n_prts, h_bidx.begin());
 
   uint n_prts_prev = cmprts->n_prts - n_prts_recv;
   thrust::copy(d_bnd_off.begin(), d_bnd_off.end(), h_bnd_off.begin());
@@ -240,8 +261,9 @@ void cuda_bndp<CudaMparticles, DIM>::scan_scatter_received_gold(CudaMparticles *
 // ----------------------------------------------------------------------
 // sort_pairs_device
 
-template<typename CudaMparticles, typename DIM>
-void cuda_bndp<CudaMparticles, DIM>::sort_pairs_device(CudaMparticles *cmprts, uint n_prts_recv)
+template <typename CudaMparticles, typename DIM>
+void cuda_bndp<CudaMparticles, DIM>::sort_pairs_device(CudaMparticles* cmprts,
+                                                       uint n_prts_recv)
 {
   static int pr_A, pr_B, pr_C, pr_D;
   if (!pr_B) {
@@ -257,7 +279,9 @@ void cuda_bndp<CudaMparticles, DIM>::sort_pairs_device(CudaMparticles *cmprts, u
 
   prof_start(pr_B);
   // FIXME why isn't 10 + 0 enough?
-  thrust::exclusive_scan(d_spine_cnts.data(), d_spine_cnts.data() + 1 + n_blocks * (10 + 1), d_spine_sums.data());
+  thrust::exclusive_scan(d_spine_cnts.data(),
+                         d_spine_cnts.data() + 1 + n_blocks * (10 + 1),
+                         d_spine_sums.data());
   prof_stop(pr_B);
 
   prof_start(pr_C);
@@ -267,47 +291,41 @@ void cuda_bndp<CudaMparticles, DIM>::sort_pairs_device(CudaMparticles *cmprts, u
   prof_start(pr_D);
   Int3 mx = b_mx();
   if (mx[0] == 1 && mx[1] == 4 && mx[2] == 4) {
-    ScanScatterDigits3x<K, V, 0, RADIX_BITS, 0,
-			NopFunctor<K>,
-			NopFunctor<K>,
-			4, 4> 
-      <<<n_blocks, B40C_RADIXSORT_THREADS>>>
-      (d_spine_sums.data().get(), cmprts->by_block_.d_idx.data().get(), cmprts->by_block_.d_id.data().get(), cmprts->by_block_.d_off.data().get(), n_blocks);
+    ScanScatterDigits3x<K, V, 0, RADIX_BITS, 0, NopFunctor<K>, NopFunctor<K>, 4,
+                        4><<<n_blocks, B40C_RADIXSORT_THREADS>>>(
+      d_spine_sums.data().get(), cmprts->by_block_.d_idx.data().get(),
+      cmprts->by_block_.d_id.data().get(), cmprts->by_block_.d_off.data().get(),
+      n_blocks);
   } else if (mx[0] == 1 && mx[1] == 8 && mx[2] == 8) {
-    ScanScatterDigits3x<K, V, 0, RADIX_BITS, 0,
-			NopFunctor<K>,
-			NopFunctor<K>,
-			8, 8> 
-      <<<n_blocks, B40C_RADIXSORT_THREADS>>>
-      (d_spine_sums.data().get(), cmprts->by_block_.d_idx.data().get(), cmprts->by_block_.d_id.data().get(), cmprts->by_block_.d_off.data().get(), n_blocks);
+    ScanScatterDigits3x<K, V, 0, RADIX_BITS, 0, NopFunctor<K>, NopFunctor<K>, 8,
+                        8><<<n_blocks, B40C_RADIXSORT_THREADS>>>(
+      d_spine_sums.data().get(), cmprts->by_block_.d_idx.data().get(),
+      cmprts->by_block_.d_id.data().get(), cmprts->by_block_.d_off.data().get(),
+      n_blocks);
   } else if (mx[0] == 1 && mx[1] == 16 && mx[2] == 16) {
-    ScanScatterDigits3x<K, V, 0, RADIX_BITS, 0,
-			NopFunctor<K>,
-			NopFunctor<K>,
-			16, 16> 
-      <<<n_blocks, B40C_RADIXSORT_THREADS>>>
-      (d_spine_sums.data().get(), cmprts->by_block_.d_idx.data().get(), cmprts->by_block_.d_id.data().get(), cmprts->by_block_.d_off.data().get(), n_blocks);
+    ScanScatterDigits3x<K, V, 0, RADIX_BITS, 0, NopFunctor<K>, NopFunctor<K>,
+                        16, 16><<<n_blocks, B40C_RADIXSORT_THREADS>>>(
+      d_spine_sums.data().get(), cmprts->by_block_.d_idx.data().get(),
+      cmprts->by_block_.d_id.data().get(), cmprts->by_block_.d_off.data().get(),
+      n_blocks);
   } else if (mx[0] == 1 && mx[1] == 32 && mx[2] == 32) {
-    ScanScatterDigits3x<K, V, 0, RADIX_BITS, 0,
-			NopFunctor<K>,
-			NopFunctor<K>,
-			32, 32> 
-      <<<n_blocks, B40C_RADIXSORT_THREADS>>>
-      (d_spine_sums.data().get(), cmprts->by_block_.d_idx.data().get(), cmprts->by_block_.d_id.data().get(), cmprts->by_block_.d_off.data().get(), n_blocks);
+    ScanScatterDigits3x<K, V, 0, RADIX_BITS, 0, NopFunctor<K>, NopFunctor<K>,
+                        32, 32><<<n_blocks, B40C_RADIXSORT_THREADS>>>(
+      d_spine_sums.data().get(), cmprts->by_block_.d_idx.data().get(),
+      cmprts->by_block_.d_id.data().get(), cmprts->by_block_.d_off.data().get(),
+      n_blocks);
   } else if (mx[0] == 1 && mx[1] == 64 && mx[2] == 64) {
-    ScanScatterDigits3x<K, V, 0, RADIX_BITS, 0,
-			NopFunctor<K>,
-			NopFunctor<K>,
-			64, 64> 
-      <<<n_blocks, B40C_RADIXSORT_THREADS>>>
-      (d_spine_sums.data().get(), cmprts->by_block_.d_idx.data().get(), cmprts->by_block_.d_id.data().get(), cmprts->by_block_.d_off.data().get(), n_blocks);
+    ScanScatterDigits3x<K, V, 0, RADIX_BITS, 0, NopFunctor<K>, NopFunctor<K>,
+                        64, 64><<<n_blocks, B40C_RADIXSORT_THREADS>>>(
+      d_spine_sums.data().get(), cmprts->by_block_.d_idx.data().get(),
+      cmprts->by_block_.d_id.data().get(), cmprts->by_block_.d_off.data().get(),
+      n_blocks);
   } else if (mx[0] == 1 && mx[1] == 128 && mx[2] == 128) {
-    ScanScatterDigits3x<K, V, 0, RADIX_BITS, 0,
-                        NopFunctor<K>,
-                        NopFunctor<K>,
-                        128, 128>
-      <<<n_blocks, B40C_RADIXSORT_THREADS>>>
-      (d_spine_sums.data().get(), cmprts->by_block_.d_idx.data().get(), cmprts->by_block_.d_id.data().get(), cmprts->by_block_.d_off.data().get(), n_blocks);
+    ScanScatterDigits3x<K, V, 0, RADIX_BITS, 0, NopFunctor<K>, NopFunctor<K>,
+                        128, 128><<<n_blocks, B40C_RADIXSORT_THREADS>>>(
+      d_spine_sums.data().get(), cmprts->by_block_.d_idx.data().get(),
+      cmprts->by_block_.d_id.data().get(), cmprts->by_block_.d_off.data().get(),
+      n_blocks);
   } else {
     printf("no support for b_mx %d x %d x %d!\n", mx[0], mx[1], mx[2]);
     assert(0);
@@ -318,13 +336,17 @@ void cuda_bndp<CudaMparticles, DIM>::sort_pairs_device(CudaMparticles *cmprts, u
   // d_ids now contains the indices to reorder by
 }
 
-template<typename CudaMparticles, typename DIM>
-void cuda_bndp<CudaMparticles, DIM>::sort_pairs_gold(CudaMparticles *cmprts, uint n_prts_recv)
+template <typename CudaMparticles, typename DIM>
+void cuda_bndp<CudaMparticles, DIM>::sort_pairs_gold(CudaMparticles* cmprts,
+                                                     uint n_prts_recv)
 {
-  thrust::host_vector<uint> h_bidx(cmprts->by_block_.d_idx.data(), cmprts->by_block_.d_idx.data() + cmprts->n_prts);
+  thrust::host_vector<uint> h_bidx(cmprts->by_block_.d_idx.data(),
+                                   cmprts->by_block_.d_idx.data() +
+                                     cmprts->n_prts);
   thrust::host_vector<uint> h_id(cmprts->n_prts);
   thrust::host_vector<uint> h_off(cmprts->by_block_.d_off);
-  thrust::host_vector<uint> h_spine_cnts(d_spine_cnts.data(), d_spine_cnts.data() + 1 + n_blocks * (10 + 1));
+  thrust::host_vector<uint> h_spine_cnts(
+    d_spine_cnts.data(), d_spine_cnts.data() + 1 + n_blocks * (10 + 1));
 
   thrust::host_vector<uint> h_spine_sums(1 + n_blocks * (10 + 1));
 
@@ -333,34 +355,35 @@ void cuda_bndp<CudaMparticles, DIM>::sort_pairs_gold(CudaMparticles *cmprts, uin
     h_spine_cnts[h_bidx[n] * 10 + CUDA_BND_S_NEW]++;
   }
 
-  thrust::exclusive_scan(h_spine_cnts.begin(), h_spine_cnts.end(), h_spine_sums.begin());
+  thrust::exclusive_scan(h_spine_cnts.begin(), h_spine_cnts.end(),
+                         h_spine_sums.begin());
   thrust::copy(h_spine_sums.begin(), h_spine_sums.end(), d_spine_sums.begin());
 
   Int3 mx = b_mx();
   for (int bid = 0; bid < n_blocks; bid++) {
     int b = bid % n_blocks_per_patch;
     int p = bid / n_blocks_per_patch;
-    for (int n = h_off[bid]; n < h_off[bid+1]; n++) {
+    for (int n = h_off[bid]; n < h_off[bid + 1]; n++) {
       uint key = h_bidx[n];
       if (key < 9) {
-	int dy = key % 3;
-	int dz = key / 3;
-	int by = b % mx[1];
-	int bz = b / mx[1];
-	uint bby = by + 1 - dy;
-	uint bbz = bz + 1 - dz;
-	assert(bby < mx[1] && bbz < mx[2]);
-	uint bb = bbz * mx[1] + bby;
-	int nn = h_spine_sums[(bb + p * n_blocks_per_patch) * 10 + key]++;
-	h_id[nn] = n;
+        int dy = key % 3;
+        int dz = key / 3;
+        int by = b % mx[1];
+        int bz = b / mx[1];
+        uint bby = by + 1 - dy;
+        uint bbz = bz + 1 - dz;
+        assert(bby < mx[1] && bbz < mx[2]);
+        uint bb = bbz * mx[1] + bby;
+        int nn = h_spine_sums[(bb + p * n_blocks_per_patch) * 10 + key]++;
+        h_id[nn] = n;
       } else { // OOB
-	assert(0);
+        assert(0);
       }
     }
   }
   for (int n = cmprts->n_prts - n_prts_recv; n < cmprts->n_prts; n++) {
-      int nn = h_spine_sums[h_bidx[n] * 10 + CUDA_BND_S_NEW]++;
-      h_id[nn] = n;
+    int nn = h_spine_sums[h_bidx[n] * 10 + CUDA_BND_S_NEW]++;
+    h_id[nn] = n;
   }
 
   thrust::copy(h_id.begin(), h_id.end(), cmprts->by_block_.d_id.begin());

--- a/src/libpsc/cuda/cuda_mparticles_indexer.h
+++ b/src/libpsc/cuda/cuda_mparticles_indexer.h
@@ -2,29 +2,29 @@
 #ifndef CUDA_MPARTICLES_INDEXER_H
 #define CUDA_MPARTICLES_INDEXER_H
 
+#include "dim.hxx"
 #include "grid.hxx"
 #include "particle_cuda.hxx"
 #include "particle_indexer.hxx"
 #include "range.hxx"
-#include "dim.hxx"
 
 #define CUDA_BND_S_NEW (9)
 #define CUDA_BND_S_OOB (10)
 #define CUDA_BND_STRIDE (10)
 
-template<typename BS>
+template <typename BS>
 struct DParticleIndexer;
 
-template<typename BS, typename DIM>
+template <typename BS, typename DIM>
 struct BlockQ;
 
-template<typename BS, typename DIM>
+template <typename BS, typename DIM>
 struct BlockSimple;
 
 // ======================================================================
 // cuda_mparticles_indexer
 
-template<typename BS>
+template <typename BS>
 struct cuda_mparticles_indexer
 {
   using real_t = float;
@@ -43,10 +43,7 @@ struct cuda_mparticles_indexer
 
   int n_patches() const { return n_patches_; }
 
-  Int3 cellPosition(const real_t xi[3]) const
-  {
-    return pi_.cellPosition(xi);
-  }
+  Int3 cellPosition(const real_t xi[3]) const { return pi_.cellPosition(xi); }
 
   Int3 blockPosition(const real_t xi[3]) const
   {
@@ -75,12 +72,11 @@ struct cuda_mparticles_indexer
 protected:
   int blockIndex(Int3 bpos, int p) const
   {
-    if (uint(bpos[0]) >= b_mx_[0] ||
-	uint(bpos[1]) >= b_mx_[1] ||
-	uint(bpos[2]) >= b_mx_[2]) {
+    if (uint(bpos[0]) >= b_mx_[0] || uint(bpos[1]) >= b_mx_[1] ||
+        uint(bpos[2]) >= b_mx_[2]) {
       return -1;
     }
-    
+
     return ((p * b_mx_[2] + bpos[2]) * b_mx_[1] + bpos[1]) * b_mx_[0] + bpos[0];
   }
 
@@ -89,16 +85,18 @@ protected:
     assert(uint(cpos[0]) < pi_.ldims_[0]);
     assert(uint(cpos[1]) < pi_.ldims_[1]);
     assert(uint(cpos[2]) < pi_.ldims_[2]);
-    
-    return ((p * pi_.ldims_[2] + cpos[2]) * pi_.ldims_[1] + cpos[1]) * pi_.ldims_[0] + cpos[0];
+
+    return ((p * pi_.ldims_[2] + cpos[2]) * pi_.ldims_[1] + cpos[1]) *
+             pi_.ldims_[0] +
+           cpos[0];
   }
 
 public:
   uint n_cells() const { return pi_.n_cells_ * n_patches(); }
-  
-  uint n_patches_;               // number of patches
-  uint n_blocks_per_patch;       // number of blocks per patch
-  uint n_blocks;                 // number of blocks in all patches in mprts
+
+  uint n_patches_;         // number of patches
+  uint n_blocks_per_patch; // number of blocks per patch
+  uint n_blocks;           // number of blocks in all patches in mprts
 private:
   ParticleIndexer<real_t> pi_;
   Int3 b_mx_;
@@ -109,7 +107,7 @@ private:
 // ======================================================================
 // DParticleIndexer
 
-template<typename BS>
+template <typename BS>
 struct DParticleIndexer
 {
   using real_t = float;
@@ -120,8 +118,8 @@ struct DParticleIndexer
   {
     for (int d = 0; d < 3; d++) {
       ldims_[d] = cpi.pi_.ldims_[d];
-      b_mx_[d]  = cpi.b_mx_[d];
-      dxi_[d]   = cpi.pi_.dxi_[d];
+      b_mx_[d] = cpi.b_mx_[d];
+      dxi_[d] = cpi.pi_.dxi_[d];
       n_blocks_ = cpi.n_blocks;
     }
   }
@@ -131,16 +129,17 @@ struct DParticleIndexer
     uint pos_x = __float2int_rd(xi4.x * dxi_[0]);
     uint pos_y = __float2int_rd(xi4.y * dxi_[1]);
     uint pos_z = __float2int_rd(xi4.z * dxi_[2]);
-    
-    //assert(pos_y < ldims_[1] && pos_z < ldims_[2]); FIXME, assert doesn't work (on macbook)
+
+    // assert(pos_y < ldims_[1] && pos_z < ldims_[2]); FIXME, assert doesn't
+    // work (on macbook)
     return ((p * ldims_[2] + pos_z) * ldims_[1] + pos_y) * ldims_[0] + pos_x;
   }
 
   __device__ int blockIndex(float4 xi4, int p) const
   {
-    int block_pos[3] = { int(__float2int_rd(xi4.x * dxi_[0]) / BS::x::value),
-			 int(__float2int_rd(xi4.y * dxi_[1]) / BS::y::value),
-			 int(__float2int_rd(xi4.z * dxi_[2]) / BS::z::value) };
+    int block_pos[3] = {int(__float2int_rd(xi4.x * dxi_[0]) / BS::x::value),
+                        int(__float2int_rd(xi4.y * dxi_[1]) / BS::y::value),
+                        int(__float2int_rd(xi4.z * dxi_[2]) / BS::z::value)};
 
     return validBlockIndex(block_pos, p);
   }
@@ -151,29 +150,29 @@ struct DParticleIndexer
     /* assert(block_pos[1] >= 0 && block_pos[1] < b_mx_[1]); */
     /* assert(block_pos[2] >= 0 && block_pos[2] < b_mx_[2]); */
 
-    return ((p * b_mx_[2] + block_pos[2]) * b_mx_[1] + block_pos[1]) * b_mx_[0] + block_pos[0];
+    return ((p * b_mx_[2] + block_pos[2]) * b_mx_[1] + block_pos[1]) *
+             b_mx_[0] +
+           block_pos[0];
   }
 
   __device__ int blockIndexFromCellPosition(const int* cpos, int p) const
   {
-    if (uint(cpos[0]) >= ldims_[0] ||
-	uint(cpos[1]) >= ldims_[1] ||
-	uint(cpos[2]) >= ldims_[2]) {
+    if (uint(cpos[0]) >= ldims_[0] || uint(cpos[1]) >= ldims_[1] ||
+        uint(cpos[2]) >= ldims_[2]) {
       return n_blocks_ + p;
     }
 
-    int bpos[3] = { int(cpos[0] / BS::x::value),
-		    int(cpos[1] / BS::y::value),
-		    int(cpos[2] / BS::z::value) };
+    int bpos[3] = {int(cpos[0] / BS::x::value), int(cpos[1] / BS::y::value),
+                   int(cpos[2] / BS::z::value)};
     return validBlockIndex(bpos, p);
   }
-  
+
   __device__ int blockShift(float xi[3], int p, int bid) const
   {
     static_assert(BS::x::value == 1, "blockShift needs work for dim_xyz");
     uint block_pos_y = __float2int_rd(xi[1] * dxi_[1]) / BS::y::value;
     uint block_pos_z = __float2int_rd(xi[2] * dxi_[2]) / BS::z::value;
-    
+
     if (block_pos_y >= b_mx_[1] || block_pos_z >= b_mx_[2]) {
       return CUDA_BND_S_OOB;
     } else {
@@ -184,14 +183,15 @@ struct DParticleIndexer
       return d2 * 3 + d1;
     }
   }
-  
+
   // ======================================================================
   // cell related
-  
+
   // ----------------------------------------------------------------------
   // find_idx_off_1st
 
-  __device__ void find_idx_off_1st(const float xi[3], int j[3], float h[3], float shift)
+  __device__ void find_idx_off_1st(const float xi[3], int j[3], float h[3],
+                                   float shift)
   {
     for (int d = 0; d < 3; d++) {
       real_t pos = scalePos(xi[d], d) + shift;
@@ -202,8 +202,9 @@ struct DParticleIndexer
 
   // ----------------------------------------------------------------------
   // find_idx_off_pos_1st
-  
-  __device__ void find_idx_off_pos_1st(const float xi[3], int j[3], float h[3], float pos[3], float shift)
+
+  __device__ void find_idx_off_pos_1st(const float xi[3], int j[3], float h[3],
+                                       float pos[3], float shift)
   {
     for (int d = 0; d < 3; d++) {
       pos[d] = scalePos(xi[d], d) + shift;
@@ -212,15 +213,15 @@ struct DParticleIndexer
     }
   }
 
-  __device__ real_t scalePos(real_t xi, int d)
-  {
-    return xi * dxi_[d];
-  }
+  __device__ real_t scalePos(real_t xi, int d) { return xi * dxi_[d]; }
 
-  template<typename DIM>
+  template <typename DIM>
   __device__ void scalePos(real_t xs[3], real_t xi[3])
   {
-    if (DIM::InvarX::value) xs[0] = 0.; else xs[0] = scalePos(xi[0], 0);
+    if (DIM::InvarX::value)
+      xs[0] = 0.;
+    else
+      xs[0] = scalePos(xi[0], 0);
     xs[1] = scalePos(xi[1], 1);
     xs[2] = scalePos(xi[2], 2);
   }
@@ -247,12 +248,12 @@ struct BlockBase
 // ======================================================================
 // BlockSimple
 
-template<typename BS, typename DIM>
+template <typename BS, typename DIM>
 struct BlockSimple : BlockBase
 {
-  static Range<int> block_starts() { return range(1);  }
+  static Range<int> block_starts() { return range(1); }
 
-  template<typename CudaMparticles>
+  template <typename CudaMparticles>
   static dim3 dimGrid(CudaMparticles& cmprts)
   {
     int gx = cmprts.b_mx()[0];
@@ -261,18 +262,17 @@ struct BlockSimple : BlockBase
     return dim3(gx, gy, gz);
   }
 
-  __device__
-  bool init(const DParticleIndexer<BS>& dpi, int block_start = 0)
+  __device__ bool init(const DParticleIndexer<BS>& dpi, int block_start = 0)
   {
     int block_pos[3];
     block_pos[0] = blockIdx.x;
     block_pos[1] = blockIdx.y;
     block_pos[2] = blockIdx.z % dpi.b_mx_[2];
-    
+
     ci0[0] = block_pos[0] * BS::x::value;
     ci0[1] = block_pos[1] * BS::y::value;
     ci0[2] = block_pos[2] * BS::z::value;
-    
+
     p = blockIdx.z / dpi.b_mx_[2];
     bid = (blockIdx.z * dpi.b_mx_[1] + blockIdx.y) * dpi.b_mx_[0] + blockIdx.x;
     return true;
@@ -282,12 +282,12 @@ struct BlockSimple : BlockBase
 // ======================================================================
 // BlockSimple specialized for dim_yz
 
-template<typename BS>
+template <typename BS>
 struct BlockSimple<BS, dim_yz> : BlockBase
 {
-  static Range<int> block_starts() { return range(1);  }
+  static Range<int> block_starts() { return range(1); }
 
-  template<typename CudaMparticles>
+  template <typename CudaMparticles>
   static dim3 dimGrid(CudaMparticles& cmprts)
   {
     int gx = cmprts.b_mx()[1];
@@ -295,64 +295,62 @@ struct BlockSimple<BS, dim_yz> : BlockBase
     return dim3(gx, gy);
   }
 
-  __device__
-  bool init(const DParticleIndexer<BS>& dpi, int block_start = 0)
+  __device__ bool init(const DParticleIndexer<BS>& dpi, int block_start = 0)
   {
     int block_pos[3];
     block_pos[1] = blockIdx.x;
     block_pos[2] = blockIdx.y % dpi.b_mx_[2];
-    
+
     ci0[0] = 0;
     ci0[1] = block_pos[1] * BS::y::value;
     ci0[2] = block_pos[2] * BS::z::value;
-    
+
     p = blockIdx.y / dpi.b_mx_[2];
     bid = blockIdx.y * dpi.b_mx_[2] + blockIdx.x;
     return true;
   }
 };
 
-template<typename BS, typename DIM>
+template <typename BS, typename DIM>
 struct BlockQ : BlockBase
 {
   static Range<int> block_starts() { return range(8); }
 
-  template<typename CudaMparticles>
+  template <typename CudaMparticles>
   static dim3 dimGrid(CudaMparticles& cmprts)
   {
-    int gx =  (cmprts.b_mx()[0] + 1) / 2;
-    int gy =  (cmprts.b_mx()[1] + 1) / 2;
+    int gx = (cmprts.b_mx()[0] + 1) / 2;
+    int gy = (cmprts.b_mx()[1] + 1) / 2;
     int gz = ((cmprts.b_mx()[2] + 1) / 2) * cmprts.n_patches;
     return dim3(gx, gy, gz);
   }
 
-  __device__
-  int init(const DParticleIndexer<BS>& dpi, int block_start)
+  __device__ int init(const DParticleIndexer<BS>& dpi, int block_start)
   {
     int block_pos[3];
     int grid_dim_z = (dpi.b_mx_[2] + 1) / 2;
     block_pos[0] = blockIdx.x * 2;
     block_pos[1] = blockIdx.y * 2;
     block_pos[2] = (blockIdx.z % grid_dim_z) * 2;
-    block_pos[0] += block_start & 1; block_start >>= 1;
-    block_pos[1] += block_start & 1; block_start >>= 1;
+    block_pos[0] += block_start & 1;
+    block_start >>= 1;
+    block_pos[1] += block_start & 1;
+    block_start >>= 1;
     block_pos[2] += block_start;
-    if (block_pos[0] >= dpi.b_mx_[0] ||
-	block_pos[1] >= dpi.b_mx_[1] ||
-	block_pos[2] >= dpi.b_mx_[2])
+    if (block_pos[0] >= dpi.b_mx_[0] || block_pos[1] >= dpi.b_mx_[1] ||
+        block_pos[2] >= dpi.b_mx_[2])
       return false;
-    
+
     ci0[0] = block_pos[0] * BS::x::value;
     ci0[1] = block_pos[1] * BS::y::value;
     ci0[2] = block_pos[2] * BS::z::value;
-    
+
     p = blockIdx.z / grid_dim_z;
 
     // FIXME won't work if b_mx_[0,1,2] not even (?)
-    bid = (((p
-	     * dpi.b_mx_[2] + block_pos[2])
-	    * dpi.b_mx_[1] + block_pos[1])
-	   * dpi.b_mx_[0] + block_pos[0]);
+    bid = (((p * dpi.b_mx_[2] + block_pos[2]) * dpi.b_mx_[1] + block_pos[1]) *
+             dpi.b_mx_[0] +
+           block_pos[0]);
     return true;
   }
 };
@@ -360,21 +358,20 @@ struct BlockQ : BlockBase
 // ----------------------------------------------------------------------
 // BlockQ specialized for dim_yz
 
-template<typename BS>
+template <typename BS>
 struct BlockQ<BS, dim_yz> : BlockBase
 {
   static Range<int> block_starts() { return range(4); }
 
-  template<typename CudaMparticles>
+  template <typename CudaMparticles>
   static dim3 dimGrid(CudaMparticles& cmprts)
   {
-    int gx =  (cmprts.b_mx()[1] + 1) / 2;
+    int gx = (cmprts.b_mx()[1] + 1) / 2;
     int gy = ((cmprts.b_mx()[2] + 1) / 2) * cmprts.n_patches();
     return dim3(gx, gy);
   }
 
-  __device__
-  int init(const DParticleIndexer<BS>& dpi, int block_start)
+  __device__ int init(const DParticleIndexer<BS>& dpi, int block_start)
   {
     int block_pos[3];
     int grid_dim_y = (dpi.b_mx_[2] + 1) / 2;
@@ -384,11 +381,11 @@ struct BlockQ<BS, dim_yz> : BlockBase
     block_pos[2] += block_start >> 1;
     if (block_pos[1] >= dpi.b_mx_[1] || block_pos[2] >= dpi.b_mx_[2])
       return false;
-    
+
     ci0[0] = 0;
     ci0[1] = block_pos[1] * BS::y::value;
     ci0[2] = block_pos[2] * BS::z::value;
-    
+
     p = blockIdx.y / grid_dim_y;
 
     // FIXME won't work if b_mx_[1,2] not even (?)
@@ -397,12 +394,10 @@ struct BlockQ<BS, dim_yz> : BlockBase
   }
 };
 
-__device__
-inline RangeStrided<uint> in_block_loop(uint block_begin, uint block_end)
+__device__ inline RangeStrided<uint> in_block_loop(uint block_begin,
+                                                   uint block_end)
 {
   return range((block_begin & ~31) + threadIdx.x, block_end, blockDim.x);
 }
 
 #endif
-
-

--- a/src/libpsc/cuda/cuda_push_mprts_yz.cu
+++ b/src/libpsc/cuda/cuda_push_mprts_yz.cu
@@ -280,7 +280,11 @@ struct CudaPushParticles
     storage.store_position(prt, n);
 
     // has moved into which block? (given as relative shift)
+#ifdef CUDA_BNDP_DIM_YZ_SPECIAL
     dmprts.bidx_[n] = dmprts.blockShift(prt.x(), current_block.p, current_block.bid);
+#else
+    dmprts.bidx_[n] = dmprts.blockNoShift(prt.x(), current_block.p);
+#endif
 
     // position xm at x^(n+.5)
     dmprts.find_idx_off_pos_1st(prt.x(), k, h1, xp, float(0.));


### PR DESCRIPTION
The optimized single-pass radix sort does lead to random memory corruptions for reasons that I couldn't
really get to the bottom to.

So this switches the yz case to to do the same as xyz, ie., use the regular `thrust::stable_sort`.