### PR TITLE
update thrust used in psc to 1.10.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,6 +40,9 @@ if(USE_CUDA)
   enable_language(CUDA)
 
   set(CMAKE_CUDA_FLAGS "${_save_CMAKE_CUDA_FLAGS}")
+
+  find_package(Thrust 1.10.0 REQUIRED)
+  thrust_create_target(Thrust)
 endif()
 
 set(MPI_CXX_SKIP_MPICXX ON)

--- a/spack/psc/packages/psc/package.py
+++ b/spack/psc/packages/psc/package.py
@@ -33,10 +33,13 @@ class Psc(CMakePackage):
     depends_on('hdf5@1.8.0:1.8.999 +hl')
     depends_on('adios2@2.4.0:', when='+adios2')
     depends_on('cuda', when='+cuda')
+    depends_on('thrust@1.10.0:', when='+cuda')
     depends_on('cuda', when='+nvtx')
     depends_on('rmm', when='+rmm')
 
     def cmake_args(self):
+        spec = self.spec
+        
         args = []
         args += ['-DUSE_CUDA={}'.format(
             'ON' if '+cuda' in self.spec else 'OFF')]
@@ -46,5 +49,6 @@ class Psc(CMakePackage):
             'ON' if '+rmm' in self.spec else 'OFF')]
         args += ['-DBUILD_TESTING={}'.format(
             'ON' if '+tests' in self.spec else 'OFF')]
+        args += ['-DThrust_DIR={}/include/thrust/cmake'.format(spec['thrust'].prefix)]
 
         return args

--- a/spack/psc/packages/thrust/package.py
+++ b/spack/psc/packages/thrust/package.py
@@ -1,0 +1,32 @@
+# Copyright 2013-2020 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack import *
+
+
+class Thrust(CMakePackage):
+    """Thrust is a parallel algorithms library
+    which resembles the C++ Standard Template Library (STL)."""
+
+    homepage = "https://thrust.github.io"
+    url      = "https://github.com/NVIDIA/thrust/archive/1.10.0.tar.gz"
+    git      = "https://github.com/NVIDIA/thrust"
+
+    version('1.10.0', tag='1.10.0', submodules=True)
+    version('1.9.10', sha256='5071c995a03e97e2bcfe0c5cc265330160316733336bb87dfcea3fc381065316')
+    version('1.9.9', sha256='74740b94e0c62e1e54f9880cf1eeb2d0bfb2203ae35fd72ece608f9b8e073ef7')
+    version('1.9.8', sha256='d014396a2128417bd1421ba80d2601422577094c0ff727c60bd3c6eb4856af9b')
+    version('1.9.7', sha256='72519f7f6b5d28953e5086253bbcf5b10decde913ddeb93872dc51522bdfad2b')
+    version('1.9.6', sha256='67e937c31d279cec9ad2c54a4f66e479dfbe506ceb0253f611a54323fb4c1cfb')
+    version('1.9.5', sha256='d155dc2a260fe0c75c63c185fa4c4b4c6c5b7c444fcdac7109bb71941c9603f1')
+    version('1.9.4', sha256='41931a7d73331fc39c6bea56d1eb8d4d8bbf7c73688979bbdab0e55772f538d1')
+    version('1.9.3', sha256='92482ad0219cd2d727766f42a4fc952d7c5fd0183c5e201d9a117568387b4fd1')
+    version('1.9.2', sha256='1fb1272be9e8c28973f5c39eb230d1914375ef38bcaacf09a3fa51c6b710b756')
+    version('1.9.1', sha256='7cf59bf42a7b05bc6799c88269bf41eb637ca2897726a5ade334a1b8b4579ef1')
+    version('1.9.0', sha256='a98cf59fc145dd161471291d4816f399b809eb0db2f7085acc7e3ebc06558b37')
+    version('1.8.2', sha256='83bc9e7b769daa04324c986eeaf48fcb53c2dda26bcc77cb3c07f4b1c359feb8')
+    
+    def build(self, spec, prefix):
+        pass

--- a/spack/psc/packages/thrust/package.py
+++ b/spack/psc/packages/thrust/package.py
@@ -27,6 +27,13 @@ class Thrust(CMakePackage):
     version('1.9.1', sha256='7cf59bf42a7b05bc6799c88269bf41eb637ca2897726a5ade334a1b8b4579ef1')
     version('1.9.0', sha256='a98cf59fc145dd161471291d4816f399b809eb0db2f7085acc7e3ebc06558b37')
     version('1.8.2', sha256='83bc9e7b769daa04324c986eeaf48fcb53c2dda26bcc77cb3c07f4b1c359feb8')
+
+    patch('https://github.com/NVIDIA/thrust/pull/1297.patch', when='@1.10.0',
+              sha256='138aa8533a875f03b9d526f114fca4fc5803311ce6b7c8e022f03c2eefed0e19')
+    patch('https://github.com/NVIDIA/thrust/pull/1298.patch', when='@1.10.0',
+              sha256='0f27f6883e0f16d2d83f8816ab09dad4ad890aed8556ba1c1227e5339ed115c0')
+    patch('https://github.com/NVIDIA/thrust/pull/1300.patch', when='@1.10.0',
+              sha256='dbcbe70de701c5f64c9307cc921c2de06924843ef187fe59f69d11e41dda5211')
     
     def build(self, spec, prefix):
         pass

--- a/src/libpsc/CMakeLists.txt
+++ b/src/libpsc/CMakeLists.txt
@@ -60,6 +60,7 @@ if (USE_CUDA)
     
     cuda/cuda_heating.cu)
   target_include_directories(psc PUBLIC cuda)
+  target_link_libraries(psc PUBLIC Thrust)
 endif()
 
 if (PSC_HAVE_RMM)


### PR DESCRIPTION
Hopefully the spack stuff in here will make it not too much of a pain to use the latest thrust in PSC.

This does in fact address the problem where some deallocate calls were given an incorrect size of zero. It's not clear that this had any real consequences, other than making tracking of actual allocated memory difficult.

Stuff like
```
1: 0: 141674,20:28:41:668905,allocate,0x2000c6cc7c00,3687168,0
1: 0: 141674,20:28:41:669354,free,0x2000c6cc7c00,0,0
```
now doesn't happen anymore.
