### PR TITLE
Pr/inject species ratio

### DIFF
--- a/src/include/inject.hxx
+++ b/src/include/inject.hxx
@@ -11,12 +11,12 @@
 
 struct InjectBase
 {
-  InjectBase(int interval, int tau)
-    : interval(interval), tau(tau)
+
+  InjectBase(int interval)
+    : interval(interval)
   {}
 
   // param
   const int interval; // inject every so many steps
-  const int tau; // in steps
 };
 

--- a/src/include/inject.hxx
+++ b/src/include/inject.hxx
@@ -11,13 +11,12 @@
 
 struct InjectBase
 {
-  InjectBase(int interval, int tau, int kind_n)
-    : interval(interval), tau(tau), kind_n(kind_n)
+  InjectBase(int interval, int tau)
+    : interval(interval), tau(tau)
   {}
 
   // param
   const int interval; // inject every so many steps
   const int tau; // in steps
-  const int kind_n; // the number of particles to inject are based on this kind's density
 };
 

--- a/src/include/inject_impl.hxx
+++ b/src/include/inject_impl.hxx
@@ -24,7 +24,7 @@ struct Inject_ : InjectBase
 #ifdef USE_CUDA
   using MFields = HMFields;  
 #else
-  using MFields = MFieldsC;
+  using MFields = MfieldsC;
 #endif
 
   // ----------------------------------------------------------------------
@@ -82,7 +82,7 @@ struct Inject_ : InjectBase
 private:
   ItemMoment_t moment_n_;
   SetupParticles setup_particles_;
-  std::function<void (int, Double3, int, Int3,  psc_particle_npt&, MFields)> init_npt_;
+  std::function<void (int, Double3, int, Int3,  psc_particle_npt&, MFields&)> init_npt_;
 };
 
 // ======================================================================

--- a/src/include/inject_impl.hxx
+++ b/src/include/inject_impl.hxx
@@ -25,9 +25,9 @@ struct Inject_ : InjectBase
   // ----------------------------------------------------------------------
   // ctor
 
