### PR TITLE
flatfoil: don't print rebalancing detail

### DIFF
--- a/src/psc_flatfoil_yz.cxx
+++ b/src/psc_flatfoil_yz.cxx
@@ -361,7 +361,7 @@ void run()
 
   // -- Balance
   psc_params.balance_interval = 1000;
-  Balance balance{psc_params.balance_interval, 3, true};
+  Balance balance{psc_params.balance_interval, 3};
 
   // -- Sort
   psc_params.sort_interval = 10;


### PR DESCRIPTION
This much verbosity isn't currently useful, but rather makes for a messy log, so let's be less verbose.