### PR TITLE
optimize particle injection

### DIFF
--- a/src/include/inject_impl.hxx
+++ b/src/include/inject_impl.hxx
@@ -57,11 +57,11 @@ struct Inject_ : InjectBase
     prof_stop(pr_1);
     
     prof_start(pr_2);
-    auto mres = evalMfields(moment_n_);
+    auto mf_n = evalMfields(moment_n_);
     prof_stop(pr_2);
     
     prof_start(pr_3);
-    auto& mf_n = mres.template get_as<Mfields>(kind_n, kind_n + 1);
+    //auto& mf_n = mres.template get_as<Mfields>(kind_n, kind_n + 1);
     prof_stop(pr_3);
     
     real_t fac = (interval * grid.dt / tau) / (1. + interval * grid.dt / tau);
@@ -82,7 +82,7 @@ struct Inject_ : InjectBase
     setup_particles_.setupParticles(mprts, lf_init_npt);
     prof_stop(pr_4);
     
-    mres.put_as(mf_n, 0, 0);
+    //mres.put_as(mf_n, 0, 0);
     prof_stop(pr);
   }
 

--- a/src/include/inject_impl.hxx
+++ b/src/include/inject_impl.hxx
@@ -29,6 +29,7 @@ struct Inject_ : InjectBase
           Target_t target, SetupParticles& setup_particles)
     : InjectBase{interval, tau, kind_n},
       target_{target},
+      moment_n_{grid},
       setup_particles_{setup_particles}
   {}
 
@@ -52,11 +53,11 @@ struct Inject_ : InjectBase
     prof_barrier("inject_barrier");
 
     prof_start(pr_1);
-    ItemMoment_t moment_n(mprts);
+    moment_n_.update(mprts);
     prof_stop(pr_1);
     
     prof_start(pr_2);
-    auto mres = evalMfields(moment_n);
+    auto mres = evalMfields(moment_n_);
     prof_stop(pr_2);
     
     prof_start(pr_3);
@@ -87,6 +88,7 @@ struct Inject_ : InjectBase
 
 private:
   Target_t target_;
+  ItemMoment_t moment_n_;
   SetupParticles setup_particles_;
 };
 

--- a/src/include/injector_simple.hxx
+++ b/src/include/injector_simple.hxx
@@ -51,6 +51,9 @@ struct InjectorSimple
     : mprts_{mprts}
   {}
 
+  void reserve(int n_prts_total)
+  {}
+
   Patch operator[](int p) const { return {mprts_, p}; }
 
 private:

--- a/src/include/setup_particles.hxx
+++ b/src/include/setup_particles.hxx
@@ -107,11 +107,23 @@ struct SetupParticles
   template <typename FUNC>
   void setupParticles(Mparticles& mprts, FUNC init_npt)
   {
+    static int pr, pr_0, pr_1;
+    if (!pr) {
+      pr = prof_register("setupp", 1., 0, 0);
+      pr_0 = prof_register("setupp 0", 1., 0, 0);
+      pr_1 = prof_register("setupp 1", 1., 0, 0);
+    }
+
+    prof_start(pr);
     const auto& grid = mprts.grid();
 
     // mprts.reserve_all(n_prts_by_patch); FIXME
 
+    prof_start(pr_0);
     auto inj = mprts.injector();
+    prof_stop(pr_0);
+
+    prof_start(pr_1);
     for (int p = 0; p < mprts.n_patches(); ++p) {
       auto ldims = grid.ldims;
       auto injector = inj[p];
@@ -163,6 +175,9 @@ struct SetupParticles
         }
       }
     }
+    prof_stop(pr_1);
+
+    prof_stop(pr);
   }
 
   // ----------------------------------------------------------------------

--- a/src/include/setup_particles.hxx
+++ b/src/include/setup_particles.hxx
@@ -95,7 +95,7 @@ struct SetupParticles
   // setup_particles
 
   template <typename FUNC>
