### PR TITLE
OutputFields: consolidation and start using gtensor

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,6 +3,7 @@ cmake_minimum_required (VERSION 3.17)
 
 foreach(policy
     CMP0074 # CMake 3.12
+    CMP0104 # CMAKE_CUDA_ARCHITECTURES
     )
   if(POLICY ${policy})
     cmake_policy(SET ${policy} NEW)

--- a/external/GTest/googletest/CMakeLists.txt
+++ b/external/GTest/googletest/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Note: CMake support is community-based. The maintainers do not use CMake
 # internally.
 
-cmake_minimum_required(VERSION 2.8.8)
+cmake_minimum_required(VERSION 3.17)
 
 if (POLICY CMP0048)
   cmake_policy(SET CMP0048 NEW)

--- a/external/GTest/googletest/googletest/CMakeLists.txt
+++ b/external/GTest/googletest/googletest/CMakeLists.txt
@@ -53,7 +53,7 @@ else()
   cmake_policy(SET CMP0048 NEW)
   project(gtest VERSION ${GOOGLETEST_VERSION} LANGUAGES CXX C)
 endif()
-cmake_minimum_required(VERSION 2.6.4)
+cmake_minimum_required(VERSION 3.17)
 
 if (POLICY CMP0063) # Visibility
   cmake_policy(SET CMP0063 NEW)

--- a/src/include/OutputFieldsDefault.h
+++ b/src/include/OutputFieldsDefault.h
@@ -25,6 +25,17 @@ struct OutputFieldsItemParams
 };
 
 // ======================================================================
+// OutputFieldsItem
+
+class OutputFieldsItem : public OutputFieldsItemParams
+{
+public:
+  OutputFieldsItem(const OutputFieldsItemParams& prm)
+    : OutputFieldsItemParams{prm}
+  {}
+};
+
+// ======================================================================
 // OutputFieldsParams
 
 struct OutputFieldsParams
@@ -242,8 +253,8 @@ private:
 
 public:
   const char* data_dir;
-  OutputFieldsItemParams fields;
-  OutputFieldsItemParams moments;
+  OutputFieldsItem fields;
+  OutputFieldsItem moments;
   Int3 rn = {};
   Int3 rx = {1000000, 1000000, 100000};
 

--- a/src/include/OutputFieldsDefault.h
+++ b/src/include/OutputFieldsDefault.h
@@ -46,6 +46,7 @@ public:
   Writer io_tfd_;
   // tfd -- FIXME?! always MfieldsC
   MfieldsC tfd_;
+  int naccum_ = 0;
 };
 
 // ======================================================================
@@ -172,7 +173,7 @@ public:
         prof_start(pr_field_acc);
         fields.tfd_ += pfd_jeh;
         prof_stop(pr_field_acc);
-        naccum_++;
+        fields.naccum_++;
       }
       if (do_tfield) {
         mpi_printf(grid.comm(), "***** Writing TFD output\n");
@@ -181,9 +182,9 @@ public:
         prof_start(pr_field_write);
         fields.io_tfd_.begin_step(grid);
         fields.io_tfd_.set_subset(grid, rn, rx);
-        _write_tfd(fields.io_tfd_, fields.tfd_, pfd_jeh, naccum_);
+        _write_tfd(fields.io_tfd_, fields.tfd_, pfd_jeh, fields.naccum_);
         fields.io_tfd_.end_step();
-        naccum_ = 0;
+        fields.naccum_ = 0;
         prof_stop(pr_field_write);
       }
       prof_stop(pr_field);
@@ -223,7 +224,7 @@ public:
         prof_start(pr_moment_acc);
         moments.tfd_ += pfd_moments;
         prof_stop(pr_moment_acc);
-        naccum_moments_++;
+        moments.naccum_++;
       }
       if (do_tfield_moments) {
         mpi_printf(grid.comm(), "***** Writing TFD moment output\n");
@@ -232,10 +233,10 @@ public:
         prof_start(pr_moment_write);
         moments.io_tfd_.begin_step(grid);
         moments.io_tfd_.set_subset(grid, rn, rx);
-        _write_tfd(moments.io_tfd_, moments.tfd_, pfd_moments, naccum_moments_);
+        _write_tfd(moments.io_tfd_, moments.tfd_, pfd_moments, moments.naccum_);
         moments.io_tfd_.end_step();
         prof_stop(pr_moment_write);
-        naccum_moments_ = 0;
+        moments.naccum_ = 0;
       }
       prof_stop(pr_moment);
     }
@@ -267,8 +268,6 @@ public:
   Int3 rx = {1000000, 1000000, 100000};
 
 private:
-  int naccum_ = 0;
-  int naccum_moments_ = 0;
   bool first_time = true;
 };
 

--- a/src/include/OutputFieldsDefault.h
+++ b/src/include/OutputFieldsDefault.h
@@ -244,7 +244,7 @@ private:
   template <typename EXP>
   static void _write_pfd(Writer& io, EXP& pfd)
   {
-    io.write(evalMfields(pfd), pfd.grid(), pfd.name(), pfd.comp_names());
+    io.write(adapt(evalMfields(pfd)), pfd.grid(), pfd.name(), pfd.comp_names());
   }
 
   template <typename EXP>
@@ -252,7 +252,7 @@ private:
   {
     // convert accumulated values to correct temporal mean
     tfd.scale(1. / naccum);
-    io.write(tfd, tfd.grid(), pfd.name(), pfd.comp_names());
+    io.write(adapt(tfd), tfd.grid(), pfd.name(), pfd.comp_names());
     tfd.zero();
   }
 

--- a/src/include/OutputFieldsDefault.h
+++ b/src/include/OutputFieldsDefault.h
@@ -27,6 +27,7 @@ struct OutputFieldsItemParams
 // ======================================================================
 // OutputFieldsItem
 
+template <typename Writer>
 class OutputFieldsItem : public OutputFieldsItemParams
 {
 public:
@@ -39,6 +40,8 @@ public:
   // private:
   int pfield_next_;
   int tfield_next_;
+  Writer io_pfd_;
+  Writer io_tfd_;
 };
 
 // ======================================================================
@@ -80,16 +83,16 @@ public:
                    grid.ibn}
   {
     if (fields.pfield_interval > 0) {
-      io_pfd_.open("pfd", data_dir);
+      fields.io_pfd_.open("pfd", data_dir);
     }
     if (moments.pfield_interval > 0) {
-      io_pfd_moments_.open("pfd_moments", data_dir);
+      moments.io_pfd_.open("pfd_moments", data_dir);
     }
     if (fields.tfield_interval > 0) {
-      io_tfd_.open("tfd", data_dir);
+      fields.io_tfd_.open("tfd", data_dir);
     }
     if (moments.tfield_interval > 0) {
-      io_tfd_moments_.open("tfd_moments", data_dir);
+      moments.io_tfd_.open("tfd_moments", data_dir);
     }
   }
 
@@ -155,10 +158,10 @@ public:
         fields.pfield_next_ += fields.pfield_interval;
 
         prof_start(pr_field_write);
