### PR TITLE
Revert "cuda: have accessor warn on un-ordered access"

### DIFF
--- a/src/libpsc/cuda/cuda_mparticles_iface.cu
+++ b/src/libpsc/cuda/cuda_mparticles_iface.cu
@@ -80,12 +80,6 @@ bool cuda_mparticles_iface<BS>::check_after_push(CudaMparticles* cmprts)
 }
 
 template<typename BS>
-bool cuda_mparticles_iface<BS>::need_reorder(CudaMparticles* cmprts)
-{
-  return cmprts->need_reorder;
-}
-
-template<typename BS>
 void cuda_mparticles_iface<BS>::dump(const CudaMparticles* cmprts, const std::string& filename)
 {
   cmprts->dump(filename);

--- a/src/libpsc/cuda/cuda_mparticles_iface.hxx
+++ b/src/libpsc/cuda/cuda_mparticles_iface.hxx
@@ -33,7 +33,5 @@ struct cuda_mparticles_iface
 
   static bool check_after_push(CudaMparticles* cmprts);
   static void dump(const CudaMparticles* cmprts, const std::string& filename);
-
-  static bool need_reorder(CudaMparticles* cmprts);
 };
 

--- a/src/libpsc/cuda/mparticles_cuda.hxx
+++ b/src/libpsc/cuda/mparticles_cuda.hxx
@@ -70,15 +70,7 @@ struct MparticlesCuda : MparticlesBase
   CudaMparticles* cmprts() { return cmprts_; }
 
   InjectorBuffered<MparticlesCuda> injector() { return {*this}; }
-  ConstAccessorCuda<MparticlesCuda> accessor() const 
-  {
-    if(Iface::need_reorder(cmprts_))
-    {
-        printf("Warning: Calling accessor with unordered particles! Expect invalid results\n");
-        abort();
-    } 
-    return {const_cast<MparticlesCuda&>(*this)}; 
-  } // FIXME cast
+  ConstAccessorCuda<MparticlesCuda> accessor() const { return {const_cast<MparticlesCuda&>(*this)}; } // FIXME cast
 
 private:
   CudaMparticles* cmprts_;


### PR DESCRIPTION
Reverts psc-code/psc#82

It turns out that the accessor does handle access when the underlying cuda particles have not been
reordered (by reordering them), so this check isn't really needed, and in particular actually comes to early, so the code doesn't even get to reordering them.

There's still a mystery as to what caused duplicate particles in John's debugging work, but I guess we'll return to that if it shows up again...