### PR TITLE
cuda heating

### DIFF
--- a/src/include/heating_spot_foil.hxx
+++ b/src/include/heating_spot_foil.hxx
@@ -33,11 +33,9 @@ public:
     double width = zh - zl;
 
     assert(n_kinds < HEATING_MAX_N_KINDS);
-    // inialize a fac for each population
+    // initalize a fac for each population
     for (int i = 0; i < n_kinds; i++)
       fac[i] = (8.f * pow(T[i], 1.5)) / (sqrt(Mi) * width);
-
-    // FIXME, I don't understand the sqrt(Mi) in here
   }
 
   template <typename R>
@@ -48,6 +46,11 @@ public:
 
     if (crd[2] <= zl || crd[2] >= zh) {
       return 0;
+    }
+
+    // uniform heating, not a spot
+    if (rH == 0) {
+      return fac[kind];
     }
 
     return shape_xy(crd, kind, dim{});

--- a/src/include/heating_spot_foil.hxx
+++ b/src/include/heating_spot_foil.hxx
@@ -43,13 +43,21 @@ public:
   template <typename R>
   KG_INLINE R operator()(const R* crd, int kind)
   {
-    R x = crd[0], y = crd[1], z = crd[2];
     if (fac[kind] == 0.0)
       return 0;
-    if (z <= zl || z >= zh) {
+
+    if (crd[2] <= zl || crd[2] >= zh) {
       return 0;
     }
 
+    return shape_xy(crd, kind);
+  }
+
+  template <typename R>
+  KG_INLINE R shape_xy(const R* crd, int kind)
+  {
+    R x = crd[0], y = crd[1];
+    
     return fac[kind] *
            (std::exp(-(sqr(x - (xc)) + sqr(y - (yc))) / sqr(rH))); // +
 #if 0

--- a/src/include/heating_spot_foil.hxx
+++ b/src/include/heating_spot_foil.hxx
@@ -19,10 +19,9 @@ struct HeatingSpotFoilParams
 // ======================================================================
 // HeatingSpotFoil
 
-struct HeatingSpotFoil : HeatingSpotFoilParams
+class HeatingSpotFoil : public HeatingSpotFoilParams
 {
-  HeatingSpotFoil() = default;
-
+public:
   HeatingSpotFoil(const Grid_t& grid, const HeatingSpotFoilParams& params)
     : HeatingSpotFoilParams(params),
       Lx_(grid.domain.length[0]),
@@ -62,7 +61,7 @@ struct HeatingSpotFoil : HeatingSpotFoilParams
 #endif
   }
 
-  // private:
+private:
   double fac[HEATING_MAX_N_KINDS];
   double Lx_, Ly_;
 };

--- a/src/include/heating_spot_foil.hxx
+++ b/src/include/heating_spot_foil.hxx
@@ -39,7 +39,7 @@ struct HeatingSpotFoil : HeatingSpotFoilParams
   }
 
   template <typename R>
-  R operator()(const R* crd, int kind)
+  KG_INLINE R operator()(const R* crd, int kind)
   {
     R x = crd[0], y = crd[1], z = crd[2];
     if (fac[kind] == 0.0)

--- a/src/include/heating_spot_foil.hxx
+++ b/src/include/heating_spot_foil.hxx
@@ -19,9 +19,12 @@ struct HeatingSpotFoilParams
 // ======================================================================
 // HeatingSpotFoil
 
+template <typename DIM>
 class HeatingSpotFoil : public HeatingSpotFoilParams
 {
 public:
+  using dim = DIM;
+
   HeatingSpotFoil(const Grid_t& grid, const HeatingSpotFoilParams& params)
     : HeatingSpotFoilParams(params),
       Lx_(grid.domain.length[0]),

--- a/src/include/heating_spot_foil.hxx
+++ b/src/include/heating_spot_foil.hxx
@@ -50,17 +50,16 @@ public:
       return 0;
     }
 
-    return shape_xy(crd, kind);
+    return shape_xy(crd, kind, dim{});
   }
 
   template <typename R>