-        io_pfd_.begin_step(grid);
-        io_pfd_.set_subset(grid, rn, rx);
-        _write_pfd(io_pfd_, pfd_jeh);
-        io_pfd_.end_step();
+        fields.io_pfd_.begin_step(grid);
+        fields.io_pfd_.set_subset(grid, rn, rx);
+        _write_pfd(fields.io_pfd_, pfd_jeh);
+        fields.io_pfd_.end_step();
         prof_stop(pr_field_write);
       }
 
@@ -174,10 +177,10 @@ public:
         fields.tfield_next_ += fields.tfield_interval;
 
         prof_start(pr_field_write);
-        io_tfd_.begin_step(grid);
-        io_tfd_.set_subset(grid, rn, rx);
-        _write_tfd(io_tfd_, tfd_jeh_, pfd_jeh, naccum_);
-        io_tfd_.end_step();
+        fields.io_tfd_.begin_step(grid);
+        fields.io_tfd_.set_subset(grid, rn, rx);
+        _write_tfd(fields.io_tfd_, tfd_jeh_, pfd_jeh, naccum_);
+        fields.io_tfd_.end_step();
         naccum_ = 0;
         prof_stop(pr_field_write);
       }
@@ -206,10 +209,10 @@ public:
         moments.pfield_next_ += moments.pfield_interval;
 
         prof_start(pr_moment_write);
-        io_pfd_moments_.begin_step(grid);
-        io_pfd_moments_.set_subset(grid, rn, rx);
-        _write_pfd(io_pfd_moments_, pfd_moments);
-        io_pfd_moments_.end_step();
+        moments.io_pfd_.begin_step(grid);
+        moments.io_pfd_.set_subset(grid, rn, rx);
+        _write_pfd(moments.io_pfd_, pfd_moments);
+        moments.io_pfd_.end_step();
         prof_stop(pr_moment_write);
       }
 
@@ -225,10 +228,10 @@ public:
         moments.tfield_next_ += moments.tfield_interval;
 
         prof_start(pr_moment_write);
-        io_tfd_moments_.begin_step(grid);
-        io_tfd_moments_.set_subset(grid, rn, rx);
-        _write_tfd(io_tfd_moments_, tfd_moments_, pfd_moments, naccum_moments_);
-        io_tfd_moments_.end_step();
+        moments.io_tfd_.begin_step(grid);
+        moments.io_tfd_.set_subset(grid, rn, rx);
+        _write_tfd(moments.io_tfd_, tfd_moments_, pfd_moments, naccum_moments_);
+        moments.io_tfd_.end_step();
         prof_stop(pr_moment_write);
         naccum_moments_ = 0;
       }
@@ -256,8 +259,8 @@ private:
 
 public:
   const char* data_dir;
-  OutputFieldsItem fields;
-  OutputFieldsItem moments;
+  OutputFieldsItem<Writer> fields;
+  OutputFieldsItem<Writer> moments;
   Int3 rn = {};
   Int3 rx = {1000000, 1000000, 100000};
 
@@ -265,10 +268,6 @@ private:
   // tfd -- FIXME?! always MfieldsC
   MfieldsC tfd_jeh_;
   MfieldsC tfd_moments_;
-  Writer io_pfd_;
-  Writer io_pfd_moments_;
-  Writer io_tfd_;
-  Writer io_tfd_moments_;
   int naccum_ = 0;
   int naccum_moments_ = 0;
   bool first_time = true;

--- a/src/include/OutputFieldsDefault.h
+++ b/src/include/OutputFieldsDefault.h
@@ -51,8 +51,12 @@ public:
   template <typename EXP>
   void write_pfd(EXP& pfd)
   {
+    pfield_next_ += pfield_interval;
+    io_pfd_.begin_step(pfd.grid());
+    io_pfd_.set_subset(pfd.grid(), rn, rx);
     io_pfd_.write(adapt(evalMfields(pfd)), pfd.grid(), pfd.name(),
                   pfd.comp_names());
+    io_pfd_.end_step();
   }
 
   template <typename EXP>
@@ -176,14 +180,9 @@ public:
       prof_stop(pr_field_calc);
 
       if (do_pfield) {
-        mpi_printf(grid.comm(), "***** Writing PFD output\n");
-        fields.pfield_next_ += fields.pfield_interval;
-
         prof_start(pr_field_write);
-        fields.io_pfd_.begin_step(grid);
-        fields.io_pfd_.set_subset(grid, fields.rn, fields.rx);
+        mpi_printf(grid.comm(), "***** Writing PFD output\n");
         fields.write_pfd(pfd_jeh);
-        fields.io_pfd_.end_step();
         prof_stop(pr_field_write);
       }
 
@@ -221,14 +220,9 @@ public:
       prof_stop(pr_moment_calc);
 
       if (do_pfield_moments) {
-        mpi_printf(grid.comm(), "***** Writing PFD moment output\n");
-        moments.pfield_next_ += moments.pfield_interval;
-
         prof_start(pr_moment_write);
-        moments.io_pfd_.begin_step(grid);
-        moments.io_pfd_.set_subset(grid, moments.rn, moments.rx);
+        mpi_printf(grid.comm(), "***** Writing PFD moment output\n");
         moments.write_pfd(pfd_moments);
-        moments.io_pfd_.end_step();
         prof_stop(pr_moment_write);
       }
 

--- a/src/include/OutputFieldsDefault.h
+++ b/src/include/OutputFieldsDefault.h
@@ -46,6 +46,22 @@ public:
     }
   }
 
+  template <typename EXP>
+  void write_pfd(EXP& pfd)
+  {
+    io_pfd_.write(adapt(evalMfields(pfd)), pfd.grid(), pfd.name(),
+                  pfd.comp_names());
+  }
+
+  template <typename EXP>
+  void write_tfd(MfieldsC& tfd, EXP& pfd)
+  {
+    // convert accumulated values to correct temporal mean
+    tfd.scale(1. / naccum_);
+    io_tfd_.write(adapt(tfd), tfd.grid(), pfd.name(), pfd.comp_names());
+    tfd.zero();
+  }
+
   // private:
   int pfield_next_;
   int tfield_next_;
@@ -161,7 +177,7 @@ public:
         prof_start(pr_field_write);
         fields.io_pfd_.begin_step(grid);
         fields.io_pfd_.set_subset(grid, rn, rx);
-        _write_pfd(fields.io_pfd_, pfd_jeh);
+        fields.write_pfd(pfd_jeh);
         fields.io_pfd_.end_step();
         prof_stop(pr_field_write);
       }
@@ -180,7 +196,7 @@ public:
         prof_start(pr_field_write);
         fields.io_tfd_.begin_step(grid);
         fields.io_tfd_.set_subset(grid, rn, rx);
-        _write_tfd(fields.io_tfd_, fields.tfd_, pfd_jeh, fields.naccum_);
+        fields.write_tfd(fields.tfd_, pfd_jeh);
         fields.io_tfd_.end_step();
         fields.naccum_ = 0;
         prof_stop(pr_field_write);
