### PR TITLE
make heating spot periodic

### DIFF
--- a/src/include/heating_spot_foil.hxx
+++ b/src/include/heating_spot_foil.hxx
@@ -22,8 +22,10 @@ struct HeatingSpotFoil : HeatingSpotFoilParams
 {
   HeatingSpotFoil() = default;
   
-  HeatingSpotFoil(const HeatingSpotFoilParams& params)
-    : HeatingSpotFoilParams(params)
+  HeatingSpotFoil(const Grid_t& grid, const HeatingSpotFoilParams& params)
+    : HeatingSpotFoilParams(params),
+      Lx_(grid.domain.length[0]),
+      Ly_(grid.domain.length[1])
   {
     double width = zh - zl;
     fac = (8.f * pow(T, 1.5)) / (sqrt(Mi) * width);
@@ -38,10 +40,20 @@ struct HeatingSpotFoil : HeatingSpotFoilParams
       return 0;
     }
     
-    return fac * exp(-(sqr(x-xc) + sqr(y-yc)) / sqr(rH));
+    return fac * exp(-(sqr(x - xc) + sqr(y - yc) +
+		       sqr(x - xc) + sqr(y - (yc + Ly_)) +
+		       sqr(x - xc) + sqr(y - (yc - Ly_)) +
+		       sqr(x - (xc + Lx_)) + sqr(y - yc) +
+		       sqr(x - (xc + Lx_)) + sqr(y - (yc + Ly_)) +
+		       sqr(x - (xc + Lx_)) + sqr(y - (yc - Ly_)) +
+		       sqr(x - (xc - Lx_)) + sqr(y - yc) +
+		       sqr(x - (xc - Lx_)) + sqr(y - (yc + Ly_)) +
+		       sqr(x - (xc - Lx_)) + sqr(y - (yc - Ly_)))
+		     / sqr(rH));
   }
 
 private:
   double fac;
+  double Lx_, Ly_;
 };
 

--- a/src/psc_flatfoil_yz.cxx
+++ b/src/psc_flatfoil_yz.cxx
@@ -417,7 +417,7 @@ void run()
   heating_foil_params.rH = 12. * g.d_i;
   heating_foil_params.T = g.target_Te_heat;
   heating_foil_params.Mi = grid.kinds[MY_ION].m;
-  HeatingSpotFoil heating_spot{heating_foil_params};
+  HeatingSpotFoil heating_spot{grid, heating_foil_params};
 
   g.heating_interval = 20;
   g.heating_begin = 0;


### PR DESCRIPTION
If the heating strength hasn't reached almost 0 at a periodic boundary,
it will abruptly fall to 0 at that boundary, leaving some artifacts,
which are now avoided by putting heating not only at the given
(xc, yc), but also shifted by a period in the periodic directions.