### PR TITLE
start getting rid of adapt() again

### DIFF
--- a/src/include/OutputFieldsDefault.h
+++ b/src/include/OutputFieldsDefault.h
@@ -38,7 +38,7 @@ public:
     : OutputFieldsItemParams{prm},
       pfield_next_{prm.pfield_first},
       tfield_next_{prm.tfield_first},
-      tfd_{grid, n_comps, ibn}
+      tfd_{grid, n_comps, {}}
   {
     if (pfield_interval > 0) {
       io_pfd_.open("pfd" + sfx, data_dir);
@@ -191,7 +191,7 @@ public:
       if (doaccum_tfield) {
         // tfd += pfd
         prof_start(pr_field_acc);
-        adapt(fields.tfd_) = adapt(fields.tfd_) + pfd;
+        fields.tfd_.storage() = fields.tfd_.storage() + pfd;
         prof_stop(pr_field_acc);
         fields.naccum_++;
       }
@@ -230,7 +230,7 @@ public:
       if (doaccum_tfield_moments) {
         // tfd += pfd
         prof_start(pr_moment_acc);
-        adapt(moments.tfd_) = adapt(moments.tfd_) + pfd;
+        moments.tfd_.storage() = moments.tfd_.storage() + pfd;
         prof_stop(pr_moment_acc);
         moments.naccum_++;
       }

--- a/src/include/OutputFieldsDefault.h
+++ b/src/include/OutputFieldsDefault.h
@@ -48,15 +48,14 @@ public:
     }
   }
 
-  template <typename EXP>
-  void write_pfd(EXP& pfd)
+  template <typename E, typename EXP>
+  void write_pfd(const E& gt_pfd, EXP& pfd)
   {
     mpi_printf(pfd.grid().comm(), "***** Writing PFD output\n");
     pfield_next_ += pfield_interval;
     io_pfd_.begin_step(pfd.grid());
     io_pfd_.set_subset(pfd.grid(), rn, rx);
-    io_pfd_.write(adapt(evalMfields(pfd)), pfd.grid(), pfd.name(),
-                  pfd.comp_names());
+    io_pfd_.write(gt_pfd, pfd.grid(), pfd.name(), pfd.comp_names());
     io_pfd_.end_step();
   }
 
@@ -184,7 +183,7 @@ public:
 
       if (do_pfield) {
         prof_start(pr_field_write);
-        fields.write_pfd(pfd_jeh);
+        fields.write_pfd(adapt(evalMfields(pfd_jeh)), pfd_jeh);
         prof_stop(pr_field_write);
       }
 
@@ -223,7 +222,7 @@ public:
 
       if (do_pfield_moments) {
         prof_start(pr_moment_write);
-        moments.write_pfd(pfd_moments);
+        moments.write_pfd(adapt(evalMfields(pfd_moments)), pfd_moments);
         prof_stop(pr_moment_write);
       }
 

--- a/src/include/OutputFieldsDefault.h
+++ b/src/include/OutputFieldsDefault.h
@@ -190,7 +190,7 @@ public:
       if (doaccum_tfield) {
         // tfd += pfd
         prof_start(pr_field_acc);
-        fields.tfd_.storage() = fields.tfd_.storage() + pfd;
+        fields.tfd_.gt() = fields.tfd_.gt() + pfd;
         prof_stop(pr_field_acc);
         fields.naccum_++;
       }
@@ -229,7 +229,7 @@ public:
       if (doaccum_tfield_moments) {
         // tfd += pfd
         prof_start(pr_moment_acc);
-        moments.tfd_.storage() = moments.tfd_.storage() + pfd;
+        moments.tfd_.gt() = moments.tfd_.gt() + pfd;
         prof_stop(pr_moment_acc);
         moments.naccum_++;
       }

--- a/src/include/OutputFieldsDefault.h
+++ b/src/include/OutputFieldsDefault.h
@@ -183,7 +183,7 @@ public:
 
       if (do_pfield) {
         prof_start(pr_field_write);
-        fields.write_pfd(adapt(evalMfields(pfd_jeh)), pfd_jeh);
+        fields.write_pfd(pfd_jeh.gt(), pfd_jeh);
         prof_stop(pr_field_write);
       }
 

--- a/src/include/OutputFieldsDefault.h
+++ b/src/include/OutputFieldsDefault.h
@@ -196,7 +196,7 @@ public:
       }
       if (do_tfield) {
         prof_start(pr_field_write);
-        fields.write_tfd(adapt(fields.tfd_), pfd_jeh);
+        fields.write_tfd(fields.tfd_.gt(), pfd_jeh);
         prof_stop(pr_field_write);
       }
       prof_stop(pr_field);