@@ -212,7 +228,7 @@ public:
         prof_start(pr_moment_write);
         moments.io_pfd_.begin_step(grid);
         moments.io_pfd_.set_subset(grid, rn, rx);
-        _write_pfd(moments.io_pfd_, pfd_moments);
+        moments.write_pfd(pfd_moments);
         moments.io_pfd_.end_step();
         prof_stop(pr_moment_write);
       }
@@ -231,7 +247,7 @@ public:
         prof_start(pr_moment_write);
         moments.io_tfd_.begin_step(grid);
         moments.io_tfd_.set_subset(grid, rn, rx);
-        _write_tfd(moments.io_tfd_, moments.tfd_, pfd_moments, moments.naccum_);
+        moments.write_tfd(moments.tfd_, pfd_moments);
         moments.io_tfd_.end_step();
         prof_stop(pr_moment_write);
         moments.naccum_ = 0;
@@ -241,22 +257,6 @@ public:
 
     prof_stop(pr);
   };
-
-private:
-  template <typename EXP>
-  static void _write_pfd(Writer& io, EXP& pfd)
-  {
-    io.write(adapt(evalMfields(pfd)), pfd.grid(), pfd.name(), pfd.comp_names());
-  }
-
-  template <typename EXP>
-  static void _write_tfd(Writer& io, MfieldsC& tfd, EXP& pfd, int naccum)
-  {
-    // convert accumulated values to correct temporal mean
-    tfd.scale(1. / naccum);
-    io.write(adapt(tfd), tfd.grid(), pfd.name(), pfd.comp_names());
-    tfd.zero();
-  }
 
 public:
   const char* data_dir;

--- a/src/include/OutputFieldsDefault.h
+++ b/src/include/OutputFieldsDefault.h
@@ -58,9 +58,17 @@ public:
   template <typename EXP>
   void write_tfd(MfieldsC& tfd, EXP& pfd)
   {
+    tfield_next_ += tfield_interval;
+
     // convert accumulated values to correct temporal mean
     tfd.scale(1. / naccum_);
+
+    io_tfd_.begin_step(tfd.grid());
+    io_tfd_.set_subset(tfd.grid(), rn, rx);
     io_tfd_.write(adapt(tfd), tfd.grid(), pfd.name(), pfd.comp_names());
+    io_tfd_.end_step();
+    naccum_ = 0;
+
     tfd.zero();
   }
 
@@ -187,15 +195,9 @@ public:
         fields.naccum_++;
       }
       if (do_tfield) {
-        mpi_printf(grid.comm(), "***** Writing TFD output\n");
-        fields.tfield_next_ += fields.tfield_interval;
-
         prof_start(pr_field_write);
-        fields.io_tfd_.begin_step(grid);
-        fields.io_tfd_.set_subset(grid, fields.rn, fields.rx);
+        mpi_printf(grid.comm(), "***** Writing TFD output\n");
         fields.write_tfd(fields.tfd_, pfd_jeh);
-        fields.io_tfd_.end_step();
-        fields.naccum_ = 0;
         prof_stop(pr_field_write);
       }
       prof_stop(pr_field);
@@ -238,16 +240,10 @@ public:
         moments.naccum_++;
       }
       if (do_tfield_moments) {
-        mpi_printf(grid.comm(), "***** Writing TFD moment output\n");
-        moments.tfield_next_ += moments.tfield_interval;
-
         prof_start(pr_moment_write);
-        moments.io_tfd_.begin_step(grid);
-        moments.io_tfd_.set_subset(grid, moments.rn, moments.rx);
+        mpi_printf(grid.comm(), "***** Writing TFD moment output\n");
         moments.write_tfd(moments.tfd_, pfd_moments);
-        moments.io_tfd_.end_step();
         prof_stop(pr_moment_write);
-        moments.naccum_ = 0;
       }
       prof_stop(pr_moment);
     }

--- a/src/include/OutputFieldsDefault.h
+++ b/src/include/OutputFieldsDefault.h
@@ -51,6 +51,7 @@ public:
   template <typename EXP>
   void write_pfd(EXP& pfd)
   {
+    mpi_printf(pfd.grid().comm(), "***** Writing PFD output\n");
     pfield_next_ += pfield_interval;
     io_pfd_.begin_step(pfd.grid());
     io_pfd_.set_subset(pfd.grid(), rn, rx);
@@ -62,6 +63,7 @@ public:
   template <typename EXP>
   void write_tfd(MfieldsC& tfd, EXP& pfd)
   {
+    mpi_printf(tfd.grid().comm(), "***** Writing TFD output\n");
     tfield_next_ += tfield_interval;
 
     // convert accumulated values to correct temporal mean
@@ -181,7 +183,6 @@ public:
 
       if (do_pfield) {
         prof_start(pr_field_write);
-        mpi_printf(grid.comm(), "***** Writing PFD output\n");
         fields.write_pfd(pfd_jeh);
         prof_stop(pr_field_write);
       }
@@ -195,7 +196,6 @@ public:
       }
       if (do_tfield) {
         prof_start(pr_field_write);
-        mpi_printf(grid.comm(), "***** Writing TFD output\n");
         fields.write_tfd(fields.tfd_, pfd_jeh);
         prof_stop(pr_field_write);
       }
@@ -221,7 +221,6 @@ public:
 
       if (do_pfield_moments) {
         prof_start(pr_moment_write);
-        mpi_printf(grid.comm(), "***** Writing PFD moment output\n");
         moments.write_pfd(pfd_moments);
         prof_stop(pr_moment_write);
       }
@@ -235,7 +234,6 @@ public:
       }
       if (do_tfield_moments) {
         prof_start(pr_moment_write);
-        mpi_printf(grid.comm(), "***** Writing TFD moment output\n");
         moments.write_tfd(moments.tfd_, pfd_moments);
         prof_stop(pr_moment_write);
       }

--- a/src/include/OutputFieldsDefault.h
+++ b/src/include/OutputFieldsDefault.h
@@ -22,6 +22,8 @@ struct OutputFieldsItemParams
   int tfield_first = 0;
   int tfield_average_length = 1000000;
   int tfield_average_every = 1;
+  Int3 rn = {};
+  Int3 rx = {1000000, 1000000, 100000};
 };
 
 // ======================================================================
@@ -81,9 +83,6 @@ struct OutputFieldsParams
 
   OutputFieldsItemParams fields;
   OutputFieldsItemParams moments;
-
-  Int3 rn = {};
-  Int3 rx = {1000000, 1000000, 100000};
 };
 
 // ======================================================================
@@ -108,9 +107,7 @@ public:
               FieldsItem_Moments_1st_cc<MparticlesFake>::n_comps(grid),
               grid.ibn,
               data_dir,
-              "_moments"},
-      rn{prm.rn},
-      rx{prm.rx}
+              "_moments"}
   {}
 
   // ----------------------------------------------------------------------
@@ -176,7 +173,7 @@ public:
 
         prof_start(pr_field_write);
         fields.io_pfd_.begin_step(grid);
