### PR TITLE
add RMM (rapids memory manager) support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,6 +25,7 @@ option(USE_VPIC "Interface with VPIC" OFF)
 option(USE_GTEST_DISCOVER_TESTS "Run tests to discover contained googletest cases" OFF)
 psc_option(ADIOS2 "Build with adios2 support" AUTO)
 option(PSC_USE_NVTX "Build with NVTX support" OFF)
+option(PSC_USE_RMM "Build with RMM memory manager support" OFF)
 
 # CUDA
 if(USE_CUDA)
@@ -55,6 +56,12 @@ if (PSC_USE_NVTX)
   set(PSC_HAVE_NVTX 1)
 endif()
 
+# RMM
+if (PSC_USE_RMM)
+  find_package(rmm CONFIG REQUIRED)
+  set(PSC_HAVE_RMM 1)
+endif()
+
 function(GenerateHeaderConfig)
   set(PSC_CONFIG_DEFINES)
   foreach(OPT IN LISTS ARGN)
@@ -76,7 +83,7 @@ endfunction()
 
 # FIXME, unify USE_CUDA, USE_VPIC options / autodetect
 # FIXME, mv helpers into separate file
-GenerateHeaderConfig(ADIOS2 NVTX)
+GenerateHeaderConfig(ADIOS2 NVTX RMM)
 
 include_directories(${CMAKE_CURRENT_BINARY_DIR}/src/include)
 # FIXME, this seems too ugly to find mrc_config.h

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,6 +29,11 @@ option(PSC_USE_RMM "Build with RMM memory manager support" OFF)
 
 # CUDA
 if(USE_CUDA)
+  # This is needed on Summit when not using modules (in a spack build) to
+  # make sure that nvcc uses the same host compiler that was otherwise
+  # specified
+  set(CMAKE_CUDA_HOST_COMPILER "${CMAKE_CXX_COMPILER}")
+
   set(_save_CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS}")
   set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -std c++14")
 

--- a/spack/psc/packages/nvtx_pmpi/package.py
+++ b/spack/psc/packages/nvtx_pmpi/package.py
@@ -1,0 +1,29 @@
+# Copyright 2013-2020 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack import *
+
+
+class NvtxPmpi(CMakePackage):
+    """FIXME: Put a proper description of your package here."""
+
+    # FIXME: Add a proper url for your package's homepage here.
+    homepage = "https://www.example.com"
+    url      = "nvtx_pmpi"
+    git      = "https://github.com/germasch/cuda-profiler.git"
+
+    # FIXME: Add a list of GitHub accounts to
+    # notify when the package is updated.
+    maintainers = ['germasch']
+
+    # FIXME: Add proper versions and checksums here.
+    version('0.0.1', branch='pr/cmake')
+
+    depends_on('mpi')
+    depends_on('cuda')
+    depends_on('python@:2.7.999', type='build')
+    depends_on('cmake@3.17.0:'  , type='build')
+
+    root_cmakelists_dir = 'nvtx_pmpi_wrappers'

--- a/spack/psc/packages/psc/package.py
+++ b/spack/psc/packages/psc/package.py
@@ -23,13 +23,16 @@ class Psc(CMakePackage):
             description='Enable CUDA support')
     variant('nvtx', default=False,
             description='Enable NVTX profiling support')
-    
+    variant('rmm', default=False,
+            description='Enable RMM memory manager support')
+
     depends_on('cmake@3.17.0:')
 
     depends_on('hdf5@1.8.0:1.8.999 +hl')
     depends_on('adios2@2.4.0:', when='+adios2')
     depends_on('cuda', when='+cuda')
     depends_on('cuda', when='+nvtx')
+    depends_on('rmm', when='+rmm')
 
     def cmake_args(self):
         args = []
@@ -37,5 +40,7 @@ class Psc(CMakePackage):
             'ON' if '+cuda' in self.spec else 'OFF')]
         args += ['-DPSC_USE_NVTX={}'.format(
             'ON' if '+nvtx' in self.spec else 'OFF')]
+        args += ['-DPSC_USE_RMM={}'.format(
+            'ON' if '+rmm' in self.spec else 'OFF')]
 
         return args