@@ -235,7 +235,7 @@ public:
       }
       if (do_tfield_moments) {
         prof_start(pr_moment_write);
-        moments.write_tfd(adapt(moments.tfd_), pfd_moments);
+        moments.write_tfd(moments.tfd_.gt(), pfd_moments);
         prof_stop(pr_moment_write);
       }
       prof_stop(pr_moment);

--- a/src/include/OutputFieldsDefault.h
+++ b/src/include/OutputFieldsDefault.h
@@ -178,12 +178,12 @@ public:
       prof_start(pr_field);
       prof_start(pr_field_calc);
       Item_jeh<MfieldsState> pfd_jeh{mflds};
-      auto&& pfd = adapt_item(pfd_jeh);
+      auto&& pfd = pfd_jeh.gt();
       prof_stop(pr_field_calc);
 
       if (do_pfield) {
         prof_start(pr_field_write);
-        fields.write_pfd(pfd_jeh.gt(), pfd_jeh);
+        fields.write_pfd(pfd, pfd_jeh);
         prof_stop(pr_field_write);
       }
 
@@ -217,12 +217,12 @@ public:
       prof_start(pr_moment);
       prof_start(pr_moment_calc);
       FieldsItem_Moments_1st_cc<Mparticles> pfd_moments{mprts};
-      auto&& pfd = adapt_item(pfd_moments);
+      auto&& pfd = pfd_moments.gt();
       prof_stop(pr_moment_calc);
 
       if (do_pfield_moments) {
         prof_start(pr_moment_write);
-        moments.write_pfd(adapt(evalMfields(pfd_moments)), pfd_moments);
+        moments.write_pfd(pfd, pfd_moments);
         prof_stop(pr_moment_write);
       }
 

--- a/src/include/fields3d.hxx
+++ b/src/include/fields3d.hxx
@@ -451,6 +451,8 @@ struct Mfields
   const MfieldsDomain& domain() const { return domain_; }
   const Grid_t& grid() const { return domain_.grid(); }
 
+  auto gt() { return Base::storage().view(); }
+
   template <typename FUNC>
   void Foreach_3d(int l, int r, FUNC&& F) const
   {

--- a/src/include/fields3d.hxx
+++ b/src/include/fields3d.hxx
@@ -548,6 +548,8 @@ struct MfieldsStateFromMfields : MfieldsStateBase
 
   Mfields& mflds() { return mflds_; }
 
+  auto gt() { return mflds_.storage(); }
+
 public: // FIXME public so that we can read/write it, friend needs include which
         // gives nvcc issues
   Mfields mflds_;

--- a/src/include/fields3d.hxx
+++ b/src/include/fields3d.hxx
@@ -585,12 +585,6 @@ extern template const MfieldsStateBase::Convert
 
 using namespace gt::placeholders;
 
-template <typename Item>
-auto adapt_item(const Item& item)
-{
-  return adapt(item.result());
-}
-
 template <typename Mfields>
 auto adapt(const Mfields& _mflds)
 {

--- a/src/include/fields3d.hxx
+++ b/src/include/fields3d.hxx
@@ -543,6 +543,9 @@ struct MfieldsStateFromMfields : MfieldsStateBase
   const Convert& convert_to() override { return convert_to_; }
   const Convert& convert_from() override { return convert_from_; }
 
+  auto storage() const { return mflds_.storage(); }
+  auto storage() { return mflds_.storage(); }
+
   Mfields& mflds() { return mflds_; }
 
 public: // FIXME public so that we can read/write it, friend needs include which
@@ -591,13 +594,8 @@ auto adapt(const Mfields& _mflds)
 {
   auto& mflds = const_cast<std::remove_const_t<Mfields>&>(_mflds);
   auto ib = mflds.ib(), im = mflds.im(), bnd = -ib;
-  auto mf_ =
-    gt::adapt<5>(&mflds(0, ib[0], ib[1], ib[2], 0),
-                 {im[0], im[1], im[2], mflds.n_comps(), mflds.n_patches()});
-  auto mf = std::move(mf_).view(_s(bnd[0], -bnd[0]), _s(bnd[1], -bnd[1]),
-                                _s(bnd[2], -bnd[2]));
-
-  return mf;
+  return mflds.storage().view(_s(bnd[0], -bnd[0]), _s(bnd[1], -bnd[1]),
+                              _s(bnd[2], -bnd[2]));
 }
 
 #endif

--- a/src/include/writer_mrc.hxx
+++ b/src/include/writer_mrc.hxx
@@ -85,6 +85,8 @@ public:
       mrc_fld_set_comp_name(fld, m, comp_names[m].c_str());
     }
 
+    assert(mf.shape() == gt::shape(grid.ldims[0], grid.ldims[1], grid.ldims[2],
+                                   n_comps, mf.shape(4)));
     for (int p = 0; p < mf.shape(4); p++) {
       for (int m = 0; m < n_comps; m++) {
         mrc_fld_foreach(fld, i, j, k, 0, 0)

--- a/src/libpsc/psc_checks/checks_impl.hxx
+++ b/src/libpsc/psc_checks/checks_impl.hxx
@@ -42,8 +42,8 @@ struct Checks_
     : ChecksParams(params),
       comm_{comm},
       rho_{grid, 1, grid.ibn},
-      rho_m_{grid, 1, grid.ibn},
-      rho_p_{grid, 1, grid.ibn},
+      rho_m_{grid, 1, {}},
+      rho_p_{grid, 1, {}},
       divj_{grid, 1, {}}
   {}
 
@@ -114,8 +114,8 @@ struct Checks_
         writer.open("continuity");
       }
       writer.begin_step(grid.timestep(), grid.timestep() * grid.dt);
-      writer.write(adapt(evalMfields(divj_)), grid, "div_j", {"div_j"});
-      writer.write(adapt(evalMfields(d_rho)), grid, "d_rho", {"d_rho"});
+      writer.write(divj_.gt(), grid, "div_j", {"div_j"});
+      writer.write(d_rho.gt(), grid, "d_rho", {"d_rho"});
       writer.end_step();
     }
 

--- a/src/libpsc/psc_checks/checks_impl.hxx
+++ b/src/libpsc/psc_checks/checks_impl.hxx
@@ -41,7 +41,7 @@ struct Checks_
   Checks_(const Grid_t& grid, MPI_Comm comm, const ChecksParams& params)
     : ChecksParams(params),
       comm_{comm},
-      rho_{grid, 1, grid.ibn},
+      rho_{grid, 1, {}},
       rho_m_{grid, 1, {}},
       rho_p_{grid, 1, {}},
       divj_{grid, 1, {}}
@@ -183,9 +183,8 @@ struct Checks_
         writer.open("gauss");
       }
       writer.begin_step(grid.timestep(), grid.timestep() * grid.dt);