-        fields.io_pfd_.set_subset(grid, rn, rx);
+        fields.io_pfd_.set_subset(grid, fields.rn, fields.rx);
         fields.write_pfd(pfd_jeh);
         fields.io_pfd_.end_step();
         prof_stop(pr_field_write);
@@ -195,7 +192,7 @@ public:
 
         prof_start(pr_field_write);
         fields.io_tfd_.begin_step(grid);
-        fields.io_tfd_.set_subset(grid, rn, rx);
+        fields.io_tfd_.set_subset(grid, fields.rn, fields.rx);
         fields.write_tfd(fields.tfd_, pfd_jeh);
         fields.io_tfd_.end_step();
         fields.naccum_ = 0;
@@ -227,7 +224,7 @@ public:
 
         prof_start(pr_moment_write);
         moments.io_pfd_.begin_step(grid);
-        moments.io_pfd_.set_subset(grid, rn, rx);
+        moments.io_pfd_.set_subset(grid, moments.rn, moments.rx);
         moments.write_pfd(pfd_moments);
         moments.io_pfd_.end_step();
         prof_stop(pr_moment_write);
@@ -246,7 +243,7 @@ public:
 
         prof_start(pr_moment_write);
         moments.io_tfd_.begin_step(grid);
-        moments.io_tfd_.set_subset(grid, rn, rx);
+        moments.io_tfd_.set_subset(grid, moments.rn, moments.rx);
         moments.write_tfd(moments.tfd_, pfd_moments);
         moments.io_tfd_.end_step();
         prof_stop(pr_moment_write);
@@ -262,8 +259,6 @@ public:
   const char* data_dir;
   OutputFieldsItem<Writer> fields;
   OutputFieldsItem<Writer> moments;
-  Int3 rn = {};
-  Int3 rx = {1000000, 1000000, 100000};
 
 private:
   bool first_time = true;

--- a/src/include/OutputFieldsDefault.h
+++ b/src/include/OutputFieldsDefault.h
@@ -60,26 +60,6 @@ public:
       pfield_next_{fields.pfield_first},
       tfield_next_{fields.tfield_first}
   {
-    if (moments.pfield_interval < 0) {
-      moments.pfield_interval = fields.pfield_interval;
-    }
-    if (moments.pfield_first < 0) {
-      moments.pfield_first = fields.pfield_first;
-    }
-
-    if (moments.tfield_interval < 0) {
-      moments.tfield_interval = fields.tfield_interval;
-    }
-    if (moments.tfield_first < 0) {
-      moments.tfield_first = fields.tfield_first;
-    }
-    if (moments.tfield_average_length < 0) {
-      moments.tfield_average_length = fields.tfield_average_length;
-    }
-    if (moments.tfield_average_every < 0) {
-      moments.tfield_average_every = fields.tfield_average_every;
-    }
-
     pfield_moments_next_ = moments.pfield_first;
     tfield_moments_next_ = moments.tfield_first;
 

--- a/src/include/OutputFieldsDefault.h
+++ b/src/include/OutputFieldsDefault.h
@@ -32,12 +32,19 @@ class OutputFieldsItem : public OutputFieldsItemParams
 {
 public:
   OutputFieldsItem(const Grid_t& grid, const OutputFieldsItemParams& prm,
-                   int n_comps, Int3 ibn)
+                   int n_comps, Int3 ibn, const char* data_dir, std::string sfx)
     : OutputFieldsItemParams{prm},
       pfield_next_{prm.pfield_first},
       tfield_next_{prm.tfield_first},
       tfd_{grid, n_comps, ibn}
-  {}
+  {
+    if (pfield_interval > 0) {
+      io_pfd_.open("pfd" + sfx, data_dir);
+    }
+    if (tfield_interval > 0) {
+      io_tfd_.open("tfd" + sfx, data_dir);
+    }
+  }
 
   // private:
   int pfield_next_;
@@ -78,26 +85,17 @@ public:
 
   OutputFieldsDefault(const Grid_t& grid, const OutputFieldsParams& prm)
     : data_dir{prm.data_dir},
-      fields{grid, prm.fields, Item_jeh<MfieldsFake>::n_comps(), {}},
-      moments{grid, prm.moments,
+      fields{grid, prm.fields, Item_jeh<MfieldsFake>::n_comps(),
+             {},   data_dir,   ""},
+      moments{grid,
+              prm.moments,
               FieldsItem_Moments_1st_cc<MparticlesFake>::n_comps(grid),
-              grid.ibn},
+              grid.ibn,
+              data_dir,
+              "_moments"},
       rn{prm.rn},
       rx{prm.rx}
-  {
-    if (fields.pfield_interval > 0) {
-      fields.io_pfd_.open("pfd", data_dir);
-    }
-    if (moments.pfield_interval > 0) {
-      moments.io_pfd_.open("pfd_moments", data_dir);
-    }
-    if (fields.tfield_interval > 0) {
-      fields.io_tfd_.open("tfd", data_dir);
-    }
-    if (moments.tfield_interval > 0) {
-      moments.io_tfd_.open("tfd_moments", data_dir);
-    }
-  }
+  {}
 
   // ----------------------------------------------------------------------
   // operator()

--- a/src/include/OutputFieldsDefault.h
+++ b/src/include/OutputFieldsDefault.h
@@ -42,7 +42,7 @@ struct OutputFieldsParams
 // OutputFieldsDefault
 
 template <typename Writer>
-class OutputFieldsDefault : public OutputFieldsParams
+class OutputFieldsDefault
 {
   using MfieldsFake = MfieldsC;
   using MparticlesFake = MparticlesDouble;
@@ -52,7 +52,11 @@ public:
   // ctor
 
   OutputFieldsDefault(const Grid_t& grid, const OutputFieldsParams& prm)
-    : OutputFieldsParams{prm},
+    : data_dir{prm.data_dir},
+      fields{prm.fields},
+      moments{prm.moments},
+      rn{prm.rn},
+      rx{prm.rx},
       tfd_jeh_{grid, Item_jeh<MfieldsFake>::n_comps(), {}},
       tfd_moments_{grid,
                    FieldsItem_Moments_1st_cc<MparticlesFake>::n_comps(grid),
@@ -235,6 +239,13 @@ private:
     io.write(adapt(tfd), tfd.grid(), pfd.name(), pfd.comp_names());
     tfd.zero();
   }
+
+public:
+  const char* data_dir;
+  OutputFieldsItemParams fields;
+  OutputFieldsItemParams moments;
+  Int3 rn = {};
+  Int3 rx = {1000000, 1000000, 100000};
 
 private:
   // tfd -- FIXME?! always MfieldsC

--- a/src/include/OutputFieldsDefault.h
+++ b/src/include/OutputFieldsDefault.h
@@ -244,7 +244,7 @@ private:
   template <typename EXP>
   static void _write_pfd(Writer& io, EXP& pfd)
   {
-    io.write(pfd, pfd.grid(), pfd.name(), pfd.comp_names());
+    io.write(evalMfields(pfd), pfd.grid(), pfd.name(), pfd.comp_names());
   }
 
   template <typename EXP>

--- a/src/include/OutputFieldsDefault.h
+++ b/src/include/OutputFieldsDefault.h
@@ -60,22 +60,22 @@ public:
     io_pfd_.end_step();
   }
 
-  template <typename EXP>
-  void write_tfd(MfieldsC& tfd, EXP& pfd)
+  template <typename E, typename EXP>
+  void write_tfd(E tfd, EXP& pfd)
   {
-    mpi_printf(tfd.grid().comm(), "***** Writing TFD output\n");
+    mpi_printf(pfd.grid().comm(), "***** Writing TFD output\n");
     tfield_next_ += tfield_interval;
 
     // convert accumulated values to correct temporal mean
-    tfd.scale(1. / naccum_);
+    tfd = (1. / naccum_) * tfd;
 
-    io_tfd_.begin_step(tfd.grid());
-    io_tfd_.set_subset(tfd.grid(), rn, rx);
-    io_tfd_.write(adapt(tfd), tfd.grid(), pfd.name(), pfd.comp_names());
+    io_tfd_.begin_step(pfd.grid());
+    io_tfd_.set_subset(pfd.grid(), rn, rx);
+    io_tfd_.write(tfd, pfd.grid(), pfd.name(), pfd.comp_names());
     io_tfd_.end_step();
     naccum_ = 0;
 
-    tfd.zero();
+    tfd = 0;
   }
 
   // private:
@@ -196,7 +196,7 @@ public:
       }
       if (do_tfield) {
         prof_start(pr_field_write);
-        fields.write_tfd(fields.tfd_, pfd_jeh);
+        fields.write_tfd(adapt(fields.tfd_), pfd_jeh);
         prof_stop(pr_field_write);
       }
       prof_stop(pr_field);