--- a/spack/psc/packages/rmm/package.py
+++ b/spack/psc/packages/rmm/package.py
@@ -1,0 +1,20 @@
+# Copyright 2013-2020 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack import *
+
+
+class Rmm(CMakePackage):
+    """RMM: RAPIDS Memory Manager"""
+
+    homepage = "https://github.com/rapidsai/rmm"
+    git      = "https://github.com/rapidsai/rmm"
+
+    maintainers = ['germasch']
+
+    version('cmake', branch='pr/cmake', git='https://github.com/germasch/rmm')
+
+    depends_on('cuda')
+

--- a/src/include/bnd_particles_impl.hxx
+++ b/src/include/bnd_particles_impl.hxx
@@ -63,7 +63,7 @@ struct BndParticlesCommon : BndParticlesBase
       pr_C = prof_register("xchg_comm", 1., 0, 0);
     }
   
-    prof_restart(pr_time_step_no_comm);
+    // prof_restart(pr_time_step_no_comm);
     prof_start(pr_B);
 #pragma omp parallel for
     for (int p = 0; p < ddcp->nr_patches; p++) {
@@ -72,7 +72,7 @@ struct BndParticlesCommon : BndParticlesBase
       if (psc_balance_comp_time_by_patch) psc_balance_comp_time_by_patch[p] += MPI_Wtime();
     }
     prof_stop(pr_B);
-    prof_stop(pr_time_step_no_comm);
+    // prof_stop(pr_time_step_no_comm);
     
     prof_start(pr_C);
     ddcp->comm(bufs);

--- a/src/include/bnd_particles_ordered_impl.hxx
+++ b/src/include/bnd_particles_ordered_impl.hxx
@@ -192,18 +192,18 @@ struct psc_bnd_particles_ordered : BndParticles_<MP>, bnd_particles_policy_order
 #if 0
     auto& mprts = mprts_base.get_as<Mparticles>();
 
-    prof_restart(pr_time_step_no_comm);
+    // prof_restart(pr_time_step_no_comm);
     prof_start(pr_A);
     this->exchange_mprts_prep(ddcp, mprts);
     prof_stop(pr_A);
     
     this->process_and_exgchange(mprts);
     
-    prof_restart(pr_time_step_no_comm);
+    // prof_restart(pr_time_step_no_comm);
     prof_start(pr_B);
     this->exchange_mprts_post(ddcp, mprts);
     prof_stop(pr_B);
-    prof_stop(pr_time_step_no_comm);
+    // prof_stop(pr_time_step_no_comm);
 
     mprts_base.put_as(mprts);
 #endif

--- a/src/include/cuda_compat.h
+++ b/src/include/cuda_compat.h
@@ -13,7 +13,7 @@
 #define __host__
 #define __device__
 
-typedef struct { float x; float y; float z; float w; } float4;
+//typedef struct { float x; float y; float z; float w; } float4;
 
 #endif
 

--- a/src/include/inject_impl.hxx
+++ b/src/include/inject_impl.hxx
@@ -37,12 +37,35 @@ struct Inject_ : InjectBase
 
   void operator()(Mparticles& mprts)
   {
+    static int pr, pr_0, pr_1, pr_2, pr_3, pr_4;
+    if (!pr) {
+      pr = prof_register("inject_impl", 1., 0, 0);
+      pr_0 = prof_register("inject_barrer", 1., 0, 0);
+      pr_1 = prof_register("inject_moment_n", 1., 0, 0);
+      pr_2 = prof_register("inject_eval", 1., 0, 0);
+      pr_3 = prof_register("inject_get_as", 1., 0, 0);
+      pr_4 = prof_register("inject_setup_prts", 1., 0, 0);
+    }
+
+    prof_start(pr);
     const auto& grid = mprts.grid();
 
+    prof_start(pr_0);
+    MPI_Barrier(MPI_COMM_WORLD);
+    prof_stop(pr_0);
+    
+    prof_start(pr_1);
     ItemMoment_t moment_n(mprts);
+    prof_stop(pr_1);
+    
+    prof_start(pr_2);
     auto mres = evalMfields(moment_n);
+    prof_stop(pr_2);
+    
+    prof_start(pr_3);
     auto& mf_n = mres.template get_as<Mfields>(kind_n, kind_n + 1);
-
+    prof_stop(pr_3);
+    
     real_t fac = (interval * grid.dt / tau) / (1. + interval * grid.dt / tau);
 
     auto lf_init_npt = [&](int kind, Double3 pos, int p, Int3 idx,
@@ -57,9 +80,12 @@ struct Inject_ : InjectBase
       }
     };
 
