### PR TITLE
fix a leak in balancing

### DIFF
--- a/src/libpsc/psc_balance/psc_balance_impl.hxx
+++ b/src/libpsc/psc_balance/psc_balance_impl.hxx
@@ -863,17 +863,17 @@ private:
 
     auto loads_all = gather_loads(*old_grid, loads);
     int n_patches_new = find_best_mapping(*old_grid, loads_all);
+    prof_stop(pr_bal_load);
+
+    if (n_patches_new < 0) { // unchanged mapping, nothing tbd
+      mpi_printf(old_grid->comm(), "***** Balance: decomposition unchanged\n");
+      return n_prts_by_patch_old;
+    }
 
     auto new_grid = new Grid_t{old_grid->domain, old_grid->bc, old_grid->kinds,
                                old_grid->norm,   old_grid->dt, n_patches_new};
     new_grid->ibn = old_grid->ibn; // FIXME, sucky ibn handling...
     new_grid->timestep_ = old_grid->timestep_;
-
-    prof_stop(pr_bal_load);
-    if (n_patches_new < 0) { // unchanged mapping, nothing tbd
-      mpi_printf(old_grid->comm(), "***** Balance: decomposition unchanged\n");
-      return n_prts_by_patch_old;
-    }
 
     mpi_printf(old_grid->comm(),
                "***** Balance: new decomposition: balancing\n");


### PR DESCRIPTION
If the decomposition is unchanged, we exit the balancing early since
there's nothing to do, but we did leak the new Grid in this case --
which memory-wise is not much, but this also leaked communicators, which
does cause trouble.