### PR TITLE
spack: update hdf5 dependency

### DIFF
--- a/spack/psc/packages/psc/package.py
+++ b/spack/psc/packages/psc/package.py
@@ -30,7 +30,7 @@ class Psc(CMakePackage):
     
     depends_on('cmake@3.17.0:')
 
-    depends_on('hdf5@1.8.0:1.8.999 +hl')
+    depends_on('hdf5 +hl')
     depends_on('adios2@2.4.0:', when='+adios2')
     depends_on('cuda', when='+cuda')
     depends_on('thrust@1.10.0:', when='+cuda')


### PR DESCRIPTION
HDF 1.8 didn't want to compile with newer MPI