-  KG_INLINE R shape_xy(const R* crd, int kind)
+  KG_INLINE R shape_xy(const R* crd, int kind, dim_xyz dim_select)
   {
     R x = crd[0], y = crd[1];
-    
+
     return fac[kind] *
-           (std::exp(-(sqr(x - (xc)) + sqr(y - (yc))) / sqr(rH))); // +
-#if 0
+           (std::exp(-(sqr(x - (xc)) + sqr(y - (yc))) / sqr(rH)) +
             std::exp(-(sqr(x - (xc)) + sqr(y - (yc + Ly_))) / sqr(rH)) +
             std::exp(-(sqr(x - (xc)) + sqr(y - (yc - Ly_))) / sqr(rH)) +
             std::exp(-(sqr(x - (xc + Lx_)) + sqr(y - (yc))) / sqr(rH)) +
@@ -69,7 +68,16 @@ public:
             std::exp(-(sqr(x - (xc - Lx_)) + sqr(y - (yc))) / sqr(rH)) +
             std::exp(-(sqr(x - (xc - Lx_)) + sqr(y - (yc + Ly_))) / sqr(rH)) +
             std::exp(-(sqr(x - (xc - Lx_)) + sqr(y - (yc - Ly_))) / sqr(rH)));
-#endif
+  }
+
+  template <typename R>
+  KG_INLINE R shape_xy(const R* crd, int kind, dim_yz dim_select)
+  {
+    R y = crd[1];
+
+    return fac[kind] * (std::exp(-(sqr(y - (yc))) / sqr(rH)) +
+                        std::exp(-(sqr(y - (yc + Ly_))) / sqr(rH)) +
+                        std::exp(-(sqr(y - (yc - Ly_))) / sqr(rH)));
   }
 
 private:

--- a/src/include/heating_spot_foil.hxx
+++ b/src/include/heating_spot_foil.hxx
@@ -38,29 +38,31 @@ struct HeatingSpotFoil : HeatingSpotFoilParams
     // FIXME, I don't understand the sqrt(Mi) in here
   }
 
-  double operator()(const double* crd, const int kind)
+  template <typename R>
+  R operator()(const R* crd, int kind)
   {
-    double x = crd[0], y = crd[1], z = crd[2];
+    R x = crd[0], y = crd[1], z = crd[2];
     if (fac[kind] == 0.0)
       return 0;
     if (z <= zl || z >= zh) {
       return 0;
     }
 
-    return fac[kind] * (exp(-(sqr(x - (xc)) + sqr(y - (yc))) / sqr(rH))); // +
+    return fac[kind] *
+           (std::exp(-(sqr(x - (xc)) + sqr(y - (yc))) / sqr(rH))); // +
 #if 0
-            exp(-(sqr(x - (xc)) + sqr(y - (yc + Ly_))) / sqr(rH)) +
-            exp(-(sqr(x - (xc)) + sqr(y - (yc - Ly_))) / sqr(rH)) +
-            exp(-(sqr(x - (xc + Lx_)) + sqr(y - (yc))) / sqr(rH)) +
-            exp(-(sqr(x - (xc + Lx_)) + sqr(y - (yc + Ly_))) / sqr(rH)) +
-            exp(-(sqr(x - (xc + Lx_)) + sqr(y - (yc - Ly_))) / sqr(rH)) +
-            exp(-(sqr(x - (xc - Lx_)) + sqr(y - (yc))) / sqr(rH)) +
-            exp(-(sqr(x - (xc - Lx_)) + sqr(y - (yc + Ly_))) / sqr(rH)) +
-            exp(-(sqr(x - (xc - Lx_)) + sqr(y - (yc - Ly_))) / sqr(rH)));
+            std::exp(-(sqr(x - (xc)) + sqr(y - (yc + Ly_))) / sqr(rH)) +
+            std::exp(-(sqr(x - (xc)) + sqr(y - (yc - Ly_))) / sqr(rH)) +
+            std::exp(-(sqr(x - (xc + Lx_)) + sqr(y - (yc))) / sqr(rH)) +
+            std::exp(-(sqr(x - (xc + Lx_)) + sqr(y - (yc + Ly_))) / sqr(rH)) +
+            std::exp(-(sqr(x - (xc + Lx_)) + sqr(y - (yc - Ly_))) / sqr(rH)) +
+            std::exp(-(sqr(x - (xc - Lx_)) + sqr(y - (yc))) / sqr(rH)) +
+            std::exp(-(sqr(x - (xc - Lx_)) + sqr(y - (yc + Ly_))) / sqr(rH)) +
+            std::exp(-(sqr(x - (xc - Lx_)) + sqr(y - (yc - Ly_))) / sqr(rH)));
 #endif
   }
 
-//private:
+  // private:
   double fac[HEATING_MAX_N_KINDS];
   double Lx_, Ly_;
 };

--- a/src/include/heating_spot_foil.hxx
+++ b/src/include/heating_spot_foil.hxx
@@ -60,7 +60,7 @@ struct HeatingSpotFoil : HeatingSpotFoilParams
 #endif
   }
 
-private:
+//private:
   double fac[HEATING_MAX_N_KINDS];
   double Lx_, Ly_;
 };

--- a/src/include/heating_spot_foil.hxx
+++ b/src/include/heating_spot_foil.hxx
@@ -47,8 +47,8 @@ struct HeatingSpotFoil : HeatingSpotFoilParams
       return 0;
     }
 
