### PR TITLE
cuda/mparticles: add clear(), fix put_as() back to MparticlesCuda

### DIFF
--- a/src/libpsc/cuda/cuda_mparticles.cuh
+++ b/src/libpsc/cuda/cuda_mparticles.cuh
@@ -185,6 +185,7 @@ protected:
 
 public:
   std::vector<uint> sizeByPatch() const;
+  void clear() { storage.resize(0); by_block_.clear(); n_prts = 0; }
 
   // per particle
   MparticlesCudaStorage storage;

--- a/src/libpsc/cuda/cuda_mparticles_iface.cu
+++ b/src/libpsc/cuda/cuda_mparticles_iface.cu
@@ -85,6 +85,12 @@ void cuda_mparticles_iface<BS>::dump(const CudaMparticles* cmprts, const std::st
   cmprts->dump(filename);
 }
 
+template<typename BS>
+void cuda_mparticles_iface<BS>::clear(CudaMparticles* cmprts)
+{
+  cmprts->clear();
+}
+
 template struct cuda_mparticles_iface<BS144>;
 template struct cuda_mparticles_iface<BS444>;
 

--- a/src/libpsc/cuda/cuda_mparticles_iface.hxx
+++ b/src/libpsc/cuda/cuda_mparticles_iface.hxx
@@ -33,5 +33,6 @@ struct cuda_mparticles_iface
 
   static bool check_after_push(CudaMparticles* cmprts);
   static void dump(const CudaMparticles* cmprts, const std::string& filename);
+  static void clear(CudaMparticles* cmprts);
 };
 

--- a/src/libpsc/cuda/cuda_mparticles_sort.cuh
+++ b/src/libpsc/cuda/cuda_mparticles_sort.cuh
@@ -319,6 +319,11 @@ struct cuda_mparticles_sort_by_block
     cmprts.reorder_and_offsets(d_idx, d_id, d_off);
   }
 
+  void clear()
+  {
+    thrust::fill(d_off.begin(), d_off.end(), 0);
+  }
+
 public:
   thrust::device_vector<uint> d_idx; // block index (incl patch) per particle
   thrust::device_vector<uint> d_id;  // particle id used for reordering

--- a/src/libpsc/cuda/mparticles_cuda.hxx
+++ b/src/libpsc/cuda/mparticles_cuda.hxx
@@ -53,6 +53,7 @@ struct MparticlesCuda : MparticlesBase
   void inject(const std::vector<Particle>& buf, const std::vector<uint>& buf_n_by_patch) { Iface::inject(cmprts_, buf, buf_n_by_patch); }
   void dump(const std::string& filename) { Iface::dump(cmprts_, filename); }
   bool check_after_push() { return Iface::check_after_push(cmprts_); }
+  void clear() { Iface::clear(cmprts_); }
 
   std::vector<uint> get_offsets() const { return Iface::get_offsets(cmprts_); }
   std::vector<Particle> get_particles() const { return Iface::get_particles(cmprts_); }

--- a/src/libpsc/cuda/psc_particles_cuda.cxx
+++ b/src/libpsc/cuda/psc_particles_cuda.cxx
@@ -16,6 +16,7 @@ static void copy_from(MparticlesBase& mprts_base, MparticlesBase& mprts_other_ba
   auto& mprts_other = dynamic_cast<MP&>(mprts_other_base);
   auto n_prts_by_patch = mprts_other.sizeByPatch();
   //mp.reserve_all(n_prts_by_patch); FIXME, would still be a good hint for the injector
+  mprts.clear();
 
   auto accessor = mprts_other.accessor();
   auto inj = mprts.injector();


### PR DESCRIPTION
This isn't currently being used, but it's helpful to have it working correctly for debugging stuff.