### PR TITLE
add 1d test case, some fixes

### DIFF
--- a/src/libpsc/psc_output_fields/fields_item_moments_1st.hxx
+++ b/src/libpsc/psc_output_fields/fields_item_moments_1st.hxx
@@ -54,6 +54,7 @@ public:
   {
     using Particle = typename Mparticles::ConstAccessor::Particle;
 
+    Base::mres_.zero();
     auto deposit = Deposit1stCc<Mparticles, Mfields>{mprts, Base::mres_};
     deposit.process([&](const Particle& prt) {
       int m = prt.kind();

--- a/src/libpsc/vpic/psc_vpic_bits.h
+++ b/src/libpsc/vpic/psc_vpic_bits.h
@@ -57,6 +57,7 @@ typedef int32_t SpeciesId; // Must be 32-bit wide for particle_injector_t
 #define UNLIKELY(_c) __builtin_expect((_c), 0)
 #endif
 
+#ifndef mprintf
 #define mprintf(fmt...)                                                        \
   do {                                                                         \
     int __rank;                                                                \
@@ -66,6 +67,9 @@ typedef int32_t SpeciesId; // Must be 32-bit wide for particle_injector_t
       printf(fmt);                                                             \
     }                                                                          \
   } while (0)
+#endif
+
+#ifndef MHERE
 #define MHERE                                                                  \
   do {                                                                         \
     int __rank;                                                                \
@@ -73,6 +77,7 @@ typedef int32_t SpeciesId; // Must be 32-bit wide for particle_injector_t
     printf("[%d] HERE: in %s() at %s:%d\n", __rank, __FUNCTION__, __FILE__,    \
            __LINE__);                                                          \
   } while (0)
+#endif
 
 // FIXME, do some proper logging eventually...
 

--- a/src/psc_flatfoil_yz.cxx
+++ b/src/psc_flatfoil_yz.cxx
@@ -10,6 +10,9 @@
 #include "../libpsc/psc_heating/psc_heating_impl.hxx"
 #include "heating_spot_foil.hxx"
 
+// quasi 1-d
+#define CASE_1D 1
+
 #define CASE_2D 2
 
 #define CASE_3D 3
@@ -300,6 +303,10 @@ Grid_t* setupGrid()
   Grid_t::Real3 LL = {1., 800., 3. * 800.}; // domain size (in d_e)
   Int3 gdims = {1, 1600, 3 * 1600};         // global number of grid points
   Int3 np = {1, 50, 3 * 50};                // division into patches
+#elif CASE == CASE_1D
+  Grid_t::Real3 LL = {1., 8., 3. * 80.}; // domain size (in d_e)
+  Int3 gdims = {1, 16, 3 * 160};         // global number of grid points
+  Int3 np = {1, 1, 3 * 5};               // division into patches
 #endif
 
   Grid_t::Domain domain{gdims, LL, -.5 * LL, np};
@@ -465,8 +472,13 @@ void run()
 
   // -- output fields
   OutputFieldsParams outf_params{};
+#if CASE == CASE_1D
+  outf_params.pfield_interval = 100;
+  outf_params.tfield_interval = -100;
+#else
   outf_params.pfield_interval = 500;
   outf_params.tfield_interval = 500;
+#endif
   outf_params.tfield_average_every = 50;
   outf_params.tfield_moments_average_every = 50;
   OutputFields outf{grid, outf_params};
@@ -500,7 +512,11 @@ void run()
   heating_foil_params.n_kinds = N_MY_KINDS;
   HeatingSpotFoil heating_spot{grid, heating_foil_params};
 
+#if CASE == CASE_1D
+  g.heating_interval = -20;
+#else
   g.heating_interval = 20;
+#endif
   g.heating_begin = 0;
   g.heating_end = 10000000;
   auto& heating = *new Heating{grid, g.heating_interval, heating_spot};

--- a/src/psc_flatfoil_yz.cxx
+++ b/src/psc_flatfoil_yz.cxx
@@ -552,9 +552,9 @@ void run()
   auto lf_inject = [&](int kind, Double3 pos, int p, Int3 idx,
                        psc_particle_npt& npt) {
     if (inject_target.is_inside(pos)) {
+      inject_target.init_npt(kind, pos, npt);
 
       if (kind == MY_ELECTRON_HE || kind == MY_ELECTRON) {
-        inject_target.init_npt(kind, pos, npt);
         npt.n =
           inject_target.n - (mf_n[p](MY_ELECTRON, idx[0], idx[1], idx[2]) +
                              mf_n[p](MY_ELECTRON_HE, idx[0], idx[1], idx[2]));
@@ -564,7 +564,6 @@ void run()
           npt.n *= (1. - g.electron_HE_ratio);
         }
       } else { // ions
-        inject_target.init_npt(kind, pos, npt);
         npt.n -= mf_n[p](kind, idx[0], idx[1], idx[2]);
       }
       if (npt.n < 0) {

--- a/src/psc_flatfoil_yz.cxx
+++ b/src/psc_flatfoil_yz.cxx
@@ -10,7 +10,12 @@
 #include "../libpsc/psc_heating/psc_heating_impl.hxx"
 #include "heating_spot_foil.hxx"
 
-//#define DIM_3D
+#define CASE_2D 2
+
+#define CASE_3D 3
+
+// FIXME select a hardcoded case
+#define CASE CASE_2D
 
 // ======================================================================
 // Particle kinds
@@ -156,7 +161,7 @@ public:
 //
 // EDIT to change order / floating point type / cuda / 2d/3d
 
-#ifdef DIM_3D
+#if CASE == CASE_3D
 using Dim = dim_xyz;
 #else
 using Dim = dim_yz;
@@ -287,11 +292,11 @@ void setupParameters()
 Grid_t* setupGrid()
 {
   // --- setup domain
-#ifdef DIM_3D
+#if CASE == CASE_3D
   Grid_t::Real3 LL = {80., 80., 3. * 80.}; // domain size (in d_e)
   Int3 gdims = {160, 160, 3 * 160};        // global number of grid points
   Int3 np = {5, 5, 3 * 5};                 // division into patches
-#else
+#elif CASE == CASE_2D
   Grid_t::Real3 LL = {1., 800., 3. * 800.}; // domain size (in d_e)
   Int3 gdims = {1, 1600, 3 * 1600};         // global number of grid points
   Int3 np = {1, 50, 3 * 50};                // division into patches


### PR DESCRIPTION
The 1-d test case, which is still inactive, and broken, here, is designed to test the injection and heating for the multiple electron species.

The CASE macro to select different variations of psc_flatfoil_yz is kinda hacky, but the best/simplest I can come with right now to keep around multiple similar cases.