+    prof_start(pr_4);
     setup_particles_.setupParticles(mprts, lf_init_npt);
-
+    prof_stop(pr_4);
+    
     mres.put_as(mf_n, 0, 0);
+    prof_stop(pr);
   }
 
 private:

--- a/src/include/psc.hxx
+++ b/src/include/psc.hxx
@@ -207,9 +207,9 @@ struct Psc
                  grid().timestep() + 1, p_.nmax, grid().timestep() * grid().dt,
                  MPI_Wtime() - time_start_);
 
-      prof_start(pr_time_step_no_comm);
-      prof_stop(
-        pr_time_step_no_comm); // actual measurements are done w/ restart
+      // prof_start(pr_time_step_no_comm);
+      // prof_stop(
+      //   pr_time_step_no_comm); // actual measurements are done w/ restart
 
       step();
       grid_->timestep_++; // FIXME, too hacky
@@ -285,8 +285,8 @@ struct Psc
       balance_(grid_, mprts_);
     }
 
-    prof_start(pr_time_step_no_comm);
-    prof_stop(pr_time_step_no_comm); // actual measurements are done w/ restart
+    // prof_start(pr_time_step_no_comm);
+    // prof_stop(pr_time_step_no_comm); // actual measurements are done w/ restart
 
     if (p_.sort_interval > 0 && timestep % p_.sort_interval == 0) {
       // mpi_printf(comm, "***** Sorting...\n");

--- a/src/kg/testing/CMakeLists.txt
+++ b/src/kg/testing/CMakeLists.txt
@@ -1,7 +1,7 @@
 
 macro(add_kg_test name src)
   add_executable(${name} ${src})
-  target_link_libraries(${name} GTest::GTest GTest::Main kg)
+  target_link_libraries(${name} GTest::GTest GTest::Main kg psc)
   if (USE_GTEST_DISCOVER_TESTS)
     gtest_discover_tests(${name})
   else()

--- a/src/kg/testing/TestDFields.cu
+++ b/src/kg/testing/TestDFields.cu
@@ -29,7 +29,7 @@ void set_dfields(DFields d_flds)
 
 TEST(DFields, Ctor)
 {
-  thrust::device_vector<float> d_storage(6);
+  psc::device_vector<float> d_storage(6);
   
   auto d_flds = DFields{{{0, 0, 0}, {3, 2, 1}}, 1, thrust::raw_pointer_cast(d_storage.data())};
   //set_raw<<<1, 1>>>(d_flds.data());

--- a/src/libpsc/CMakeLists.txt
+++ b/src/libpsc/CMakeLists.txt
@@ -62,6 +62,10 @@ if (USE_CUDA)
   target_include_directories(psc PUBLIC cuda)
 endif()
 
+if (PSC_HAVE_RMM)
+  target_link_libraries(psc PUBLIC rapids::rmm)
+endif()
+
 if (USE_VPIC)
   add_library(VPIC::VPIC INTERFACE IMPORTED)
   set_target_properties(VPIC::VPIC PROPERTIES

--- a/src/libpsc/cuda/bnd_particles_cuda_impl.cu
+++ b/src/libpsc/cuda/bnd_particles_cuda_impl.cu
@@ -48,18 +48,18 @@ void BndParticlesCuda<Mparticles, DIM>::operator()(Mparticles& mprts)
     pr_B = prof_register("xchg_mprts_post", 1., 0, 0);
   }
   
-  prof_restart(pr_time_step_no_comm);
+  // prof_restart(pr_time_step_no_comm);
   prof_start(pr_A);
   auto&& bufs = cbndp_->prep(mprts.cmprts());
   prof_stop(pr_A);
   
   this->process_and_exchange(mprts, bufs);
   
-  prof_restart(pr_time_step_no_comm);
+  // prof_restart(pr_time_step_no_comm);
   prof_start(pr_B);
   cbndp_->post(mprts.cmprts());
   prof_stop(pr_B);
-  prof_stop(pr_time_step_no_comm);
+  // prof_stop(pr_time_step_no_comm);
 }
 
 template struct BndParticlesCuda<MparticlesCuda<BS144>, dim_yz>;

--- a/src/libpsc/cuda/cuda_base.cu
+++ b/src/libpsc/cuda/cuda_base.cu
@@ -1,4 +1,13 @@
 
+#include "PscConfig.h"
+
+#ifdef PSC_HAVE_RMM
+#include <rmm/mr/device/cnmem_memory_resource.hpp>
+#include <rmm/mr/device/cuda_memory_resource.hpp>
+#include <rmm/mr/device/default_memory_resource.hpp>
+#include <rmm/thrust_rmm_allocator.h>
+#endif
+
 #include <cstdio>
 #include <cassert>
 #include <cuda_bits.h>
@@ -12,6 +21,11 @@ cuda_base_init(void)
     return;
 
   first_time = false;
+
+#ifdef PSC_HAVE_RMM
+  static rmm::mr::cnmem_memory_resource pool_mr;
+  rmm::mr::set_default_resource(&pool_mr);
+#endif
 
   int deviceCount;
   cudaGetDeviceCount(&deviceCount);

--- a/src/libpsc/cuda/cuda_bits.h
+++ b/src/libpsc/cuda/cuda_bits.h
@@ -2,6 +2,27 @@
 #ifndef CUDA_BITS_H
 #define CUDA_BITS_H
 
+#include "PscConfig.h"
+
+#ifdef PSC_HAVE_RMM
+#include <rmm/thrust_rmm_allocator.h>
+
+namespace psc
+{
+template <typename T>
+using device_vector = rmm::device_vector<T>;
+}
+
+#else
+#include <thrust/device_vector.h>
+
+namespace psc
+{
+template <typename T>
+using device_vector = thrust::device_vector<T>;
+}
+#endif
+
 #define cudaCheck(ierr)                                                        \
   do {                                                                         \
     if (ierr != cudaSuccess) {                                                 \

--- a/src/libpsc/cuda/cuda_bnd.cuh
+++ b/src/libpsc/cuda/cuda_bnd.cuh
@@ -58,8 +58,8 @@ struct CudaBnd
       }
     }
 
-    void operator()(const thrust::device_vector<uint>& map,
-		    const thrust::device_vector<real_t>& buf, thrust::device_ptr<real_t> d_flds)
+    void operator()(const psc::device_vector<uint>& map,
+		    const psc::device_vector<real_t>& buf, thrust::device_ptr<real_t> d_flds)
     {
       if (buf.empty()) return;
       
@@ -78,8 +78,8 @@ struct CudaBnd
       thrust::scatter(buf.begin(), buf.end(), map.begin(), h_flds.begin());
     }
 
-    void operator()(const thrust::device_vector<uint>& map,
-		    const thrust::device_vector<real_t>& buf, thrust::device_ptr<real_t> d_flds)
+    void operator()(const psc::device_vector<uint>& map,
+		    const psc::device_vector<real_t>& buf, thrust::device_ptr<real_t> d_flds)
     {
 #if 1
       thrust::scatter(buf.begin(), buf.end(), map.begin(), d_flds);
@@ -149,11 +149,11 @@ struct CudaBnd
     thrust::host_vector<real_t> send_buf;
     thrust::host_vector<real_t> recv_buf;
 
-    thrust::device_vector<uint> d_recv, d_send;
-    thrust::device_vector<uint> d_local_recv, d_local_send;
-    thrust::device_vector<real_t> d_local_buf;
-    thrust::device_vector<real_t> d_send_buf;
-    thrust::device_vector<real_t> d_recv_buf;
+    psc::device_vector<uint> d_recv, d_send;
+    psc::device_vector<uint> d_local_recv, d_local_send;
+    psc::device_vector<real_t> d_local_buf;
+    psc::device_vector<real_t> d_send_buf;
+    psc::device_vector<real_t> d_recv_buf;
 
     mrc_ddc_pattern2* patt;
     int mb, me;

--- a/src/libpsc/cuda/cuda_bndp.cu
+++ b/src/libpsc/cuda/cuda_bndp.cu
@@ -347,8 +347,13 @@ void cuda_bndp<CudaMparticles, DIM>::post(CudaMparticles* _cmprts)
   cmprts.n_prts += n_prts_recv;
 
   thrust::sequence(cmprts.by_block_.d_id.begin(), cmprts.by_block_.d_id.end());
+#ifdef PSC_HAVE_RMM
+  thrust::stable_sort_by_key(rmm::exec_policy(0)->on(0), d_bidx.begin(),
+                             d_bidx.end(), cmprts.by_block_.d_id.begin());
+#else
   thrust::stable_sort_by_key(d_bidx.begin(), d_bidx.end(),
                              cmprts.by_block_.d_id.begin());
+#endif
 
   // drop the previously sent particles, which have been sorted to the end of
   // the array, now

--- a/src/libpsc/cuda/cuda_bndp.h
+++ b/src/libpsc/cuda/cuda_bndp.h
@@ -178,12 +178,12 @@ struct cuda_bndp<CudaMparticles, dim_yz>
   void scan_scatter_received_gold(CudaMparticles* cmprts, uint n_prts_recv);
   void update_offsets_gold(CudaMparticles* cmprts);
 
-  thrust::device_vector<uint> d_spine_cnts;
-  thrust::device_vector<uint> d_spine_sums;
+  psc::device_vector<uint> d_spine_cnts;
+  psc::device_vector<uint> d_spine_sums;
   uint n_prts_send;
-  thrust::device_vector<uint> d_bnd_off;
+  psc::device_vector<uint> d_bnd_off;
 
-  thrust::device_vector<uint>
+  psc::device_vector<uint>
     d_sums; // FIXME, should go away (only used in some gold stuff)
 
   BndBuffers bufs;

--- a/src/libpsc/cuda/cuda_mfields.h
+++ b/src/libpsc/cuda/cuda_mfields.h
@@ -2,6 +2,7 @@
 #ifndef CUDA_MFIELDS_H
 #define CUDA_MFIELDS_H
 
+#include "cuda_bits.h"
 #include "cuda_iface.h"
 #include "cuda_iface_bnd.h"
 #include "cuda_base.cuh"
@@ -38,7 +39,7 @@ struct cuda_mfields_bnd {
   int im[3];
   int ib[3];
   struct cuda_mfields_bnd_patch *bnd_by_patch;
-  thrust::device_vector<fields_cuda_real_t> d_buf;
+  psc::device_vector<fields_cuda_real_t> d_buf;
   thrust::host_vector<fields_cuda_real_t> h_buf;
   int *h_nei_patch;
   int *d_nei_patch;
@@ -105,7 +106,7 @@ using DFields = DMFields::fields_view_t;
 // ======================================================================
 // cuda_mfields
 
-using MfieldsStorageDeviceVector = thrust::device_vector<float>;
+using MfieldsStorageDeviceVector = psc::device_vector<float>;
 
 struct cuda_mfields : CudaMfields<MfieldsStorageDeviceVector>
 {

--- a/src/libpsc/cuda/cuda_mparticles.cu
+++ b/src/libpsc/cuda/cuda_mparticles.cu
@@ -145,9 +145,9 @@ k_reorder_and_offsets(DMparticlesCuda<BS> dmprts, int nr_prts,
 // reorder_and_offsets
 
 template<typename BS>
-void cuda_mparticles<BS>::reorder_and_offsets(const thrust::device_vector<uint>& d_idx,
-					      const thrust::device_vector<uint>& d_id,
-					      thrust::device_vector<uint>& d_off)
+void cuda_mparticles<BS>::reorder_and_offsets(const psc::device_vector<uint>& d_idx,
+					      const psc::device_vector<uint>& d_id,
+					      psc::device_vector<uint>& d_off)
 {
   if (this->n_patches() == 0) {
     return;
@@ -205,7 +205,7 @@ void cuda_mparticles<BS>::reorder()
 // reorder
 
 template<typename BS>
-void cuda_mparticles<BS>::reorder(const thrust::device_vector<uint>& d_id)
+void cuda_mparticles<BS>::reorder(const psc::device_vector<uint>& d_id)
 {
   if (this->n_prts == 0) {
     return;

--- a/src/libpsc/cuda/cuda_mparticles.cuh
+++ b/src/libpsc/cuda/cuda_mparticles.cuh
@@ -130,7 +130,7 @@ struct MparticlesCudaStorage_
 // ======================================================================
 // MparticlesCudaStorage
 
-using MparticlesCudaStorage = MparticlesCudaStorage_<thrust::device_vector<float4>>;
+using MparticlesCudaStorage = MparticlesCudaStorage_<psc::device_vector<float4>>;
 
 // ======================================================================
 // HMparticlesCudaStorage
@@ -242,9 +242,9 @@ private:
   
 public:
   void reorder();
-  void reorder(const thrust::device_vector<uint>& d_id);
-  void reorder_and_offsets(const thrust::device_vector<uint>& d_idx, const thrust::device_vector<uint>& d_id,
-			   thrust::device_vector<uint>& d_off);
+  void reorder(const psc::device_vector<uint>& d_id);
+  void reorder_and_offsets(const psc::device_vector<uint>& d_idx, const psc::device_vector<uint>& d_id,
+			   psc::device_vector<uint>& d_off);
   void reorder_and_offsets_slow();
   void swap_alt();
 

--- a/src/libpsc/cuda/cuda_mparticles_sort.cuh
+++ b/src/libpsc/cuda/cuda_mparticles_sort.cuh
@@ -43,8 +43,8 @@ __global__ static void k_find_cell_indices_ids(DMparticlesCuda<BS> dmprts,
 
 template <typename BS>
 inline void find_cell_indices_ids(cuda_mparticles<BS>& cmprts,
-                                  thrust::device_vector<uint>& d_cidx,
-                                  thrust::device_vector<uint>& d_id)
+                                  psc::device_vector<uint>& d_cidx,
+                                  psc::device_vector<uint>& d_id)
 {
   if (cmprts.n_patches() == 0) {
     return;
@@ -127,8 +127,8 @@ __global__ static void k_find_block_indices_ids(DMparticlesCuda<BS> dmprts,
 
 template <typename BS>
 inline void find_block_indices_ids(cuda_mparticles<BS>& cmprts,
-                                   thrust::device_vector<uint>& d_idx,
-                                   thrust::device_vector<uint>& d_id)
+                                   psc::device_vector<uint>& d_idx,
+                                   psc::device_vector<uint>& d_id)
 {
   if (cmprts.n_patches() == 0) {
     return;
@@ -199,9 +199,9 @@ struct cuda_mparticles_sort
   }
 
 public:
-  thrust::device_vector<uint> d_idx; // cell index (incl patch) per particle
-  thrust::device_vector<uint> d_id;  // particle id used for reordering
-  thrust::device_vector<uint>
+  psc::device_vector<uint> d_idx; // cell index (incl patch) per particle
+  psc::device_vector<uint> d_id;  // particle id used for reordering
+  psc::device_vector<uint>
     d_off; // particles per cell
            // are at indices [offsets[cell] .. offsets[cell+1][
 };
@@ -268,9 +268,9 @@ struct cuda_mparticles_randomize_sort
   }
 
 public:
-  thrust::device_vector<double> d_random_idx; // randomized cell index
-  thrust::device_vector<uint> d_id;          // particle id used for reordering
-  thrust::device_vector<uint>
+  psc::device_vector<double> d_random_idx; // randomized cell index
+  psc::device_vector<uint> d_id;          // particle id used for reordering
+  psc::device_vector<uint>
     d_off; // particles per cell
            // are at indices [offsets[cell] .. offsets[cell+1][
   RngStateCuda rng_state_;
@@ -325,9 +325,9 @@ struct cuda_mparticles_sort_by_block
   }
 
 public:
-  thrust::device_vector<uint> d_idx; // block index (incl patch) per particle
-  thrust::device_vector<uint> d_id;  // particle id used for reordering
-  thrust::device_vector<uint>
+  psc::device_vector<uint> d_idx; // block index (incl patch) per particle
+  psc::device_vector<uint> d_id;  // particle id used for reordering
+  psc::device_vector<uint>
     d_off; // particles per cell
            // are at indices [offsets[block] .. offsets[block+1][
 };

--- a/src/libpsc/cuda/rng_state.cuh
+++ b/src/libpsc/cuda/rng_state.cuh
@@ -85,7 +85,7 @@ public:
   int size() { return rngs_.size(); }
 
 private:
-  thrust::device_vector<Rng> rngs_;
+  psc::device_vector<Rng> rngs_;
 };
 
 // ----------------------------------------------------------------------

--- a/src/libpsc/tests/test_collision_cuda.cu
+++ b/src/libpsc/tests/test_collision_cuda.cu
@@ -45,7 +45,7 @@ TEST(RngStateCuda, access)
   RngStateCuda rng_state(dim_grid.x * THREADS_PER_BLOCK);
 
   ASSERT_EQ(THREADS_PER_BLOCK, 128);
-  thrust::device_vector<float> x(dim_grid.x * THREADS_PER_BLOCK);
+  psc::device_vector<float> x(dim_grid.x * THREADS_PER_BLOCK);
   kernel_random<<<dim_grid, THREADS_PER_BLOCK>>>(rng_state, x.data());
 
   float sum = thrust::reduce(x.begin(), x.end(), 0.f, thrust::plus<float>());

--- a/src/psc_flatfoil_yz.cxx
+++ b/src/psc_flatfoil_yz.cxx
@@ -10,14 +10,7 @@
 #include "../libpsc/psc_heating/psc_heating_impl.hxx"
 #include "heating_spot_foil.hxx"
 #include "inject_impl.hxx"
-#ifdef PSC_HAVE_RMM
-#include "rmm/thrust_rmm_allocator.h"
-#include "rmm/mr/device/default_memory_resource.hpp"
-#include "rmm/mr/device/cuda_memory_resource.hpp"
-#include "rmm/mr/device/cnmem_memory_resource.hpp"
-rmm::mr::cnmem_memory_resource* pool_mr;
 
-#endif
 #define DIM_3D
 
 // ======================================================================
@@ -520,10 +513,7 @@ void run()
 int main(int argc, char** argv)
 {
   psc_init(argc, argv);
-#ifdef PSC_HAVE_RMM
-  pool_mr = new rmm::mr::cnmem_memory_resource{(1<<30)}; 
-  rmm::mr::set_default_resource(pool_mr);
-#endif
+
   run();
 
   psc_finalize();

--- a/src/psc_flatfoil_yz.cxx
+++ b/src/psc_flatfoil_yz.cxx
@@ -10,7 +10,14 @@
 #include "../libpsc/psc_heating/psc_heating_impl.hxx"
 #include "heating_spot_foil.hxx"
 #include "inject_impl.hxx"
+#ifdef PSC_HAVE_RMM
+#include "rmm/thrust_rmm_allocator.h"
+#include "rmm/mr/device/default_memory_resource.hpp"
+#include "rmm/mr/device/cuda_memory_resource.hpp"
+#include "rmm/mr/device/cnmem_memory_resource.hpp"
+rmm::mr::cnmem_memory_resource* pool_mr;
 
+#endif
 #define DIM_3D
 
 // ======================================================================
@@ -513,7 +520,10 @@ void run()
 int main(int argc, char** argv)
 {
   psc_init(argc, argv);
-
+#ifdef PSC_HAVE_RMM
+  pool_mr = new rmm::mr::cnmem_memory_resource{(1<<30)}; 
+  rmm::mr::set_default_resource(pool_mr);
+#endif
   run();
 
   psc_finalize();

--- a/src/tests/thrust1.cu
+++ b/src/tests/thrust1.cu
@@ -16,7 +16,7 @@ main(void)
   // resize H
   H.resize(2); std::cout << "H now has size " << H.size() << std::endl;
   // Copy host_vector H to device_vector D
-  thrust::device_vector<int> D = H;
+  psc::device_vector<int> D = H;
   // elements of D can be modified
   D[0] = 99; D[1] = 88;
   // print contents of D


### PR DESCRIPTION
This PR uses a RMM pool allocator to avoid frequent expensive cudaMalloc/cudaFree calls.

Also adds some more detailed profile markers.