-  void operator()(Mparticles& mprts, FUNC init_npt)
+  void operator()(Mparticles& mprts, FUNC&& init_npt)
   {
     setupParticles(mprts, [&](int kind, Double3 pos, int p, Int3 idx,
                               psc_particle_npt& npt) { init_npt(kind, pos, npt); });
@@ -105,7 +105,7 @@ struct SetupParticles
   // setupParticles
 
   template <typename FUNC>
-  void setupParticles(Mparticles& mprts, FUNC init_npt)
+  void setupParticles(Mparticles& mprts, FUNC&& init_npt)
   {
     static int pr, pr_0, pr_1, pr_2, pr_3;
     if (!pr) {
@@ -236,7 +236,7 @@ struct SetupParticles
   // partition
 
   template <typename FUNC>
-  std::vector<uint> partition(const Grid_t& grid, FUNC init_npt)
+  std::vector<uint> partition(const Grid_t& grid, FUNC&& init_npt)
   {
     std::vector<uint> n_prts_by_patch(grid.n_patches());
 

--- a/src/include/setup_particles.hxx
+++ b/src/include/setup_particles.hxx
@@ -34,6 +34,9 @@ struct SetupParticles
 
   int get_n_in_cell(const psc_particle_npt& npt)
   {
+    if (npt.n == 0) {
+      return 0;
+    }
     if (fractional_n_particles_per_cell) {
       int n_prts = npt.n / norm_.cori;
       float rmndr = npt.n / norm_.cori - n_prts;

--- a/src/include/setup_particles.hxx
+++ b/src/include/setup_particles.hxx
@@ -110,13 +110,9 @@ struct SetupParticles
   template <typename FUNC>
   void setupParticles(Mparticles& mprts, FUNC&& init_npt)
   {
-    static int pr, pr_0, pr_1, pr_2, pr_3;
+    static int pr;
     if (!pr) {
       pr = prof_register("setupp", 1., 0, 0);
-      pr_0 = prof_register("setupp 0", 1., 0, 0);
-      pr_1 = prof_register("setupp 1", 1., 0, 0);
-      pr_2 = prof_register("setupp 2", 1., 0, 0);
-      pr_3 = prof_register("setupp 3", 1., 0, 0);
     }
 
     prof_start(pr);
@@ -124,61 +120,8 @@ struct SetupParticles
 
     // mprts.reserve_all(n_prts_by_patch); FIXME
 
-    prof_start(pr_0);
     auto inj = mprts.injector();
-    prof_stop(pr_0);
 
-    prof_start(pr_1);
-    int n_prts_total = 0;
-    for (int p = 0; p < mprts.n_patches(); ++p) {
-      auto ldims = grid.ldims;
-
-      for (int jz = 0; jz < ldims[2]; jz++) {
-        for (int jy = 0; jy < ldims[1]; jy++) {
-          for (int jx = 0; jx < ldims[0]; jx++) {
-            Double3 pos = {grid.patches[p].x_cc(jx), grid.patches[p].y_cc(jy),
-                           grid.patches[p].z_cc(jz)};
-            // FIXME, the issue really is that (2nd order) particle pushers
-            // don't handle the invariant dim right
-            if (grid.isInvar(0) == 1)
-              pos[0] = grid.patches[p].x_nc(jx);
-            if (grid.isInvar(1) == 1)
-              pos[1] = grid.patches[p].y_nc(jy);
-            if (grid.isInvar(2) == 1)
-              pos[2] = grid.patches[p].z_nc(jz);
-
-            int n_q_in_cell = 0;
-            for (int pop = 0; pop < n_populations_; pop++) {
-              psc_particle_npt npt{};
-              if (pop < kinds_.size()) {
-                npt.kind = pop;
-              }
-              init_npt(pop, pos, p, {jx, jy, jz}, npt);
-
-              int n_in_cell;
-              if (pop != neutralizing_population) {
-                n_in_cell = get_n_in_cell(npt);
-                n_q_in_cell += kinds_[npt.kind].q * n_in_cell;
-              } else {
-                // FIXME, should handle the case where not the last population
-                // is neutralizing
-                assert(neutralizing_population == n_populations_ - 1);
-                n_in_cell = -n_q_in_cell / kinds_[npt.kind].q;
-              }
-	      n_prts_total += n_in_cell;
-            }
-          }
-        }
-      }
-    }
-    prof_stop(pr_1);
-
-    mprintf("n_prts_total %d\n", n_prts_total);
-    prof_start(pr_2);
-    inj.reserve(n_prts_total * 1.2);
-    prof_stop(pr_2);
-
-    prof_start(pr_3);
     for (int p = 0; p < mprts.n_patches(); ++p) {
       auto ldims = grid.ldims;
       auto injector = inj[p];
@@ -230,7 +173,6 @@ struct SetupParticles
         }
       }
     }
-    prof_stop(pr_3);
 
     prof_stop(pr);
   }

--- a/src/libpsc/cuda/fields_item_moments_1st_cuda.hxx
+++ b/src/libpsc/cuda/fields_item_moments_1st_cuda.hxx
@@ -75,9 +75,18 @@ public:
   int n_comps() const { return Base::mres_.n_comps(); }
   Int3 ibn() const { return Base::mres_.ibn(); }
 
+  explicit Moment_n_1st_cuda(const Grid_t& grid)
+    : Base{grid}, bnd_{grid, grid.ibn}
+  {}
+  
   explicit Moment_n_1st_cuda(const Mparticles& mprts)
     : Base{mprts.grid()},
       bnd_{mprts.grid(), mprts.grid().ibn}
+  {
+    update(mprts);
+  }
+
+  void update(const Mparticles& mprts)
   {
     static int pr, pr_1, pr_2;
     if (!pr) {

--- a/src/libpsc/cuda/injector_buffered.hxx
+++ b/src/libpsc/cuda/injector_buffered.hxx
@@ -65,6 +65,11 @@ struct InjectorBuffered
     mprts_.inject(buf_, n_prts_by_patch_);
   }
 
+  void reserve(int n_prts_total)
+  {
+    buf_.reserve(n_prts_total);
+  }
+
   Patch operator[](int p)
   {
     // ensure that we inject particles into patches in ascending order

--- a/src/libpsc/cuda/injector_buffered.hxx
+++ b/src/libpsc/cuda/injector_buffered.hxx
@@ -38,7 +38,8 @@ struct InjectorBuffered
       auto x = Double3::fromPointer(new_prt.x) - patch.xb;
       auto u = Double3::fromPointer(new_prt.u);
       real_t q = mprts.grid().kinds[new_prt.kind].q;
-      raw(Particle{Real3(x), Real3(u), q * real_t(new_prt.w), new_prt.kind, mprts.uid_gen(), new_prt.tag});
+      injector_.buf_.push_back({Real3(x), Real3(u), q * real_t(new_prt.w), new_prt.kind, mprts.uid_gen(), new_prt.tag});
+      n_prts_++;
     }
 
     // FIXME do we want to keep this? or just have a psc::particle::Inject version instead?

--- a/src/libpsc/psc_output_fields/fields_item_fields.hxx
+++ b/src/libpsc/psc_output_fields/fields_item_fields.hxx
@@ -53,6 +53,12 @@ template <typename E,
           typename std::enable_if<isSpaceCuda<E>::value, int>::type = 0>
 inline MfieldsC evalMfields(const MFexpression<E>& xp)
 {
+  static int pr;
+  if (!pr) {
+    pr = prof_register("evalMfields cuda", 1., 0, 0);
+  }
+
+  prof_start(pr);
   const auto& exp = xp.derived().result();
   MfieldsC mflds{exp.grid(), exp.n_comps(), exp.ibn()};
 
@@ -67,6 +73,7 @@ inline MfieldsC evalMfields(const MFexpression<E>& xp)
       });
     }
   }
+  prof_stop(pr);
   return mflds;
 }
 

--- a/src/libpsc/psc_output_fields/fields_item_fields.hxx
+++ b/src/libpsc/psc_output_fields/fields_item_fields.hxx
@@ -53,18 +53,30 @@ template <typename E,
           typename std::enable_if<isSpaceCuda<E>::value, int>::type = 0>
 inline MfieldsC evalMfields(const MFexpression<E>& xp)
 {
-  static int pr;
+  static int pr, pr_0, pr_1, pr_2, pr_3;
   if (!pr) {
     pr = prof_register("evalMfields cuda", 1., 0, 0);
+    pr_0 = prof_register("evalMfields h", 1., 0, 0);
+    pr_1 = prof_register("evalMfields hm", 1., 0, 0);
+    pr_2 = prof_register("evalMfields dh", 1., 0, 0);
+    pr_3 = prof_register("evalMfields hh", 1., 0, 0);
   }
 
   prof_start(pr);
   const auto& exp = xp.derived().result();
+  prof_start(pr_0);
   MfieldsC mflds{exp.grid(), exp.n_comps(), exp.ibn()};
+  prof_stop(pr_1);
 
+  prof_start(pr_1);
   auto h_exp = hostMirror(exp);
-  copy(exp, h_exp);
+  prof_stop(pr_1);
 
+  prof_start(pr_2);
+  copy(exp, h_exp);
+  prof_stop(pr_2);
+
+  prof_start(pr_3);
   for (int p = 0; p < mflds.n_patches(); p++) {
     auto flds = mflds[p];
     for (int m = 0; m < exp.n_comps(); m++) {
@@ -73,6 +85,7 @@ inline MfieldsC evalMfields(const MFexpression<E>& xp)
       });
     }
   }
