### PR TITLE
restart: more fixing

### DIFF
--- a/src/include/checkpoint.hxx
+++ b/src/include/checkpoint.hxx
@@ -49,7 +49,6 @@ inline void read_checkpoint(const std::string& filename, Grid_t& grid,
   auto io = kg::io::IOAdios2{};
   auto reader = io.open(filename, kg::io::Mode::Read);
   reader.get("grid", grid);
-  psc_balance_generation_cnt++;
   mprts.~Mparticles();
   mflds.~MfieldsState();
   new (&mprts) Mparticles(grid);

--- a/src/psc_flatfoil_yz.cxx
+++ b/src/psc_flatfoil_yz.cxx
@@ -350,6 +350,12 @@ void run()
   auto grid_ptr = setupGrid();
   auto& grid = *grid_ptr;
 
+  Mparticles mprts(grid);
+  MfieldsState mflds(grid);
+  if (!read_checkpoint_filename.empty()) {
+    read_checkpoint(read_checkpoint_filename, grid, mprts, mflds);
+  }
+  
   // ----------------------------------------------------------------------
   // Set up various objects needed to run this case
 
@@ -479,20 +485,16 @@ void run()
   // ----------------------------------------------------------------------
   // setup initial conditions
 
-  Mparticles mprts(grid);
-  MfieldsState mflds(grid);
   if (read_checkpoint_filename.empty()) {
     initializeParticles(setup_particles, balance, grid_ptr, mprts,
                         inject_target);
     initializeFields(mflds);
-  } else {
-    read_checkpoint(read_checkpoint_filename, *grid_ptr, mprts, mflds);
   }
 
   // ----------------------------------------------------------------------
   // hand off to PscIntegrator to run the simulation
 
-  auto psc = makePscIntegrator<PscConfig>(psc_params, *grid_ptr, mflds, mprts,
+  auto psc = makePscIntegrator<PscConfig>(psc_params, grid, mflds, mprts,
                                           balance, collision, checks, marder,
                                           diagnostics, lf_inject);
 


### PR DESCRIPTION
Should really be fixed for good now... Things do go wrong if
the grid changes after other things already rely on the previous
decomposition, so now we just read the checkpoint earlier, and everything
else should get to use the new grid right away.