-      writer.write(adapt(evalMfields(rho_)), grid, "rho", {"rho"});
-      writer.write(adapt(evalMfields(dive)), dive.grid(), dive.name(),
-                   dive.comp_names());
+      writer.write(rho_.gt(), grid, "rho", {"rho"});
+      writer.write(dive.gt(), dive.grid(), dive.name(), dive.comp_names());
       writer.end_step();
     }
 

--- a/src/libpsc/psc_output_fields/fields_item_fields.hxx
+++ b/src/libpsc/psc_output_fields/fields_item_fields.hxx
@@ -494,11 +494,6 @@ public:
 
   Item_jeh(MfieldsState& mflds) : mflds_{mflds} {}
 
-  const Real& operator()(int m, Int3 ijk, int p) const
-  {
-    return mflds_(m, ijk[0], ijk[1], ijk[2], p);
-  }
-
   auto gt() const
   {
     auto bnd = -mflds_.ib();
@@ -550,11 +545,6 @@ public:
         });
       }
     }
-  }
-
-  const Real& operator()(int m, Int3 ijk, int p) const
-  {
-    return mflds_(m, ijk[0], ijk[1], ijk[2], p);
   }
 
   auto gt() const

--- a/src/libpsc/psc_output_fields/fields_item_fields.hxx
+++ b/src/libpsc/psc_output_fields/fields_item_fields.hxx
@@ -499,6 +499,13 @@ public:
     return mflds_(m, ijk[0], ijk[1], ijk[2], p);
   }
 
+  auto gt() const
+  {
+    auto bnd = -mflds_.ib();
+    return mflds_.gt().view(_s(bnd[0], -bnd[0]), _s(bnd[1], -bnd[1]),
+                            _s(bnd[2], -bnd[2]));
+  }
+
   const Grid_t& grid() const { return mflds_.grid(); }
   Int3 ibn() const { return {}; }
   int n_patches() const { return grid().n_patches(); }
@@ -548,6 +555,13 @@ public:
   const Real& operator()(int m, Int3 ijk, int p) const
   {
     return mflds_(m, ijk[0], ijk[1], ijk[2], p);
+  }
+
+  auto gt() const
+  {
+    auto bnd = -mflds_.ib();
+    return mflds_.storage().view(_s(bnd[0], -bnd[0]), _s(bnd[1], -bnd[1]),
+                                 _s(bnd[2], -bnd[2]));
   }
 
   const Grid_t& grid() const { return mflds_.grid(); }

--- a/src/libpsc/psc_output_fields/fields_item_fields.hxx
+++ b/src/libpsc/psc_output_fields/fields_item_fields.hxx
@@ -596,6 +596,21 @@ public:
               grid.domain.dx[2]);
   }
 