-    return fac[kind] *
-           (exp(-(sqr(x - (xc)) + sqr(y - (yc))) / sqr(rH)) +
+    return fac[kind] * (exp(-(sqr(x - (xc)) + sqr(y - (yc))) / sqr(rH))); // +
+#if 0
             exp(-(sqr(x - (xc)) + sqr(y - (yc + Ly_))) / sqr(rH)) +
             exp(-(sqr(x - (xc)) + sqr(y - (yc - Ly_))) / sqr(rH)) +
             exp(-(sqr(x - (xc + Lx_)) + sqr(y - (yc))) / sqr(rH)) +
@@ -57,6 +57,7 @@ struct HeatingSpotFoil : HeatingSpotFoilParams
             exp(-(sqr(x - (xc - Lx_)) + sqr(y - (yc))) / sqr(rH)) +
             exp(-(sqr(x - (xc - Lx_)) + sqr(y - (yc + Ly_))) / sqr(rH)) +
             exp(-(sqr(x - (xc - Lx_)) + sqr(y - (yc - Ly_))) / sqr(rH)));
+#endif
   }
 
 private:

--- a/src/libpsc/cuda/cuda_heating.cu
+++ b/src/libpsc/cuda/cuda_heating.cu
@@ -102,11 +102,7 @@ struct cuda_heating_foil : HeatingSpotFoilParams
     dim3 dimGrid = BlockSimple<BS, dim_xyz>::dimGrid(*cmprts);
 
     if (first_time_) { // FIXME
-      d_xb_by_patch_.resize(cmprts->n_patches());
-      thrust::copy(
-        cmprts->xb_by_patch.data(),
-        cmprts->xb_by_patch.data() + cmprts->n_patches(),
-        d_xb_by_patch_.begin());
+      d_xb_by_patch_ = cmprts->xb_by_patch;
       h_prm_.d_xb_by_patch = d_xb_by_patch_.data().get();
       h_prm_.heating_dt = heating_dt;
 

--- a/src/libpsc/cuda/cuda_heating.cu
+++ b/src/libpsc/cuda/cuda_heating.cu
@@ -114,6 +114,10 @@ struct cuda_heating_foil : HeatingSpotFoilParams
     d_curand_states_ = nullptr;
   }
 
+  // no copy constructor / assign
+  cuda_heating_foil(const cuda_heating_foil&) = delete;
+  cuda_heating_foil& operator=(const cuda_heating_foil&) = delete;
+
   template <typename BS>
   void reset(cuda_mparticles<BS>* cmprts)
   {

--- a/src/libpsc/cuda/cuda_heating.cu
+++ b/src/libpsc/cuda/cuda_heating.cu
@@ -123,27 +123,7 @@ struct cuda_heating_foil : HeatingSpotFoilParams
 
   __host__ __device__ float get_H(float* crd, int kind)
   {
-    double x = crd[0], y = crd[1], z = crd[2];
-    if (heating_spot_.fac[kind] == 0.0)
-      return 0;
-
-    if (z <= zl || z >= zh) {
-      return 0;
-    }
-
-    double Lx = heating_spot_.Lx_;
-    double Ly = heating_spot_.Ly_;
-
-    return heating_spot_.fac[kind] *
-           (exp(-(sqr(x - (xc)) + sqr(y - (yc))) / sqr(rH)) +
-            exp(-(sqr(x - (xc)) + sqr(y - (yc + Ly))) / sqr(rH)) +
-            exp(-(sqr(x - (xc)) + sqr(y - (yc - Ly))) / sqr(rH)) +
-            exp(-(sqr(x - (xc + Lx)) + sqr(y - (yc))) / sqr(rH)) +
-            exp(-(sqr(x - (xc + Lx)) + sqr(y - (yc + Ly))) / sqr(rH)) +
-            exp(-(sqr(x - (xc + Lx)) + sqr(y - (yc - Ly))) / sqr(rH)) +
-            exp(-(sqr(x - (xc - Lx)) + sqr(y - (yc))) / sqr(rH)) +
-            exp(-(sqr(x - (xc - Lx)) + sqr(y - (yc + Ly))) / sqr(rH)) +
-            exp(-(sqr(x - (xc - Lx)) + sqr(y - (yc - Ly))) / sqr(rH)));
+    return heating_spot_(crd, kind);
   }
 
   // ----------------------------------------------------------------------

--- a/src/libpsc/cuda/cuda_heating.cu
+++ b/src/libpsc/cuda/cuda_heating.cu
@@ -99,6 +99,7 @@ struct cuda_heating_foil : HeatingSpotFoilParams
       heating_dt(heating_dt),
       Lx_(grid.domain.length[0]),
       Ly_(grid.domain.length[1]),
+      heating_spot_{grid, params},
       h_prm_{},
       d_curand_states_{},
       first_time_{true}
@@ -235,6 +236,7 @@ struct cuda_heating_foil : HeatingSpotFoilParams
   float fac[HEATING_MAX_N_KINDS];
   float heating_dt;
   float Lx_, Ly_;
+  HeatingSpotFoil heating_spot_;
 
   cuda_heating_params h_prm_;
   curandState* d_curand_states_;

--- a/src/libpsc/cuda/cuda_heating.cu
+++ b/src/libpsc/cuda/cuda_heating.cu
@@ -48,8 +48,6 @@ __global__ static void k_curand_setup(curandState* d_curand_states)
   curand_init(1234, id, 0, &d_curand_states[id]);
 }
 