@@ -234,7 +234,7 @@ public:
       }
       if (do_tfield_moments) {
         prof_start(pr_moment_write);
-        moments.write_tfd(moments.tfd_, pfd_moments);
+        moments.write_tfd(adapt(moments.tfd_), pfd_moments);
         prof_stop(pr_moment_write);
       }
       prof_stop(pr_moment);

--- a/src/include/OutputFieldsDefault.h
+++ b/src/include/OutputFieldsDefault.h
@@ -179,6 +179,7 @@ public:
       prof_start(pr_field);
       prof_start(pr_field_calc);
       Item_jeh<MfieldsState> pfd_jeh{mflds};
+      auto&& pfd = adapt_item(pfd_jeh);
       prof_stop(pr_field_calc);
 
       if (do_pfield) {
@@ -190,7 +191,7 @@ public:
       if (doaccum_tfield) {
         // tfd += pfd
         prof_start(pr_field_acc);
-        fields.tfd_ += pfd_jeh;
+        adapt(fields.tfd_) = adapt(fields.tfd_) + pfd;
         prof_stop(pr_field_acc);
         fields.naccum_++;
       }
@@ -217,6 +218,7 @@ public:
       prof_start(pr_moment);
       prof_start(pr_moment_calc);
       FieldsItem_Moments_1st_cc<Mparticles> pfd_moments{mprts};
+      auto&& pfd = adapt_item(pfd_moments);
       prof_stop(pr_moment_calc);
 
       if (do_pfield_moments) {
@@ -228,7 +230,7 @@ public:
       if (doaccum_tfield_moments) {
         // tfd += pfd
         prof_start(pr_moment_acc);
-        moments.tfd_ += pfd_moments;
+        adapt(moments.tfd_) = adapt(moments.tfd_) + pfd;
         prof_stop(pr_moment_acc);
         moments.naccum_++;
       }

--- a/src/include/fields.hxx
+++ b/src/include/fields.hxx
@@ -5,6 +5,8 @@
 #include "dim.hxx"
 #include "kg/Vec3.h"
 
+#include <gtensor/gtensor.h>
+
 template <typename F, typename D = dim_xyz>
 class Fields3d
 {
@@ -20,18 +22,18 @@ public:
       im(f.im())
   {}
 
-  const real_t operator()(int m, int i, int j, int k) const
+  GT_INLINE const real_t operator()(int m, int i, int j, int k) const
   {
     return data_[index(m, i, j, k)];
   }
 
-  real_t& operator()(int m, int i, int j, int k)
+  GT_INLINE real_t& operator()(int m, int i, int j, int k)
   {
     return data_[index(m, i, j, k)];
   }
 
 private:
-  int index(int m, int i_, int j_, int k_) const
+  GT_INLINE int index(int m, int i_, int j_, int k_) const
   {
     int i = dim::InvarX::value ? 0 : i_;
     int j = dim::InvarY::value ? 0 : j_;

--- a/src/include/fields3d.hxx
+++ b/src/include/fields3d.hxx
@@ -606,4 +606,21 @@ const MfieldsStateBase::Convert
 extern template const MfieldsStateBase::Convert
   MfieldsStateFromMfields<Mfields<double>>::convert_from_;
 
+#include <gtensor/gtensor.h>
+
+using namespace gt::placeholders;
+
+template <typename Mfields>
+auto adapt(Mfields& mflds)
+{
+  auto ib = mflds.ib(), im = mflds.im(), bnd = -ib;
+  auto mf_ =
+    gt::adapt<5>(&mflds(0, ib[0], ib[1], ib[2], 0),
+                 {im[0], im[1], im[2], mflds.n_comps(), mflds.n_patches()});
+  auto mf = std::move(mf_).view(_s(bnd[0], -bnd[0]), _s(bnd[1], -bnd[1]),
+                                _s(bnd[2], -bnd[2]));
+
+  return mf;
+}
+
 #endif

--- a/src/include/fields3d.hxx
+++ b/src/include/fields3d.hxx
@@ -611,8 +611,9 @@ extern template const MfieldsStateBase::Convert
 using namespace gt::placeholders;
 
 template <typename Mfields>
-auto adapt(Mfields& mflds)
+auto adapt(Mfields& _mflds)
 {
+  auto& mflds = const_cast<std::remove_const_t<Mfields>&>(_mflds);
   auto ib = mflds.ib(), im = mflds.im(), bnd = -ib;
   auto mf_ =
     gt::adapt<5>(&mflds(0, ib[0], ib[1], ib[2], 0),

--- a/src/include/fields3d.hxx
+++ b/src/include/fields3d.hxx
@@ -611,7 +611,7 @@ extern template const MfieldsStateBase::Convert
 using namespace gt::placeholders;
 
 template <typename Mfields>
-auto adapt(Mfields& _mflds)
+auto adapt(const Mfields& _mflds)
 {
   auto& mflds = const_cast<std::remove_const_t<Mfields>&>(_mflds);
   auto ib = mflds.ib(), im = mflds.im(), bnd = -ib;

--- a/src/include/fields3d.hxx
+++ b/src/include/fields3d.hxx
@@ -556,6 +556,9 @@ struct MfieldsStateFromMfields : MfieldsStateBase
 
   const Grid_t& grid() const { return mflds_.grid(); }
   int n_patches() const { return mflds_.n_patches(); }
+  Int3 ib() const { return mflds_.ib(); }
+  Int3 im() const { return mflds_.im(); }
+  int n_comps() const { return mflds_.n_comps(); }
 
   fields_view_t operator[](int p) { return mflds_[p]; }
 
@@ -609,6 +612,12 @@ extern template const MfieldsStateBase::Convert
 #include <gtensor/gtensor.h>
 
 using namespace gt::placeholders;
+
+template <typename Item>
+auto adapt_item(const Item& item)
+{
+  return adapt(item.result());
+}
 
 template <typename Mfields>
 auto adapt(const Mfields& _mflds)

--- a/src/include/writer_mrc.hxx
+++ b/src/include/writer_mrc.hxx
@@ -68,11 +68,9 @@ public:
   void end_step() { mrc_io_close(io_.get()); }
 
   template <typename Mfields>
-  void write(const Mfields& mflds, const Grid_t& grid, const std::string& name,
+  void write(const Mfields& mf, const Grid_t& grid, const std::string& name,
              const std::vector<std::string>& comp_names)
   {
-    auto mf = adapt(mflds);
-
     int n_comps = comp_names.size();
     // FIXME, should generally equal the # of component in mflds,
     // but this way allows us to write fewer components, useful to hack around
@@ -87,7 +85,7 @@ public:
       mrc_fld_set_comp_name(fld, m, comp_names[m].c_str());
     }
 
-    for (int p = 0; p < mflds.n_patches(); p++) {
+    for (int p = 0; p < mf.shape(4); p++) {
       for (int m = 0; m < n_comps; m++) {
         mrc_fld_foreach(fld, i, j, k, 0, 0)
         {

--- a/src/include/writer_mrc.hxx
+++ b/src/include/writer_mrc.hxx
@@ -73,6 +73,7 @@ public:
   {
     auto&& eval_mflds = evalMfields(_mflds);
     auto& mflds = const_cast<MfieldsC&>(eval_mflds);
+    auto mf = adapt(mflds);
 
     int n_comps = comp_names.size();
     // FIXME, should generally equal the # of component in mflds,
@@ -92,7 +93,7 @@ public:
       for (int m = 0; m < n_comps; m++) {
         mrc_fld_foreach(fld, i, j, k, 0, 0)
         {
-          MRC_S5(fld, i, j, k, m, p) = mflds(m, i, j, k, p);
+          MRC_S5(fld, i, j, k, m, p) = mf(i, j, k, m, p);
         }
         mrc_fld_foreach_end;
       }

--- a/src/include/writer_mrc.hxx
+++ b/src/include/writer_mrc.hxx
@@ -68,10 +68,9 @@ public:
   void end_step() { mrc_io_close(io_.get()); }
 
   template <typename Mfields>
-  void write(const Mfields& _mflds, const Grid_t& grid, const std::string& name,
+  void write(const Mfields& mflds, const Grid_t& grid, const std::string& name,
              const std::vector<std::string>& comp_names)
   {
-    auto& mflds = const_cast<Mfields&>(_mflds);
     auto mf = adapt(mflds);
 
     int n_comps = comp_names.size();

--- a/src/include/writer_mrc.hxx
+++ b/src/include/writer_mrc.hxx
@@ -71,8 +71,7 @@ public:
   void write(const Mfields& _mflds, const Grid_t& grid, const std::string& name,
              const std::vector<std::string>& comp_names)
   {
-    auto&& eval_mflds = evalMfields(_mflds);
-    auto& mflds = const_cast<MfieldsC&>(eval_mflds);
+    auto& mflds = const_cast<Mfields&>(_mflds);
     auto mf = adapt(mflds);
 
     int n_comps = comp_names.size();

--- a/src/libpsc/cuda/checks_cuda_impl.hxx
+++ b/src/libpsc/cuda/checks_cuda_impl.hxx
@@ -108,8 +108,8 @@ struct ChecksCuda
         writer.open("continuity");
       }
       writer.begin_step(grid.timestep(), grid.timestep() * grid.dt);
-      writer.write(divj_, grid, "div_j", {"div_j"});
-      writer.write(d_rho, grid, "d_rho", {"d_rho"});
+      writer.write(adapt(divj_), grid, "div_j", {"div_j"});
+      writer.write(adapt(d_rho), grid, "d_rho", {"d_rho"});
       writer.end_step();
     }
 
@@ -185,8 +185,8 @@ struct ChecksCuda
         writer.open("gauss");
       }
       writer.begin_step(grid.timestep(), grid.timestep() * grid.dt);
-      writer.write(evalMfields(rho), grid, "rho", {"rho"});
-      writer.write(evalMfields(dive), dive.grid(), dive.name(),
+      writer.write(adapt(evalMfields(rho)), grid, "rho", {"rho"});
+      writer.write(adapt(evalMfields(dive)), dive.grid(), dive.name(),
                    dive.comp_names());
       writer.end_step();
     }

--- a/src/libpsc/cuda/checks_cuda_impl.hxx
+++ b/src/libpsc/cuda/checks_cuda_impl.hxx
@@ -185,8 +185,9 @@ struct ChecksCuda
         writer.open("gauss");
       }
       writer.begin_step(grid.timestep(), grid.timestep() * grid.dt);
-      writer.write(rho, grid, "rho", {"rho"});
-      writer.write(dive, dive.grid(), dive.name(), dive.comp_names());
+      writer.write(evalMfields(rho), grid, "rho", {"rho"});
+      writer.write(evalMfields(dive), dive.grid(), dive.name(),
+                   dive.comp_names());
       writer.end_step();
     }
 

--- a/src/libpsc/cuda/marder_cuda_impl.hxx
+++ b/src/libpsc/cuda/marder_cuda_impl.hxx
@@ -45,8 +45,8 @@ struct MarderCuda : MarderBase
       static int cnt;
       io_.begin_step(cnt, cnt); // ppsc->timestep, ppsc->timestep * ppsc->dt);
       cnt++;
-      io_.write(evalMfields(rho), rho.grid(), "rho", {"rho"});
-      io_.write(evalMfields(dive), dive.grid(), "dive", {"dive"});
+      io_.write(adapt(evalMfields(rho)), rho.grid(), "rho", {"rho"});
+      io_.write(adapt(evalMfields(dive)), dive.grid(), "dive", {"dive"});
       io_.end_step();
     }
 

--- a/src/libpsc/cuda/marder_cuda_impl.hxx
+++ b/src/libpsc/cuda/marder_cuda_impl.hxx
@@ -45,8 +45,8 @@ struct MarderCuda : MarderBase
       static int cnt;
       io_.begin_step(cnt, cnt); // ppsc->timestep, ppsc->timestep * ppsc->dt);
       cnt++;
-      io_.write(rho, rho.grid(), "rho", {"rho"});
-      io_.write(dive, dive.grid(), "dive", {"dive"});
+      io_.write(evalMfields(rho), rho.grid(), "rho", {"rho"});
+      io_.write(evalMfields(dive), dive.grid(), "dive", {"dive"});
       io_.end_step();
     }
 

--- a/src/libpsc/psc_checks/checks_impl.hxx
+++ b/src/libpsc/psc_checks/checks_impl.hxx
@@ -114,8 +114,8 @@ struct Checks_
         writer.open("continuity");
       }
       writer.begin_step(grid.timestep(), grid.timestep() * grid.dt);
-      writer.write(evalMfields(divj_), grid, "div_j", {"div_j"});
-      writer.write(evalMfields(d_rho), grid, "d_rho", {"d_rho"});
+      writer.write(adapt(evalMfields(divj_)), grid, "div_j", {"div_j"});
+      writer.write(adapt(evalMfields(d_rho)), grid, "d_rho", {"d_rho"});
       writer.end_step();
     }
 
@@ -183,8 +183,8 @@ struct Checks_
         writer.open("gauss");
       }
       writer.begin_step(grid.timestep(), grid.timestep() * grid.dt);
-      writer.write(evalMfields(rho_), grid, "rho", {"rho"});
-      writer.write(evalMfields(dive), dive.grid(), dive.name(),
+      writer.write(adapt(evalMfields(rho_)), grid, "rho", {"rho"});
+      writer.write(adapt(evalMfields(dive)), dive.grid(), dive.name(),
                    dive.comp_names());
       writer.end_step();
     }

--- a/src/libpsc/psc_checks/checks_impl.hxx
+++ b/src/libpsc/psc_checks/checks_impl.hxx
@@ -114,8 +114,8 @@ struct Checks_
         writer.open("continuity");
       }
       writer.begin_step(grid.timestep(), grid.timestep() * grid.dt);
-      writer.write(divj_, grid, "div_j", {"div_j"});
-      writer.write(d_rho, grid, "d_rho", {"d_rho"});
+      writer.write(evalMfields(divj_), grid, "div_j", {"div_j"});
+      writer.write(evalMfields(d_rho), grid, "d_rho", {"d_rho"});
       writer.end_step();
     }
 
@@ -183,8 +183,9 @@ struct Checks_
         writer.open("gauss");
       }
       writer.begin_step(grid.timestep(), grid.timestep() * grid.dt);
-      writer.write(rho_, grid, "rho", {"rho"});
-      writer.write(dive, dive.grid(), dive.name(), dive.comp_names());
+      writer.write(evalMfields(rho_), grid, "rho", {"rho"});
+      writer.write(evalMfields(dive), dive.grid(), dive.name(),
+                   dive.comp_names());
       writer.end_step();
     }
 

--- a/src/libpsc/psc_output_fields/fields_item_fields.hxx
+++ b/src/libpsc/psc_output_fields/fields_item_fields.hxx
@@ -516,7 +516,7 @@ public:
 
   Item_jeh(MfieldsState& mflds) : mflds_{mflds} {}
 
-  Real operator()(int m, Int3 ijk, int p) const
+  const Real& operator()(int m, Int3 ijk, int p) const
   {
     return mflds_(m, ijk[0], ijk[1], ijk[2], p);
   }
@@ -524,6 +524,8 @@ public:
   const Grid_t& grid() const { return mflds_.grid(); }
   Int3 ibn() const { return {}; }
   int n_patches() const { return grid().n_patches(); }
+
+  MfieldsState& result() const { return mflds_; }
 
 private:
   MfieldsState& mflds_;
@@ -565,7 +567,7 @@ public:
     }
   }
 