+  prof_stop(pr_3);
   prof_stop(pr);
   return mflds;
 }

--- a/src/libpsc/psc_output_fields/fields_item_fields.hxx
+++ b/src/libpsc/psc_output_fields/fields_item_fields.hxx
@@ -51,7 +51,7 @@ inline const MfieldsC& evalMfields(const MfieldsC& mflds) { return mflds; }
 
 template <typename E,
           typename std::enable_if<isSpaceCuda<E>::value, int>::type = 0>
-inline MfieldsC evalMfields(const MFexpression<E>& xp)
+inline HMFields evalMfields(const MFexpression<E>& xp)
 {
   static int pr, pr_0, pr_1, pr_2, pr_3;
   if (!pr) {
@@ -64,9 +64,6 @@ inline MfieldsC evalMfields(const MFexpression<E>& xp)
 
   prof_start(pr);
   const auto& exp = xp.derived().result();
-  prof_start(pr_0);
-  MfieldsC mflds{exp.grid(), exp.n_comps(), exp.ibn()};
-  prof_stop(pr_1);
 
   prof_start(pr_1);
   auto h_exp = hostMirror(exp);
@@ -76,18 +73,8 @@ inline MfieldsC evalMfields(const MFexpression<E>& xp)
   copy(exp, h_exp);
   prof_stop(pr_2);
 
-  prof_start(pr_3);
-  for (int p = 0; p < mflds.n_patches(); p++) {
-    auto flds = mflds[p];
-    for (int m = 0; m < exp.n_comps(); m++) {
-      mflds.Foreach_3d(0, 0, [&](int i, int j, int k) {
-        flds(m, i, j, k) = h_exp[p](m, i, j, k);
-      });
-    }
-  }
-  prof_stop(pr_3);
   prof_stop(pr);
-  return mflds;
+  return h_exp;
 }
 
 inline MfieldsC evalMfields(const MfieldsCuda& mf)

--- a/src/libpsc/psc_output_fields/fields_item_moments_1st.hxx
+++ b/src/libpsc/psc_output_fields/fields_item_moments_1st.hxx
@@ -43,6 +43,8 @@ public:
   int n_comps() const { return Base::mres_.n_comps(); }
   Int3 ibn() const { return Base::mres_.ibn(); }
 
+  explicit Moment_n_1st(const Grid_t& grid) : Base{grid} {}
+
   explicit Moment_n_1st(const Mparticles& mprts) : Base{mprts.grid()}
   {
     update(mprts);
@@ -371,4 +373,3 @@ public:
 };
 
 #endif
-

--- a/src/libpsc/psc_output_fields/fields_item_moments_1st.hxx
+++ b/src/libpsc/psc_output_fields/fields_item_moments_1st.hxx
@@ -45,6 +45,11 @@ public:
 
   explicit Moment_n_1st(const Mparticles& mprts) : Base{mprts.grid()}
   {
+    update(mprts);
+  }
+
+  void update(const Mparticles& mprts)
+  {
     using Particle = typename Mparticles::ConstAccessor::Particle;
 
     auto deposit = Deposit1stCc<Mparticles, Mfields>{mprts, Base::mres_};

--- a/src/psc_flatfoil_yz.cxx
+++ b/src/psc_flatfoil_yz.cxx
@@ -292,7 +292,7 @@ void initializeParticles(SetupParticles<Mparticles>& setup_particles,
   // -- set particle initial condition
   partitionAndSetupParticles(
     setup_particles, balance, grid_ptr, mprts,
-    [&](int kind, double crd[3], psc_particle_npt& npt) {
+    [&](int kind, Double3 crd, psc_particle_npt& npt) {
       switch (kind) {
         case MY_ION:
           npt.n = g.background_n;


### PR DESCRIPTION
* avoid recreating the moments object at every injection, which caused the recreation of the boundary exchange, too, which
is somewhat costly.
* avoid some unnecessary copies when moving moments from GPU memory to host
