### PR TITLE
save some particle GPU memory

### DIFF
--- a/src/libpsc/cuda/cuda_mparticles.cuh
+++ b/src/libpsc/cuda/cuda_mparticles.cuh
@@ -95,6 +95,11 @@ struct MparticlesCudaStorage_
 
   __host__ void resize(size_t n)
   {
+    // grow arrays by 20% only
+    if (n > xi4.capacity()) {
+      xi4.reserve(1.2 * n);
+      pxi4.reserve(1.2 * n);
+    }
     xi4.resize(n);
     pxi4.resize(n);
   }

--- a/src/libpsc/cuda/cuda_mparticles_base.cu
+++ b/src/libpsc/cuda/cuda_mparticles_base.cu
@@ -22,8 +22,7 @@ cuda_mparticles_base<BS>::cuda_mparticles_base(const Grid_t& grid)
 template <typename BS>
 void cuda_mparticles_base<BS>::resize(uint size)
 {
-  storage.xi4.resize(size);
-  storage.pxi4.resize(size);
+  storage.resize(size);
 }
 
 // ----------------------------------------------------------------------


### PR DESCRIPTION
Grow particle arrays by 20% only.

Otherwise, after resizing, they'll be exact size, and soon after, they need to grow, and by default their allocated size will double, which isn't good when being low on GPU memory.