-  Real operator()(int m, Int3 ijk, int p) const
+  const Real& operator()(int m, Int3 ijk, int p) const
   {
     return mflds_(m, ijk[0], ijk[1], ijk[2], p);
   }
@@ -573,6 +575,8 @@ public:
   const Grid_t& grid() const { return mflds_.grid(); }
   Int3 ibn() const { return {}; }
   int n_patches() const { return grid().n_patches(); }
+
+  MfieldsSingle& result() const { return mflds_; }
 
 private:
   mutable MfieldsSingle mflds_; // FIXME!!

--- a/src/libpsc/psc_output_fields/fields_item_moments_1st.hxx
+++ b/src/libpsc/psc_output_fields/fields_item_moments_1st.hxx
@@ -242,6 +242,8 @@ public:
     });
     Base::bnd_.add_ghosts(Base::mres_);
   }
+
+  const Mfields& result() const { return Base::mres_; }
 };
 
 #ifdef USE_CUDA
@@ -392,6 +394,8 @@ public:
     mprts.put_as(h_mprts, MP_DONT_COPY);
     prof_stop(pr);
   }
+
+  const Mfields& result() const { return Base::mres_; }
 };
 
 #endif

--- a/src/libpsc/psc_push_fields/marder_impl.hxx
+++ b/src/libpsc/psc_push_fields/marder_impl.hxx
@@ -47,8 +47,8 @@ struct Marder_ : MarderBase
       static int cnt;
       io_.begin_step(cnt, cnt); // ppsc->timestep, ppsc->timestep * ppsc->dt);
       cnt++;