+  gt::gtensor<Real, 5> gt() const
+  {
+    auto res =
+      gt::empty<Real>({grid().ldims[0], grid().ldims[1], grid().ldims[2],
+                       n_comps(), grid().n_patches()});
+    auto k_res = res.to_kernel();
+
+    gt::launch<5>(
+      res.shape(), GT_LAMBDA(int i, int j, int k, int m, int p) {
+        k_res(i, j, k, m, p) = (*this)(m, {i, j, k}, p);
+      });
+
+    return res;
+  }
+
   const Grid_t& grid() const { return mflds_.grid(); }
   Int3 ibn() const { return {}; }
   int n_patches() const { return grid().n_patches(); }

--- a/src/libpsc/psc_output_fields/fields_item_moments_1st.hxx
+++ b/src/libpsc/psc_output_fields/fields_item_moments_1st.hxx
@@ -243,7 +243,12 @@ public:
     Base::bnd_.add_ghosts(Base::mres_);
   }
 
-  const Mfields& result() const { return Base::mres_; }
+  auto gt()
+  {
+    auto bnd = -Base::mres_.ib();
+    return Base::mres_.storage().view(_s(bnd[0], -bnd[0]), _s(bnd[1], -bnd[1]),
+                                      _s(bnd[2], -bnd[2]));
+  }
 };
 
 #ifdef USE_CUDA
@@ -395,7 +400,12 @@ public:
     prof_stop(pr);
   }
 
-  const Mfields& result() const { return Base::mres_; }
+  auto gt()
+  {
+    auto bnd = -Base::mres_.ib();
+    return Base::mres_.storage().view(_s(bnd[0], -bnd[0]), _s(bnd[1], -bnd[1]),
+                                      _s(bnd[2], -bnd[2]));
+  }
 };
 
 #endif

--- a/src/libpsc/psc_push_fields/marder_impl.hxx
+++ b/src/libpsc/psc_push_fields/marder_impl.hxx
@@ -51,7 +51,7 @@ struct Marder_ : MarderBase
       io_.write(rho_.gt().view(_s(bnd[0], -bnd[0]), _s(bnd[1], -bnd[1]),
                                _s(bnd[2], -bnd[2])),
                 rho_.grid(), "rho", {"rho"});
-      io_.write(adapt(evalMfields(dive)), dive.grid(), "dive", {"dive"});
+      io_.write(dive.gt(), dive.grid(), "dive", {"dive"});
       io_.end_step();
     }
 

--- a/src/libpsc/psc_push_fields/marder_impl.hxx
+++ b/src/libpsc/psc_push_fields/marder_impl.hxx
@@ -47,7 +47,10 @@ struct Marder_ : MarderBase
       static int cnt;
       io_.begin_step(cnt, cnt); // ppsc->timestep, ppsc->timestep * ppsc->dt);
       cnt++;
-      io_.write(adapt(evalMfields(rho_)), rho_.grid(), "rho", {"rho"});
+      Int3 bnd = -rho_.ib();
+      io_.write(rho_.gt().view(_s(bnd[0], -bnd[0]), _s(bnd[1], -bnd[1]),
+                               _s(bnd[2], -bnd[2])),
+                rho_.grid(), "rho", {"rho"});
       io_.write(adapt(evalMfields(dive)), dive.grid(), "dive", {"dive"});
       io_.end_step();
     }

--- a/src/psc_flatfoil_yz.cxx
+++ b/src/psc_flatfoil_yz.cxx
@@ -507,20 +507,24 @@ void run()
   ChecksParams checks_params{};
 #if CASE == CASE_2D_SMALL
   checks_params.continuity_every_step = 1;
+  checks_params.continuity_dump_always = true;
 #else
   checks_params.continuity_every_step = 0;
+  checks_params.continuity_dump_always = false;
 #endif
   checks_params.continuity_threshold = 1e-4;
   checks_params.continuity_verbose = true;
-  checks_params.continuity_dump_always = false;
+
 #if CASE == CASE_2D_SMALL
   checks_params.gauss_every_step = 1;
+  checks_params.gauss_dump_always = true;
 #else
   checks_params.gauss_every_step = 100;
+  checks_params.gauss_dump_always = false;
 #endif
   checks_params.gauss_threshold = 1e-4;
   checks_params.gauss_verbose = true;
-  checks_params.gauss_dump_always = false;
+
   Checks checks{grid, MPI_COMM_WORLD, checks_params};
 
   // -- Marder correction


### PR DESCRIPTION
Now that most underlying stuff is based on gtensor, we should be able to use that directly, rather than wrapping with adapt.