### PR TITLE
properly set the next write-out flag after restart.  

### DIFF
--- a/src/include/OutputFieldsDefault.h
+++ b/src/include/OutputFieldsDefault.h
@@ -129,6 +129,10 @@ public:
     if(first_time){
         first_time = false;
         if(timestep != 0)
+            pfield_next_ = timestep + pfield_interval;
+            tfield_next_ = timestep + tfield_interval;
+            pfield_moments_next_ = timestep + pfield_moments_interval;
+            tfield_moments_next_ = timestep + tfield_moments_interval;
             return;
     }
 


### PR DESCRIPTION
without setting `fld_next_` flds are written out at each "average every" interval