-      io_.write(evalMfields(rho_), rho_.grid(), "rho", {"rho"});
-      io_.write(evalMfields(dive), dive.grid(), "dive", {"dive"});
+      io_.write(adapt(evalMfields(rho_)), rho_.grid(), "rho", {"rho"});
+      io_.write(adapt(evalMfields(dive)), dive.grid(), "dive", {"dive"});
       io_.end_step();
     }
 

--- a/src/libpsc/psc_push_fields/marder_impl.hxx
+++ b/src/libpsc/psc_push_fields/marder_impl.hxx
@@ -47,8 +47,8 @@ struct Marder_ : MarderBase
       static int cnt;
       io_.begin_step(cnt, cnt); // ppsc->timestep, ppsc->timestep * ppsc->dt);
       cnt++;
-      io_.write(rho_, rho_.grid(), "rho", {"rho"});
-      io_.write(dive, dive.grid(), "dive", {"dive"});
+      io_.write(evalMfields(rho_), rho_.grid(), "rho", {"rho"});
+      io_.write(evalMfields(dive), dive.grid(), "dive", {"dive"});
       io_.end_step();
     }
 

--- a/src/psc_bubble_yz.cxx
+++ b/src/psc_bubble_yz.cxx
@@ -332,7 +332,7 @@ static void run()
 
   // -- output fields
   OutputFieldsParams outf_params{};
-  outf_params.pfield_interval = 200;
+  outf_params.fields.pfield_interval = 200;
   OutputFields outf{grid, outf_params};
 
   // -- output particles

--- a/src/psc_flatfoil_yz.cxx
+++ b/src/psc_flatfoil_yz.cxx
@@ -520,21 +520,21 @@ void run()
   // -- output fields
   OutputFieldsParams outf_params{};
 #if CASE == CASE_1D
-  outf_params.pfield_interval = 100;
-  outf_params.tfield_interval = -100;
+  outf_params.fields.pfield_interval = 100;
+  outf_params.fields.tfield_interval = -100;
 #elif CASE == CASE_2D_SMALL
-  outf_params.pfield_interval = 4;
-  outf_params.tfield_interval = 4;
+  outf_params.fields.pfield_interval = 4;
+  outf_params.fields.tfield_interval = 4;
 #else