-struct cuda_heating_foil;
-
 template <typename BS>
 __global__ static void k_heating_run_foil(HeatingSpotFoil foil,
                                           DMparticlesCuda<BS> dmprts,
@@ -69,12 +67,11 @@ struct cuda_heating_foil : HeatingSpotFoilParams
       first_time_{true}
   {}
 
-  // no copy constructor / assign
+  // no copy constructor / assign to catch performance issues
   cuda_heating_foil(const cuda_heating_foil&) = delete;
   cuda_heating_foil& operator=(const cuda_heating_foil&) = delete;
 
-  template <typename BS>
-  void reset(cuda_mparticles<BS>* cmprts)
+  void reset()
   {
     first_time_ = true;
   }
@@ -262,7 +259,7 @@ HeatingCuda<BS>::~HeatingCuda()
 template <typename BS>
 void HeatingCuda<BS>::reset(MparticlesCuda<BS>& mprts)
 {
-  foil_->reset(mprts.cmprts());
+  foil_->reset();
 }
 
 template <typename BS>

--- a/src/libpsc/cuda/cuda_heating.cu
+++ b/src/libpsc/cuda/cuda_heating.cu
@@ -108,14 +108,10 @@ struct cuda_heating_foil : HeatingSpotFoilParams
 
   ~cuda_heating_foil()
   {
-    // FIXME, since we're copy-constructing this when passing to device,
-    // implementing the dtor breaks things...
-#if 0
     cuda_heating_params_free(h_prm_);
     
     myCudaFree(d_curand_states_);
     d_curand_states_ = nullptr;
-#endif
   }
 
   template <typename BS>

--- a/src/libpsc/cuda/cuda_heating.cu
+++ b/src/libpsc/cuda/cuda_heating.cu
@@ -93,12 +93,12 @@ __global__ static void k_heating_run_foil(cuda_heating_foil d_foil,
 
 struct cuda_heating_foil : HeatingSpotFoilParams
 {
-  cuda_heating_foil(const HeatingSpotFoilParams& params, double heating_dt,
-                    double Lx, double Ly)
+  cuda_heating_foil(const Grid_t& grid, const HeatingSpotFoilParams& params,
+                    double heating_dt)
     : HeatingSpotFoilParams(params),
       heating_dt(heating_dt),
-      Lx_(Lx),
-      Ly_(Ly),
+      Lx_(grid.domain.length[0]),
+      Ly_(grid.domain.length[1]),
       h_prm_{},
       d_curand_states_{},
       first_time_{true}
@@ -336,8 +336,7 @@ __global__ static void __launch_bounds__(THREADS_PER_BLOCK, 3)
 template <typename BS>
 template <typename FUNC>
 HeatingCuda<BS>::HeatingCuda(const Grid_t& grid, int interval, FUNC get_H)
-  : foil_{new cuda_heating_foil{get_H, interval * grid.dt,
-                                grid.domain.length[0], grid.domain.length[1]}},
+  : foil_{new cuda_heating_foil{grid, get_H, interval * grid.dt}},
     balance_generation_cnt_{-1}
 {}
 

--- a/src/libpsc/cuda/cuda_heating.cu
+++ b/src/libpsc/cuda/cuda_heating.cu
@@ -97,8 +97,6 @@ struct cuda_heating_foil : HeatingSpotFoilParams
                     double heating_dt)
     : HeatingSpotFoilParams(params),
       heating_dt(heating_dt),
-      Lx_(grid.domain.length[0]),
-      Ly_(grid.domain.length[1]),
       heating_spot_{grid, params},
       h_prm_{},
       d_curand_states_{},
@@ -138,16 +136,19 @@ struct cuda_heating_foil : HeatingSpotFoilParams
       return 0;
     }
 
+    double Lx = heating_spot_.Lx_;
+    double Ly = heating_spot_.Ly_;
+
     return fac[kind] *
            (exp(-(sqr(x - (xc)) + sqr(y - (yc))) / sqr(rH)) +
-            exp(-(sqr(x - (xc)) + sqr(y - (yc + Ly_))) / sqr(rH)) +
-            exp(-(sqr(x - (xc)) + sqr(y - (yc - Ly_))) / sqr(rH)) +
-            exp(-(sqr(x - (xc + Lx_)) + sqr(y - (yc))) / sqr(rH)) +
-            exp(-(sqr(x - (xc + Lx_)) + sqr(y - (yc + Ly_))) / sqr(rH)) +
-            exp(-(sqr(x - (xc + Lx_)) + sqr(y - (yc - Ly_))) / sqr(rH)) +
-            exp(-(sqr(x - (xc - Lx_)) + sqr(y - (yc))) / sqr(rH)) +
-            exp(-(sqr(x - (xc - Lx_)) + sqr(y - (yc + Ly_))) / sqr(rH)) +
-            exp(-(sqr(x - (xc - Lx_)) + sqr(y - (yc - Ly_))) / sqr(rH)));
+            exp(-(sqr(x - (xc)) + sqr(y - (yc + Ly))) / sqr(rH)) +
+            exp(-(sqr(x - (xc)) + sqr(y - (yc - Ly))) / sqr(rH)) +
+            exp(-(sqr(x - (xc + Lx)) + sqr(y - (yc))) / sqr(rH)) +
+            exp(-(sqr(x - (xc + Lx)) + sqr(y - (yc + Ly))) / sqr(rH)) +
+            exp(-(sqr(x - (xc + Lx)) + sqr(y - (yc - Ly))) / sqr(rH)) +
+            exp(-(sqr(x - (xc - Lx)) + sqr(y - (yc))) / sqr(rH)) +
+            exp(-(sqr(x - (xc - Lx)) + sqr(y - (yc + Ly))) / sqr(rH)) +
+            exp(-(sqr(x - (xc - Lx)) + sqr(y - (yc - Ly))) / sqr(rH)));
   }
 
   // ----------------------------------------------------------------------