-  Inject_(const Grid_t& grid, int interval, int tau, int kind_n,
+  Inject_(const Grid_t& grid, int interval, int tau,
           Target_t target, SetupParticles& setup_particles)
-    : InjectBase{interval, tau, kind_n},
+    : InjectBase{interval, tau},
       target_{target},
       moment_n_{grid},
       setup_particles_{setup_particles}
@@ -70,7 +70,7 @@ struct Inject_ : InjectBase
                            psc_particle_npt& npt) {
       if (target_.is_inside(pos)) {
         target_.init_npt(kind, pos, npt);
-        npt.n -= mf_n[p](kind_n, idx[0], idx[1], idx[2]);
+        npt.n -= mf_n[p](kind, idx[0], idx[1], idx[2]);
         if (npt.n < 0) {
           npt.n = 0;
         }

--- a/src/include/setup_particles.hxx
+++ b/src/include/setup_particles.hxx
@@ -146,7 +146,12 @@ struct SetupParticles
               if (pop < kinds_.size()) {
                 npt.kind = pop;
               }
-              init_npt(pop, pos, p, {jx, jy, jz}, npt);
+              if(pop == HE_population){
+                init_npt(non_neutralizing_population, pos, p, {jx, jy, jz}, npt);
+                npt.n *= HE_ratio;
+              }else
+                //should electrons inject by moments and then scale to (1-HE_ratio)?
+                init_npt(pop, pos, p, {jx, jy, jz}, npt);
 
               int n_in_cell;
               if (pop != neutralizing_population) {
@@ -235,6 +240,9 @@ struct SetupParticles
   int neutralizing_population = {-1};
   bool fractional_n_particles_per_cell = {false};
   bool initial_momentum_gamma_correction = {false};
+  int non_neutralizing_population = 0;
+  int HE_population = -1;
+  float HE_ratio = 0.0;;
 
 private:
   const Grid_t::Kinds kinds_;

--- a/src/include/setup_particles.hxx
+++ b/src/include/setup_particles.hxx
@@ -146,12 +146,7 @@ struct SetupParticles
               if (pop < kinds_.size()) {
                 npt.kind = pop;
               }
-              if(pop == HE_population){
-                init_npt(non_neutralizing_population, pos, p, {jx, jy, jz}, npt);
-                npt.n *= HE_ratio;
-              }else
-                //should electrons inject by moments and then scale to (1-HE_ratio)?
-                init_npt(pop, pos, p, {jx, jy, jz}, npt);
+              init_npt(pop, pos, p, {jx, jy, jz}, npt);
 
               int n_in_cell;
               if (pop != neutralizing_population) {
@@ -240,9 +235,6 @@ struct SetupParticles
   int neutralizing_population = {-1};
   bool fractional_n_particles_per_cell = {false};
   bool initial_momentum_gamma_correction = {false};
-  int non_neutralizing_population = 0;
-  int HE_population = -1;
-  float HE_ratio = 0.0;;
 
 private:
   const Grid_t::Kinds kinds_;

--- a/src/libpsc/tests/test_inject.cxx
+++ b/src/libpsc/tests/test_inject.cxx
@@ -99,7 +99,7 @@ TYPED_TEST(InjectTest, Test1)
   const int inject_tau = 10;
   auto target = InjectTestTarget{};
   auto setup_particles = SetupParticles<Mparticles>{grid};
-  Inject inject{grid, inject_interval, inject_tau, 0, target, setup_particles}; // FIXME, can't use "auto inject = Inject{...}", though I want to
+  Inject inject{grid, inject_interval, inject_tau, target, setup_particles}; // FIXME, can't use "auto inject = Inject{...}", though I want to
 
   // let's start with no particles
   Mparticles mprts{grid};

--- a/src/libpsc/tests/test_inject.cxx
+++ b/src/libpsc/tests/test_inject.cxx
@@ -99,7 +99,7 @@ TYPED_TEST(InjectTest, Test1)
   const int inject_tau = 10;
   auto target = InjectTestTarget{};
   auto setup_particles = SetupParticles<Mparticles>{grid};
-  Inject inject{grid, inject_interval, inject_tau, target, setup_particles, 1, 0, 0.0}; // FIXME, can't use "auto inject = Inject{...}", though I want to
+  Inject inject{grid, inject_interval, inject_tau, target, setup_particles, 1, -1, 0.0}; // FIXME, can't use "auto inject = Inject{...}", though I want to
 
   // let's start with no particles
   Mparticles mprts{grid};

--- a/src/libpsc/tests/test_inject.cxx
+++ b/src/libpsc/tests/test_inject.cxx
@@ -99,7 +99,7 @@ TYPED_TEST(InjectTest, Test1)
   const int inject_tau = 10;
   auto target = InjectTestTarget{};
   auto setup_particles = SetupParticles<Mparticles>{grid};
-  Inject inject{grid, inject_interval, inject_tau, target, setup_particles}; // FIXME, can't use "auto inject = Inject{...}", though I want to
+  Inject inject{grid, inject_interval, inject_tau, target, setup_particles, 1, 0, 0.0}; // FIXME, can't use "auto inject = Inject{...}", though I want to
 
   // let's start with no particles
   Mparticles mprts{grid};

--- a/src/psc_flatfoil_yz.cxx
+++ b/src/psc_flatfoil_yz.cxx
@@ -477,12 +477,10 @@ void run()
   SetupParticles<Mparticles> setup_particles(grid);
   setup_particles.fractional_n_particles_per_cell = true;
   setup_particles.neutralizing_population = MY_ION;
-  setup_particles.HE_population = MY_ELECTRON_HE;
-  setup_particles.non_neutralizing_population = MY_ELECTRON;
-  setup_particles.HE_ratio = g.electron_HE_ratio;
 
-  Inject inject{grid,        g.inject_interval, inject_tau,
-                inject_target,     setup_particles};
+  Inject inject{grid, g.inject_interval, inject_tau,
+                inject_target, setup_particles,
+                MY_ELECTRON, MY_ELECTRON_HE, g.electron_HE_ratio};
 
   auto lf_inject = [&](const Grid_t& grid, Mparticles& mprts) {
     static int pr_inject, pr_heating;

--- a/src/psc_flatfoil_yz.cxx
+++ b/src/psc_flatfoil_yz.cxx
@@ -11,7 +11,7 @@
 #include "heating_spot_foil.hxx"
 #include "inject_impl.hxx"
 
-#define DIM_3D
+//#define DIM_3D
 
 // ======================================================================
 // Particle kinds
@@ -477,9 +477,12 @@ void run()
   SetupParticles<Mparticles> setup_particles(grid);
   setup_particles.fractional_n_particles_per_cell = true;
   setup_particles.neutralizing_population = MY_ION;
+  setup_particles.HE_population = MY_ELECTRON_HE;
+  setup_particles.non_neutralizing_population = MY_ELECTRON;
+  setup_particles.HE_ratio = g.electron_HE_ratio;
 
   Inject inject{grid,        g.inject_interval, inject_tau,
-                MY_ELECTRON, inject_target,     setup_particles};
+                inject_target,     setup_particles};
 
   auto lf_inject = [&](const Grid_t& grid, Mparticles& mprts) {
     static int pr_inject, pr_heating;

--- a/src/psc_flatfoil_yz.cxx
+++ b/src/psc_flatfoil_yz.cxx
@@ -486,11 +486,12 @@ void run()
 #ifdef USE_CUDA
   using MFields = HMFields;  
 #else
-  using MFields = MFieldsC;
+  using MFields = MfieldsC;
 #endif
   double fac = (g.inject_interval * grid.dt / inject_tau) / (1. + g.inject_interval * grid.dt / inject_tau);
-  auto lf_init_npt = [&](int kind, Double3 pos, int p, Int3 idx,
-                         psc_particle_npt& npt, MFields mf_n) {
+  auto lf_init_npt = [&fac, &inject_target](int kind, Double3 pos, int p, Int3 idx,
+                         psc_particle_npt& npt, MFields& mf_n) {
+
     if (inject_target.is_inside(pos)) {
   
       if(kind == MY_ELECTRON_HE){


### PR DESCRIPTION
I'm not sure if you have other ideas for this implementation? this method maintains the correct electron_he/electron ratio, but maybe there is a cleaner way?  Specifically I don't know if we should scale according to note on line 153 in `setup_particles.hxx`