-  outf_params.pfield_interval = 500;
-  outf_params.tfield_interval = 500;
+  outf_params.fields.pfield_interval = 500;
+  outf_params.fields.tfield_interval = 500;
 #endif
 #if CASE == CASE_2D_SMALL
-  outf_params.tfield_average_every = 2;
-  outf_params.tfield_moments_average_every = 2;
+  outf_params.fields.tfield_average_every = 2;
+  outf_params.moments.tfield_average_every = 2;
 #else
-  outf_params.tfield_average_every = 50;
-  outf_params.tfield_moments_average_every = 50;
+  outf_params.fields.tfield_average_every = 50;
+  outf_params.moments.tfield_average_every = 50;
 #endif
   OutputFields outf{grid, outf_params};
 

--- a/src/psc_flatfoil_yz.cxx
+++ b/src/psc_flatfoil_yz.cxx
@@ -518,24 +518,26 @@ void run()
   // FIXME, this really is too complicated and not very flexible
 
   // -- output fields
+  OutputFieldsItemParams outf_item_params{};
   OutputFieldsParams outf_params{};
 #if CASE == CASE_1D
-  outf_params.fields.pfield_interval = 100;
-  outf_params.fields.tfield_interval = -100;
+  outf_item_params.pfield_interval = 100;
+  outf_item_params.tfield_interval = -100;
 #elif CASE == CASE_2D_SMALL
-  outf_params.fields.pfield_interval = 4;
-  outf_params.fields.tfield_interval = 4;
+  outf_item_params.pfield_interval = 4;
+  outf_item_params.tfield_interval = 4;
 #else
-  outf_params.fields.pfield_interval = 500;
-  outf_params.fields.tfield_interval = 500;
+  outf_item_params.pfield_interval = 500;
+  outf_item_params.tfield_interval = 500;
 #endif
 #if CASE == CASE_2D_SMALL
-  outf_params.fields.tfield_average_every = 2;
-  outf_params.moments.tfield_average_every = 2;
+  outf_item_params.tfield_average_every = 2;
 #else
-  outf_params.fields.tfield_average_every = 50;
-  outf_params.moments.tfield_average_every = 50;
+  outf_item_params.tfield_average_every = 50;
 #endif
+
+  outf_params.fields = outf_item_params;
+  outf_params.moments = outf_item_params;
   OutputFields outf{grid, outf_params};
 
   // -- output particles

--- a/src/psc_harris_xz.cxx
+++ b/src/psc_harris_xz.cxx
@@ -514,7 +514,8 @@ public:
     MPI_Comm comm = grid.comm();
 
     int timestep = grid.timestep();
-    if (outf_.pfield_interval > 0 && timestep % outf_.pfield_interval == 0) {
+    if (outf_.fields.pfield_interval > 0 &&
+        timestep % outf_.fields.pfield_interval == 0) {
       mpi_printf(comm, "***** Writing PFD output\n");
       io_pfd_.begin_step(grid);
 
@@ -533,7 +534,7 @@ public:
       io_pfd_.end_step();
     }
 
-    if (outf_.tfield_interval > 0) {
+    if (outf_.fields.tfield_interval > 0) {
       auto result_state = outf_state_(mflds);
 
       for (int p = 0; p < mflds_acc_state_.n_patches(); p++) {
@@ -557,7 +558,7 @@ public:
 
       n_accum_++;
 
-      if (timestep % outf_.tfield_interval == 0) {
+      if (timestep % outf_.fields.tfield_interval == 0) {
         mpi_printf(comm, "***** Writing TFD output\n");
         io_tfd_.begin_step(grid);
         mflds_acc_state_.scale(1. / n_accum_);
@@ -867,9 +868,9 @@ void run()
   // -- output fields
   OutputFieldsParams outf_params;
   double output_field_interval = 1.;
-  outf_params.pfield_interval =
+  outf_params.fields.pfield_interval =
     int((output_field_interval / (phys.wci * grid.dt)));
-  outf_params.tfield_interval =
+  outf_params.fields.tfield_interval =
     int((output_field_interval / (phys.wci * grid.dt)));
   OutputFields outf{grid, outf_params};
 

--- a/src/psc_harris_xz.cxx
+++ b/src/psc_harris_xz.cxx
@@ -520,13 +520,13 @@ public:
 
       {
         auto result = outf_state_(mflds);
-        io_pfd_.write(evalMfields(result.mflds), grid, result.name,
+        io_pfd_.write(adapt(evalMfields(result.mflds)), grid, result.name,
                       result.comp_names);
       }
 
       {
         auto result = outf_hydro_(mprts, *hydro, *interpolator);
-        io_pfd_.write(evalMfields(result.mflds), grid, result.name,
+        io_pfd_.write(adapt(result.mflds), grid, result.name,
                       result.comp_names);
       }
 
@@ -561,12 +561,12 @@ public:
         mpi_printf(comm, "***** Writing TFD output\n");
         io_tfd_.begin_step(grid);
         mflds_acc_state_.scale(1. / n_accum_);
-        io_tfd_.write(mflds_acc_state_, grid, result_state.name,
+        io_tfd_.write(adapt(mflds_acc_state_), grid, result_state.name,
                       result_state.comp_names);
         mflds_acc_state_.zero();
 
         mflds_acc_hydro_.scale(1. / n_accum_);
-        io_tfd_.write(mflds_acc_hydro_, grid, result_hydro.name,
+        io_tfd_.write(adapt(mflds_acc_hydro_), grid, result_hydro.name,
                       result_hydro.comp_names);
         mflds_acc_hydro_.zero();
 

--- a/src/psc_harris_xz.cxx
+++ b/src/psc_harris_xz.cxx
@@ -520,12 +520,14 @@ public:
 
       {
         auto result = outf_state_(mflds);
-        io_pfd_.write(result.mflds, grid, result.name, result.comp_names);
+        io_pfd_.write(evalMfields(result.mflds), grid, result.name,
+                      result.comp_names);
       }
 
       {
         auto result = outf_hydro_(mprts, *hydro, *interpolator);
-        io_pfd_.write(result.mflds, grid, result.name, result.comp_names);
+        io_pfd_.write(evalMfields(result.mflds), grid, result.name,
+                      result.comp_names);
       }
 
       io_pfd_.end_step();

--- a/src/psc_whistler.cxx
+++ b/src/psc_whistler.cxx
@@ -311,7 +311,7 @@ void run()
 
   // -- output fields
   OutputFieldsParams outf_params{};
-  outf_params.pfield_interval = 200;
+  outf_params.fields.pfield_interval = 200;
   OutputFields outf{grid, outf_params};
 
   // -- output particles


### PR DESCRIPTION
This PR mostly does some consolidation on the OutputFields code, consolidating repeated code between writing out EMJ fields and the moments.

This starts using gtensor arrays in some minor fashion in order to facilitate better unification of the cuda and non-cuda pathways in the code, with one the first goals being able to support computation and aggregation (or time-averaging) of the moments completely on the GPU.