@@ -235,7 +236,6 @@ struct cuda_heating_foil : HeatingSpotFoilParams
   bool first_time_;
   float fac[HEATING_MAX_N_KINDS];
   float heating_dt;
-  float Lx_, Ly_;
   HeatingSpotFoil heating_spot_;
 
   cuda_heating_params h_prm_;

--- a/src/libpsc/cuda/cuda_heating.cu
+++ b/src/libpsc/cuda/cuda_heating.cu
@@ -234,27 +234,26 @@ void cuda_heating_run_foil_gold(HS& foil, float heating_dt,
 
 // ======================================================================
 
-template <typename BS>
-template <typename FUNC>
-HeatingCuda<BS>::HeatingCuda(const Grid_t& grid, int interval, FUNC get_H)
-  : foil_{new cuda_heating_foil<HeatingSpotFoil<dim_xyz>>{grid, get_H, interval * grid.dt}},
+template <typename HS, typename BS>
+HeatingCuda<HS, BS>::HeatingCuda(const Grid_t& grid, int interval, HS heating_spot)
+  : foil_{new cuda_heating_foil<HS>{grid, heating_spot, interval * grid.dt}},
     balance_generation_cnt_{-1}
 {}
 
-template <typename BS>
-HeatingCuda<BS>::~HeatingCuda()
+template <typename HS, typename BS>
+HeatingCuda<HS, BS>::~HeatingCuda()
 {
   delete foil_;
 }
 
-template <typename BS>
-void HeatingCuda<BS>::reset(MparticlesCuda<BS>& mprts)
+template <typename HS, typename BS>
+void HeatingCuda<HS, BS>::reset(MparticlesCuda<BS>& mprts)
 {
   foil_->reset();
 }
 
-template <typename BS>
-void HeatingCuda<BS>::operator()(MparticlesCuda<BS>& mprts)
+template <typename HS, typename BS>
+void HeatingCuda<HS, BS>::operator()(MparticlesCuda<BS>& mprts)
 {
   if (psc_balance_generation_cnt > this->balance_generation_cnt_) {
     balance_generation_cnt_ = psc_balance_generation_cnt;
@@ -266,10 +265,5 @@ void HeatingCuda<BS>::operator()(MparticlesCuda<BS>& mprts)
 
 // ======================================================================
 
-template struct HeatingCuda<BS144>;
-template HeatingCuda<BS144>::HeatingCuda(const Grid_t& grid, int interval,
-                                         HeatingSpotFoil<dim_yz> get_H);
-
-template struct HeatingCuda<BS444>;
-template HeatingCuda<BS444>::HeatingCuda(const Grid_t& grid, int interval,
-                                         HeatingSpotFoil<dim_yz> get_H);
+template struct HeatingCuda<HeatingSpotFoil<dim_yz>, BS144>;
+template struct HeatingCuda<HeatingSpotFoil<dim_xyz>, BS444>;

--- a/src/libpsc/cuda/cuda_heating.cu
+++ b/src/libpsc/cuda/cuda_heating.cu
@@ -101,12 +101,7 @@ struct cuda_heating_foil : HeatingSpotFoilParams
       h_prm_{},
       d_curand_states_{},
       first_time_{true}
-  {
-    assert(n_kinds < HEATING_MAX_N_KINDS);
-    float width = zh - zl;
-    for (int i = 0; i < n_kinds; i++)
-      fac[i] = (8.f * pow(T[i], 1.5)) / (sqrt(Mi) * width);
-  }
+  {}
 
   ~cuda_heating_foil()
   {
@@ -129,7 +124,7 @@ struct cuda_heating_foil : HeatingSpotFoilParams
   __host__ __device__ float get_H(float* crd, int kind)
   {
     double x = crd[0], y = crd[1], z = crd[2];
-    if (fac[kind] == 0.0)
+    if (heating_spot_.fac[kind] == 0.0)
       return 0;
 
     if (z <= zl || z >= zh) {
@@ -139,7 +134,7 @@ struct cuda_heating_foil : HeatingSpotFoilParams
     double Lx = heating_spot_.Lx_;
     double Ly = heating_spot_.Ly_;
 
-    return fac[kind] *
+    return heating_spot_.fac[kind] *
            (exp(-(sqr(x - (xc)) + sqr(y - (yc))) / sqr(rH)) +
             exp(-(sqr(x - (xc)) + sqr(y - (yc + Ly))) / sqr(rH)) +
             exp(-(sqr(x - (xc)) + sqr(y - (yc - Ly))) / sqr(rH)) +
@@ -234,7 +229,6 @@ struct cuda_heating_foil : HeatingSpotFoilParams
 
   // state (FIXME, shouldn't be part of the interface)
   bool first_time_;
-  float fac[HEATING_MAX_N_KINDS];
   float heating_dt;
   HeatingSpotFoil heating_spot_;
 

--- a/src/libpsc/cuda/cuda_heating.cu
+++ b/src/libpsc/cuda/cuda_heating.cu
@@ -117,12 +117,11 @@ __global__ static void __launch_bounds__(THREADS_PER_BLOCK, 3)
 // cuda_heating_foil
 
 template <typename HS>
-struct cuda_heating_foil : HeatingSpotFoilParams
+struct cuda_heating_foil
 {
   cuda_heating_foil(const Grid_t& grid, const HeatingSpotFoilParams& params,
                     double heating_dt)
-    : HeatingSpotFoilParams(params),
-      heating_dt(heating_dt),
+    : heating_dt(heating_dt),
       heating_spot_{grid, params},
       first_time_{true}
   {}

--- a/src/libpsc/cuda/cuda_heating.cu
+++ b/src/libpsc/cuda/cuda_heating.cu
@@ -124,7 +124,7 @@ struct cuda_heating_foil : HeatingSpotFoilParams
   // run_foil
 
   template <typename BS>
-  void run_foil(cuda_mparticles<BS>* cmprts, curandState* d_curand_states)
+  void run_foil(cuda_mparticles<BS>* cmprts)
   {
     if (cmprts->n_prts == 0) {
       return;
@@ -132,7 +132,7 @@ struct cuda_heating_foil : HeatingSpotFoilParams
     dim3 dimGrid = BlockSimple<BS, dim_xyz>::dimGrid(*cmprts);
 
     k_heating_run_foil<BS>
-      <<<dimGrid, THREADS_PER_BLOCK>>>(heating_spot_, *cmprts, h_prm_, d_curand_states);
+      <<<dimGrid, THREADS_PER_BLOCK>>>(heating_spot_, *cmprts, h_prm_, d_curand_states_);
     cuda_sync_if_enabled();
   }
 
@@ -168,7 +168,7 @@ struct cuda_heating_foil : HeatingSpotFoilParams
       cmprts->reorder();
     }
 
-    run_foil<BS>(cmprts, d_curand_states_);
+    run_foil<BS>(cmprts);
   }
 
   // state (FIXME, shouldn't be part of the interface)

--- a/src/libpsc/cuda/cuda_heating.cu
+++ b/src/libpsc/cuda/cuda_heating.cu
@@ -231,27 +231,27 @@ void cuda_heating_run_foil_gold(HS& foil, float heating_dt,
 
 // ======================================================================
 
-template <typename HS, typename BS>
-HeatingCuda<HS, BS>::HeatingCuda(const Grid_t& grid, int interval,
+template <typename HS, typename MP>
+HeatingCuda<HS, MP>::HeatingCuda(const Grid_t& grid, int interval,
                                  HS heating_spot)
   : foil_{new cuda_heating_foil<HS>{grid, heating_spot, interval * grid.dt}},
     balance_generation_cnt_{-1}
 {}
 
-template <typename HS, typename BS>
-HeatingCuda<HS, BS>::~HeatingCuda()
+template <typename HS, typename MP>
+HeatingCuda<HS, MP>::~HeatingCuda()
 {
   delete foil_;
 }
 
-template <typename HS, typename BS>
-void HeatingCuda<HS, BS>::reset(MparticlesCuda<BS>& mprts)
+template <typename HS, typename MP>
+void HeatingCuda<HS, MP>::reset(const MP& mprts)
 {
   foil_->reset();
 }
 
-template <typename HS, typename BS>
-void HeatingCuda<HS, BS>::operator()(MparticlesCuda<BS>& mprts)
+template <typename HS, typename MP>
+void HeatingCuda<HS, MP>::operator()(MP& mprts)
 {
   if (psc_balance_generation_cnt > this->balance_generation_cnt_) {
     balance_generation_cnt_ = psc_balance_generation_cnt;
@@ -263,5 +263,5 @@ void HeatingCuda<HS, BS>::operator()(MparticlesCuda<BS>& mprts)
 
 // ======================================================================
 
-template struct HeatingCuda<HeatingSpotFoil<dim_yz>, BS144>;
-template struct HeatingCuda<HeatingSpotFoil<dim_xyz>, BS444>;
+template struct HeatingCuda<HeatingSpotFoil<dim_yz>, MparticlesCuda<BS144>>;
+template struct HeatingCuda<HeatingSpotFoil<dim_xyz>, MparticlesCuda<BS444>>;

--- a/src/libpsc/cuda/cuda_heating.cu
+++ b/src/libpsc/cuda/cuda_heating.cu
@@ -170,8 +170,8 @@ struct cuda_heating_foil
   float heating_dt_;
   HS heating_spot_;
 
-  thrust::device_vector<Float3> d_xb_by_patch_;
-  thrust::device_vector<curandState> d_curand_states_;
+  psc::device_vector<Float3> d_xb_by_patch_;
+  psc::device_vector<curandState> d_curand_states_;
 };
 
 // ----------------------------------------------------------------------

--- a/src/libpsc/cuda/heating_cuda_impl.hxx
+++ b/src/libpsc/cuda/heating_cuda_impl.hxx
@@ -12,11 +12,10 @@
 template <typename HS>
 struct cuda_heating_foil;
 
-template <typename BS>
+template <typename HS, typename BS>
 struct HeatingCuda : HeatingBase
 {
-  template <typename FUNC>
-  HeatingCuda(const Grid_t& grid, int interval, FUNC get_H);
+  HeatingCuda(const Grid_t& grid, int interval, HS heating_spot);
 
   ~HeatingCuda();
 
@@ -25,6 +24,6 @@ struct HeatingCuda : HeatingBase
   void operator()(MparticlesCuda<BS>& mprts);
 
 private:
-  cuda_heating_foil<HeatingSpotFoil<dim_xyz>>* foil_;
+  cuda_heating_foil<HS>* foil_;
   int balance_generation_cnt_;
 };

--- a/src/libpsc/cuda/heating_cuda_impl.hxx
+++ b/src/libpsc/cuda/heating_cuda_impl.hxx
@@ -12,16 +12,16 @@
 template <typename HS>
 struct cuda_heating_foil;
 
-template <typename HS, typename BS>
+template <typename HS, typename MP>
 struct HeatingCuda : HeatingBase
 {
   HeatingCuda(const Grid_t& grid, int interval, HS heating_spot);
 
   ~HeatingCuda();
 
-  void reset(MparticlesCuda<BS>& mprts);
+  void reset(const MP& mprts);
 
-  void operator()(MparticlesCuda<BS>& mprts);
+  void operator()(MP& mprts);
 
 private:
   cuda_heating_foil<HS>* foil_;

--- a/src/libpsc/cuda/heating_cuda_impl.hxx
+++ b/src/libpsc/cuda/heating_cuda_impl.hxx
@@ -4,10 +4,12 @@
 #include "heating.hxx"
 #include "mparticles_cuda.hxx"
 #include "psc_fields_cuda.h"
+#include "heating_spot_foil.hxx"
 
 // ======================================================================
 // psc_heating subclass "cuda"
 
+template <typename HS>
 struct cuda_heating_foil;
 
 template <typename BS>
@@ -23,6 +25,6 @@ struct HeatingCuda : HeatingBase
   void operator()(MparticlesCuda<BS>& mprts);
 
 private:
-  cuda_heating_foil* foil_;
+  cuda_heating_foil<HeatingSpotFoil<dim_xyz>>* foil_;
   int balance_generation_cnt_;
 };

--- a/src/libpsc/psc_heating/psc_heating_impl.hxx
+++ b/src/libpsc/psc_heating/psc_heating_impl.hxx
@@ -97,14 +97,14 @@ template <>
 struct HeatingSelector<MparticlesCuda<BS444>>
 {
   using Mparticles = MparticlesCuda<BS444>;
-  using Heating = HeatingCuda<HeatingSpotFoil<dim_xyz>, typename Mparticles::BS>;
+  using Heating = HeatingCuda<HeatingSpotFoil<dim_xyz>, Mparticles>;
 };
 
 template <>
 struct HeatingSelector<MparticlesCuda<BS144>>
 {
   using Mparticles = MparticlesCuda<BS144>;
-  using Heating = HeatingCuda<HeatingSpotFoil<dim_yz>, typename Mparticles::BS>;
+  using Heating = HeatingCuda<HeatingSpotFoil<dim_yz>, Mparticles>;
 };
 
 #endif

--- a/src/libpsc/psc_heating/psc_heating_impl.hxx
+++ b/src/libpsc/psc_heating/psc_heating_impl.hxx
@@ -97,14 +97,14 @@ template <>
 struct HeatingSelector<MparticlesCuda<BS444>>
 {
   using Mparticles = MparticlesCuda<BS444>;
-  using Heating = HeatingCuda<typename Mparticles::BS>;
+  using Heating = HeatingCuda<HeatingSpotFoil<dim_xyz>, typename Mparticles::BS>;
 };
 
 template <>
 struct HeatingSelector<MparticlesCuda<BS144>>
 {
   using Mparticles = MparticlesCuda<BS144>;
-  using Heating = HeatingCuda<typename Mparticles::BS>;
+  using Heating = HeatingCuda<HeatingSpotFoil<dim_yz>, typename Mparticles::BS>;
 };
 
 #endif

--- a/src/psc_flatfoil_yz.cxx
+++ b/src/psc_flatfoil_yz.cxx
@@ -553,11 +553,7 @@ void run()
   heating_foil_params.n_kinds = N_MY_KINDS;
   HeatingSpotFoil heating_spot{grid, heating_foil_params};
 
-#if CASE == CASE_1D
-  g.heating_interval = -20;
-#else
   g.heating_interval = 20;
-#endif
   g.heating_begin = 0;
   g.heating_end = 10000000;
   auto& heating = *new Heating{grid, g.heating_interval, heating_spot};

--- a/src/psc_flatfoil_yz.cxx
+++ b/src/psc_flatfoil_yz.cxx
@@ -538,11 +538,16 @@ void run()
   HeatingSpotFoilParams heating_foil_params{};
   heating_foil_params.zl = -1. * g.d_i;
   heating_foil_params.zh = 1. * g.d_i;
+#if CASE == CASE_1D
   heating_foil_params.xc = 0. * g.d_i;
-#if CASE == CASE_2D_SMALL
+  heating_foil_params.yc = 0. * g.d_i;
+  heating_foil_params.rH = 1000. * g.d_i;
+#elif CASE == CASE_2D_SMALL
+  heating_foil_params.xc = 0. * g.d_i;
   heating_foil_params.yc = 2. * g.d_i;
   heating_foil_params.rH = 1. * g.d_i;
 #else
+  heating_foil_params.xc = 0. * g.d_i;
   heating_foil_params.yc = 20. * g.d_i;
   heating_foil_params.rH = 12. * g.d_i;
 #endif

--- a/src/psc_flatfoil_yz.cxx
+++ b/src/psc_flatfoil_yz.cxx
@@ -17,7 +17,7 @@
 #define CASE_2D_SMALL 4
 
 // FIXME select a hardcoded case
-#define CASE CASE_1D
+#define CASE CASE_2D
 
 // ======================================================================
 // Particle kinds

--- a/src/psc_flatfoil_yz.cxx
+++ b/src/psc_flatfoil_yz.cxx
@@ -556,7 +556,7 @@ void run()
   heating_foil_params.T[MY_ION] = g.target_Ti_heat;
   heating_foil_params.Mi = grid.kinds[MY_ION].m;
   heating_foil_params.n_kinds = N_MY_KINDS;
-  HeatingSpotFoil heating_spot{grid, heating_foil_params};
+  HeatingSpotFoil<Dim> heating_spot{grid, heating_foil_params};
 
   g.heating_interval = 20;
   g.heating_begin = 0;

--- a/src/psc_flatfoil_yz.cxx
+++ b/src/psc_flatfoil_yz.cxx
@@ -17,7 +17,7 @@
 #define CASE_2D_SMALL 4
 
 // FIXME select a hardcoded case
-#define CASE CASE_2D
+#define CASE CASE_1D
 
 // ======================================================================
 // Particle kinds

--- a/src/psc_flatfoil_yz.cxx
+++ b/src/psc_flatfoil_yz.cxx
@@ -541,7 +541,7 @@ void run()
 #if CASE == CASE_1D
   heating_foil_params.xc = 0. * g.d_i;
   heating_foil_params.yc = 0. * g.d_i;
-  heating_foil_params.rH = 1000. * g.d_i;
+  heating_foil_params.rH = 0.; // uniform
 #elif CASE == CASE_2D_SMALL
   heating_foil_params.xc = 0. * g.d_i;
   heating_foil_params.yc = 2. * g.d_i;


### PR DESCRIPTION
This revamps the heating so that the same HeatingSpotFoil is used by the CPU and the GPU code. It does then fix the issue with periodic copies of the heating spot, which help ensuring that a somewhat broad spot isn't incompatible with periodic boundaries, but where one has to be careful to get the 2d and quasi-1d case right.

It does a decent amount of clean up and fixes some known existing memory leak, though that was probably not real significant.