### PR TITLE
Allow direct calculation and aggregation of output fields on the GPU

### DIFF
--- a/src/include/OutputFieldsDefault.h
+++ b/src/include/OutputFieldsDefault.h
@@ -30,7 +30,7 @@ struct OutputFieldsItemParams
 // ======================================================================
 // OutputFieldsItem
 
-template <typename Writer>
+template <typename Mfields, typename Writer>
 class OutputFieldsItem : public OutputFieldsItemParams
 {
 public:
@@ -112,8 +112,7 @@ private:
   int tfield_next_;
   Writer io_pfd_;
   Writer io_tfd_;
-  // tfd -- FIXME?! always MfieldsC
-  MfieldsC tfd_;
+  Mfields tfd_;
   int naccum_ = 0;
   bool first_time_ =
     true; // to keep track so we can skip first output on restart
@@ -179,8 +178,8 @@ public:
   };
 
 public:
-  OutputFieldsItem<Writer> fields;
-  OutputFieldsItem<Writer> moments;
+  OutputFieldsItem<MfieldsC, Writer> fields;
+  OutputFieldsItem<MfieldsC, Writer> moments;
 };
 
 #ifdef xPSC_HAVE_ADIOS2

--- a/src/include/OutputFieldsDefault.h
+++ b/src/include/OutputFieldsDefault.h
@@ -130,27 +130,23 @@ struct OutputFieldsParams
 // ======================================================================
 // OutputFieldsDefault
 
-template <typename Writer>
+template <typename MfieldsState, typename Mparticles, typename Writer>
 class OutputFieldsDefault
 {
-  using MfieldsFake = MfieldsC;
-  using MparticlesFake = MparticlesDouble;
-
 public:
   // ----------------------------------------------------------------------
   // ctor
 
   OutputFieldsDefault(const Grid_t& grid, const OutputFieldsParams& prm)
-    : fields{grid, prm.fields, Item_jeh<MfieldsFake>::n_comps(), {}, ""},
+    : fields{grid, prm.fields, Item_jeh<MfieldsState>::n_comps(), {}, ""},
       moments{grid, prm.moments,
-              FieldsItem_Moments_1st_cc<MparticlesFake>::n_comps(grid),
-              grid.ibn, "_moments"}
+              FieldsItem_Moments_1st_cc<Mparticles>::n_comps(grid), grid.ibn,
+              "_moments"}
   {}
 
   // ----------------------------------------------------------------------
   // operator()
 
-  template <typename MfieldsState, typename Mparticles>
   void operator()(MfieldsState& mflds, Mparticles& mprts)
   {
     const auto& grid = mflds._grid();
@@ -185,11 +181,14 @@ public:
 #ifdef xPSC_HAVE_ADIOS2
 
 #include "writer_adios2.hxx"
-using OutputFields = OutputFieldsDefault<WriterADIOS2>;
+template <typename MfieldsState, typename Mparticles>
+using OutputFields =
+  OutputFieldsDefault<MfieldsState, Mparticles, WriterADIOS2>;
 
 #else
 
 #include "writer_mrc.hxx"
-using OutputFields = OutputFieldsDefault<WriterMRC>;
+template <typename MfieldsState, typename Mparticles>
+using OutputFields = OutputFieldsDefault<MfieldsState, Mparticles, WriterMRC>;
 
 #endif

--- a/src/include/OutputFieldsDefault.h
+++ b/src/include/OutputFieldsDefault.h
@@ -102,7 +102,7 @@ public:
         io_tfd_.end_step();
         naccum_ = 0;
 
-        tfd_.gt() = 0;
+        tfd_.gt().view() = 0;
       }
     }
   }

--- a/src/include/OutputFieldsDefault.h
+++ b/src/include/OutputFieldsDefault.h
@@ -35,7 +35,7 @@ class OutputFieldsItem : public OutputFieldsItemParams
 {
 public:
   OutputFieldsItem(const Grid_t& grid, const OutputFieldsItemParams& prm,
-                   int n_comps, Int3 ibn, std::string sfx)
+                   int n_comps, std::string sfx)
     : OutputFieldsItemParams{prm},
       pfield_next_{prm.pfield_first},
       tfield_next_{prm.tfield_first},
@@ -138,10 +138,9 @@ public:
   // ctor
 
   OutputFieldsDefault(const Grid_t& grid, const OutputFieldsParams& prm)
-    : fields{grid, prm.fields, Item_jeh<MfieldsState>::n_comps(), {}, ""},
+    : fields{grid, prm.fields, Item_jeh<MfieldsState>::n_comps(), ""},
       moments{grid, prm.moments,
-              FieldsItem_Moments_1st_cc<Mparticles>::n_comps(grid), grid.ibn,
-              "_moments"}
+              FieldsItem_Moments_1st_cc<Mparticles>::n_comps(grid), "_moments"}
   {}
 
   // ----------------------------------------------------------------------

--- a/src/include/OutputFieldsDefault.h
+++ b/src/include/OutputFieldsDefault.h
@@ -13,29 +13,6 @@
 
 namespace detail
 {
-template <typename T, typename S>
-struct Mfields_from_type_space
-{
-  using type = Mfields<T>;
-};
-
-#ifdef USE_CUDA
-template <typename T>
-struct Mfields_from_type_space<T, gt::space::device>
-{
-  static_assert(std::is_same<T, float>::value, "CUDA only supports float");
-  using type = MfieldsCuda;
-};
-#endif
-} // namespace detail
-
-template <typename E>
-using Mfields_from_gt_t =
-  typename detail::Mfields_from_type_space<typename E::value_type,
-                                           typename E::space>::type;
-
-namespace detail
-{
 template <typename Mparticles, typename Dim, typename Enable = void>
 struct moment_selector
 {

--- a/src/include/OutputFieldsDefault.h
+++ b/src/include/OutputFieldsDefault.h
@@ -8,6 +8,28 @@
 
 #include <memory>
 
+namespace detail
+{
+
+template <typename MfieldsState>
+struct tfd_Item_jeh
+{
+  using type = Mfields<typename MfieldsState::Real>;
+};
+
+#ifdef USE_CUDA
+template <>
+struct tfd_Item_jeh<MfieldsStateCuda>
+{
+  using type = MfieldsCuda;
+};
+#endif
+
+} // namespace detail
+
+template <typename MfieldsState>
+using tfd_Item_jeh_t = typename detail::tfd_Item_jeh<MfieldsState>::type;
+
 template <typename Mparticles>
 using FieldsItem_Moments_1st_cc = Moments_1st<Mparticles>;
 
@@ -173,7 +195,7 @@ public:
   };
 
 public:
-  OutputFieldsItem<MfieldsC, Writer> fields;
+  OutputFieldsItem<tfd_Item_jeh_t<MfieldsState>, Writer> fields;
   OutputFieldsItem<MfieldsC, Writer> moments;
 };
 

--- a/src/include/OutputFieldsDefault.h
+++ b/src/include/OutputFieldsDefault.h
@@ -53,8 +53,7 @@ struct moment_selector<
 } // namespace detail
 
 template <typename Mparticles>
-using FieldsItem_Moments_1st_cc =
-  typename detail::moment_selector<Mparticles, dim_yz>::type;
+using Item_Moments = typename detail::moment_selector<Mparticles, dim_yz>::type;
 
 // ======================================================================
 // OutputFieldsItemParams
@@ -184,8 +183,8 @@ public:
 
   OutputFieldsDefault(const Grid_t& grid, const OutputFieldsParams& prm)
     : fields{grid, prm.fields, Item_jeh<MfieldsState>::n_comps(), ""},
-      moments{grid, prm.moments,
-              FieldsItem_Moments_1st_cc<Mparticles>::n_comps(grid), "_moments"}
+      moments{grid, prm.moments, Item_Moments<Mparticles>::n_comps(grid),
+              "_moments"}
   {}
 
   // ----------------------------------------------------------------------
@@ -210,8 +209,7 @@ public:
     prof_stop(pr_fields);
 
     prof_start(pr_moments);
-    moments(timestep,
-            [&]() { return FieldsItem_Moments_1st_cc<Mparticles>(mprts); });
+    moments(timestep, [&]() { return Item_Moments<Mparticles>(mprts); });
     prof_stop(pr_moments);
 
     prof_stop(pr);
@@ -219,9 +217,7 @@ public:
 
 public:
   OutputFieldsItem<Mfields_from_gt_t<Item_jeh<MfieldsState>>, Writer> fields;
-  OutputFieldsItem<Mfields_from_gt_t<FieldsItem_Moments_1st_cc<Mparticles>>,
-                   Writer>
-    moments;
+  OutputFieldsItem<Mfields_from_gt_t<Item_Moments<Mparticles>>, Writer> moments;
 };
 
 #ifdef xPSC_HAVE_ADIOS2

--- a/src/include/OutputFieldsDefault.h
+++ b/src/include/OutputFieldsDefault.h
@@ -29,8 +29,8 @@ struct moment_selector<
 #endif
 } // namespace detail
 
-template <typename Mparticles>
-using Item_Moments = typename detail::moment_selector<Mparticles, dim_yz>::type;
+template <typename Mparticles, typename Dim>
+using Item_Moments = typename detail::moment_selector<Mparticles, Dim>::type;
 
 // ======================================================================
 // OutputFieldsItemParams
@@ -151,7 +151,8 @@ struct OutputFieldsParams
 // ======================================================================
 // OutputFieldsDefault
 
-template <typename MfieldsState, typename Mparticles, typename Writer>
+template <typename MfieldsState, typename Mparticles, typename Dim,
+          typename Writer>
 class OutputFieldsDefault
 {
 public:
@@ -160,7 +161,7 @@ public:
 
   OutputFieldsDefault(const Grid_t& grid, const OutputFieldsParams& prm)
     : fields{grid, prm.fields, Item_jeh<MfieldsState>::n_comps(), ""},
-      moments{grid, prm.moments, Item_Moments<Mparticles>::n_comps(grid),
+      moments{grid, prm.moments, Item_Moments<Mparticles, Dim>::n_comps(grid),
               "_moments"}
   {}
 
@@ -186,7 +187,7 @@ public:
     prof_stop(pr_fields);
 
     prof_start(pr_moments);
-    moments(timestep, [&]() { return Item_Moments<Mparticles>(mprts); });
+    moments(timestep, [&]() { return Item_Moments<Mparticles, Dim>(mprts); });
     prof_stop(pr_moments);
 
     prof_stop(pr);
@@ -194,20 +195,22 @@ public:
 
 public:
   OutputFieldsItem<Mfields_from_gt_t<Item_jeh<MfieldsState>>, Writer> fields;
-  OutputFieldsItem<Mfields_from_gt_t<Item_Moments<Mparticles>>, Writer> moments;
+  OutputFieldsItem<Mfields_from_gt_t<Item_Moments<Mparticles, Dim>>, Writer>
+    moments;
 };
 
 #ifdef xPSC_HAVE_ADIOS2
 
 #include "writer_adios2.hxx"
-template <typename MfieldsState, typename Mparticles>
+template <typename MfieldsState, typename Mparticles, typename Dim>
 using OutputFields =
-  OutputFieldsDefault<MfieldsState, Mparticles, WriterADIOS2>;
+  OutputFieldsDefault<MfieldsState, Mparticles, Dim, WriterADIOS2>;
 
 #else
 
 #include "writer_mrc.hxx"
-template <typename MfieldsState, typename Mparticles>
-using OutputFields = OutputFieldsDefault<MfieldsState, Mparticles, WriterMRC>;
+template <typename MfieldsState, typename Mparticles, typename Dim>
+using OutputFields =
+  OutputFieldsDefault<MfieldsState, Mparticles, Dim, WriterMRC>;
 
 #endif

--- a/src/include/fields3d.hxx
+++ b/src/include/fields3d.hxx
@@ -434,6 +434,7 @@ struct Mfields
   using real_t = R;
   using Base = MfieldsCRTP<Mfields<R>>;
   using Storage = typename Base::Storage;
+  using space = gt::space::host;
 
   Mfields(const MfieldsDomain& domain, int n_fields, Int3 ibn)
     : MfieldsBase(domain.grid(), n_fields, ibn),

--- a/src/include/fields3d.hxx
+++ b/src/include/fields3d.hxx
@@ -516,6 +516,7 @@ struct MfieldsStateFromMfields : MfieldsStateBase
 {
   using fields_view_t = typename Mfields::fields_view_t;
   using real_t = typename Mfields::real_t;
+  using Real = typename Mfields::Real;
 
   MfieldsStateFromMfields(const Grid_t& grid)
     : MfieldsStateBase{grid, NR_FIELDS,

--- a/src/include/fields3d.hxx
+++ b/src/include/fields3d.hxx
@@ -599,6 +599,38 @@ auto adapt(const Mfields& _mflds)
                               _s(bnd[2], -bnd[2]));
 }
 
+// ======================================================================
+// Mfields_from_gt_T
+
+#ifdef USE_CUDA
+#include "psc_fields_cuda.h"
+#endif
+
+namespace detail
+{
+template <typename T, typename S>
+struct Mfields_from_type_space
+{
+  using type = Mfields<T>;
+};
+
+#ifdef USE_CUDA
+template <typename T>
+struct Mfields_from_type_space<T, gt::space::device>
+{
+  static_assert(std::is_same<T, float>::value, "CUDA only supports float");
+  using type = MfieldsCuda;
+};
+#endif
+} // namespace detail
+
+template <typename E>
+using Mfields_from_gt_t =
+  typename detail::Mfields_from_type_space<typename E::value_type,
+                                           typename E::space>::type;
+
+// ======================================================================
+
 namespace gt
 {
 

--- a/src/include/fields3d.hxx
+++ b/src/include/fields3d.hxx
@@ -517,6 +517,7 @@ struct MfieldsStateFromMfields : MfieldsStateBase
   using fields_view_t = typename Mfields::fields_view_t;
   using real_t = typename Mfields::real_t;
   using Real = typename Mfields::Real;
+  using space = gt::space::host;
 
   MfieldsStateFromMfields(const Grid_t& grid)
     : MfieldsStateBase{grid, NR_FIELDS,

--- a/src/include/psc_fields_cuda.h
+++ b/src/include/psc_fields_cuda.h
@@ -129,6 +129,7 @@ void copy(const HMFields& hmflds, MfieldsCuda& mflds);
 struct MfieldsStateCuda : MfieldsStateBase
 {
   using real_t = MfieldsCuda::real_t;
+  using space = gt::space::device;
 
   MfieldsStateCuda(const Grid_t& grid)
     : MfieldsStateBase{grid, NR_FIELDS, grid.ibn},

--- a/src/include/psc_fields_cuda.h
+++ b/src/include/psc_fields_cuda.h
@@ -155,6 +155,8 @@ struct MfieldsStateCuda : MfieldsStateBase
   MfieldsCuda& mflds() { return mflds_; }
   const MfieldsCuda& mflds() const { return mflds_; }
 
+  auto gt() { return mflds_.gt(); }
+
 private:
   MfieldsCuda mflds_;
 };

--- a/src/libpsc/cuda/fields_item_moments_1st_cuda.hxx
+++ b/src/libpsc/cuda/fields_item_moments_1st_cuda.hxx
@@ -141,6 +141,8 @@ public:
   using Mparticles = _Mparticles;
   using Mfields = MfieldsCuda;
   using Bnd = BndCuda3<Mfields>;
+  using value_type = typename Mfields::real_t;
+  using space = gt::space::device;
 
   constexpr static int n_moments = 13;
   static char const* name() { return "all_1st"; }

--- a/src/libpsc/cuda/fields_item_moments_1st_cuda.hxx
+++ b/src/libpsc/cuda/fields_item_moments_1st_cuda.hxx
@@ -150,11 +150,11 @@ public:
     return n_moments * grid.kinds.size();
   }
 
-  static std::vector<std::string> comp_names(const Grid_t& grid)
+  std::vector<std::string> comp_names()
   {
     return addKindSuffix({"rho", "jx", "jy", "jz", "px", "py", "pz", "txx",
                           "tyy", "tzz", "txy", "tyz", "tzx"},
-                         grid.kinds);
+                         Base::grid().kinds);
   }
 
   int n_comps() const { return Base::mres_.n_comps(); }
@@ -202,6 +202,13 @@ public:
   }
 
   const Mfields& result() const { return Base::mres_; }
+
+  auto gt()
+  {
+    auto bnd = Base::mres_.ibn();
+    return Base::mres_.gt().view(_s(bnd[0], -bnd[0]), _s(bnd[1], -bnd[1]),
+                                 _s(bnd[2], -bnd[2]));
+  }
 
 private:
   Bnd bnd_;

--- a/src/libpsc/psc_output_fields/fields_item_fields.hxx
+++ b/src/libpsc/psc_output_fields/fields_item_fields.hxx
@@ -57,7 +57,7 @@ public:
 
   auto gt() const
   {
-    auto bnd = -mflds_.ib();
+    auto bnd = mflds_.ibn();
     return mflds_.gt().view(_s(bnd[0], -bnd[0]), _s(bnd[1], -bnd[1]),
                             _s(bnd[2], -bnd[2]));
   }

--- a/src/libpsc/psc_output_fields/fields_item_fields.hxx
+++ b/src/libpsc/psc_output_fields/fields_item_fields.hxx
@@ -73,59 +73,6 @@ private:
 };
 
 // ======================================================================
-// Item_jeh
-//
-// Main fields in their natural staggering
-
-template <>
-class Item_jeh<MfieldsStateCuda>
-  : public MFexpression<Item_jeh<MfieldsStateCuda>>
-{
-  using MfieldsState = MfieldsStateCuda;
-
-public:
-  using Real = typename MfieldsState::real_t;
-
-  static char const* name() { return "jeh"; }
-  static int n_comps() { return 9; }
-  static std::vector<std::string> comp_names()
-  {
-    return {"jx_ec", "jy_ec", "jz_ec", "ex_ec", "ey_ec",
-            "ez_ec", "hx_fc", "hy_fc", "hz_fc"};
-  }
-
-  Item_jeh(MfieldsState& mflds)
-    : mflds_(mflds.grid(), NR_FIELDS, mflds.grid().ibn)
-  {
-    auto hmflds = hostMirror(mflds);
-    copy(mflds, hmflds);
-    for (int p = 0; p < mflds_.n_patches(); p++) {
-      for (int m = 0; m < mflds_.n_comps(); m++) {
-        mflds_.Foreach_3d(0, 0, [&](int i, int j, int k) {
-          mflds_(m, i, j, k, p) = hmflds(m, i, j, k, p);
-        });
-      }
-    }
-  }
-
-  auto gt() const
-  {
-    auto bnd = -mflds_.ib();
-    return mflds_.storage().view(_s(bnd[0], -bnd[0]), _s(bnd[1], -bnd[1]),
-                                 _s(bnd[2], -bnd[2]));
-  }
-
-  const Grid_t& grid() const { return mflds_.grid(); }
-  Int3 ibn() const { return {}; }
-  int n_patches() const { return grid().n_patches(); }
-
-  MfieldsSingle& result() const { return mflds_; }
-
-private:
-  mutable MfieldsSingle mflds_; // FIXME!!
-};
-
-// ======================================================================
 // Item_dive
 
 template <typename MfieldsState>

--- a/src/libpsc/psc_output_fields/fields_item_fields.hxx
+++ b/src/libpsc/psc_output_fields/fields_item_fields.hxx
@@ -44,6 +44,8 @@ class Item_jeh : public MFexpression<Item_jeh<MfieldsState>>
 {
 public:
   using Real = typename MfieldsState::real_t;
+  using value_type = Real;
+  using space = typename MfieldsState::space;
 
   static char const* name() { return "jeh"; }
   static int n_comps() { return 9; }

--- a/src/libpsc/psc_output_fields/fields_item_moments_1st.hxx
+++ b/src/libpsc/psc_output_fields/fields_item_moments_1st.hxx
@@ -205,6 +205,8 @@ public:
   using Base = ItemMomentCRTP<Moments_1st<MP, MF>, MF>;
   using Mparticles = MP;
   using Mfields = MF;
+  using value_type = typename Mfields::real_t;
+  using space = typename Mfields::space;
 
   using Base::n_comps;
 

--- a/src/libpsc/vpic/mfields_state_psc.hxx
+++ b/src/libpsc/vpic/mfields_state_psc.hxx
@@ -165,6 +165,7 @@ struct MfieldsStatePsc
   using real_t = float;
   using Real = real_t;
   using Element = MfieldsStatePscElement;
+  using space = gt::space::host;
 
   // FIXME, have to settle on BX or CBX...
   enum

--- a/src/libpsc/vpic/mfields_state_psc.hxx
+++ b/src/libpsc/vpic/mfields_state_psc.hxx
@@ -163,6 +163,7 @@ struct MfieldsStatePsc
   using SfaParams = PscSfaParams<Grid, MaterialList>;
   using MaterialCoefficient = typename SfaParams::MaterialCoefficient;
   using real_t = float;
+  using Real = real_t;
   using Element = MfieldsStatePscElement;
 
   // FIXME, have to settle on BX or CBX...

--- a/src/psc_bubble_yz.cxx
+++ b/src/psc_bubble_yz.cxx
@@ -333,7 +333,7 @@ static void run()
   // -- output fields
   OutputFieldsParams outf_params{};
   outf_params.fields.pfield_interval = 200;
-  OutputFields outf{grid, outf_params};
+  OutputFields<MfieldsState, Mparticles> outf{grid, outf_params};
 
   // -- output particles
   OutputParticlesParams outp_params{};

--- a/src/psc_bubble_yz.cxx
+++ b/src/psc_bubble_yz.cxx
@@ -333,7 +333,7 @@ static void run()
   // -- output fields
   OutputFieldsParams outf_params{};
   outf_params.fields.pfield_interval = 200;
-  OutputFields<MfieldsState, Mparticles> outf{grid, outf_params};
+  OutputFields<MfieldsState, Mparticles, Dim> outf{grid, outf_params};
 
   // -- output particles
   OutputParticlesParams outp_params{};

--- a/src/psc_flatfoil_yz.cxx
+++ b/src/psc_flatfoil_yz.cxx
@@ -524,7 +524,7 @@ void run()
 
   outf_params.fields = outf_item_params;
   outf_params.moments = outf_item_params;
-  OutputFields outf{grid, outf_params};
+  OutputFields<MfieldsState, Mparticles> outf{grid, outf_params};
 
   // -- output particles
   OutputParticlesParams outp_params{};

--- a/src/psc_flatfoil_yz.cxx
+++ b/src/psc_flatfoil_yz.cxx
@@ -524,7 +524,7 @@ void run()
 
   outf_params.fields = outf_item_params;
   outf_params.moments = outf_item_params;
-  OutputFields<MfieldsState, Mparticles> outf{grid, outf_params};
+  OutputFields<MfieldsState, Mparticles, Dim> outf{grid, outf_params};
 
   // -- output particles
   OutputParticlesParams outp_params{};

--- a/src/psc_harris_xz.cxx
+++ b/src/psc_harris_xz.cxx
@@ -493,8 +493,8 @@ void setup_log(const Grid_t& grid)
 class Diagnostics
 {
 public:
-  Diagnostics(Grid_t& grid, OutputFields& outf, OutputParticles& outp,
-              DiagEnergies& oute)
+  Diagnostics(Grid_t& grid, OutputFields<MfieldsState, Mparticles>& outf,
+              OutputParticles& outp, DiagEnergies& oute)
     : outf_{outf},
       outp_{outp},
       oute_{oute},
@@ -594,7 +594,7 @@ public:
 private:
   WriterMRC io_pfd_;
   WriterMRC io_tfd_;
-  OutputFields& outf_;
+  OutputFields<MfieldsState, Mparticles>& outf_;
   OutputFieldsVpic<MfieldsState> outf_state_;
   OutputHydro outf_hydro_;
   OutputParticles& outp_;
@@ -877,7 +877,7 @@ void run()
     int((output_field_interval / (phys.wci * grid.dt)));
   outf_params.fields.tfield_interval =
     int((output_field_interval / (phys.wci * grid.dt)));
-  OutputFields outf{grid, outf_params};
+  OutputFields<MfieldsState, Mparticles> outf{grid, outf_params};
 
   OutputParticlesParams outp_params{};
   outp_params.every_step =

--- a/src/psc_harris_xz.cxx
+++ b/src/psc_harris_xz.cxx
@@ -493,7 +493,8 @@ void setup_log(const Grid_t& grid)
 class Diagnostics
 {
 public:
-  Diagnostics(Grid_t& grid, OutputFields<MfieldsState, Mparticles>& outf,
+  Diagnostics(Grid_t& grid,
+              OutputFields<MfieldsState, Mparticles, dim_xz>& outf,
               OutputParticles& outp, DiagEnergies& oute)
     : outf_{outf},
       outp_{outp},
@@ -594,7 +595,7 @@ public:
 private:
   WriterMRC io_pfd_;
   WriterMRC io_tfd_;
-  OutputFields<MfieldsState, Mparticles>& outf_;
+  OutputFields<MfieldsState, Mparticles, dim_xz>& outf_;
   OutputFieldsVpic<MfieldsState> outf_state_;
   OutputHydro outf_hydro_;
   OutputParticles& outp_;
@@ -877,7 +878,7 @@ void run()
     int((output_field_interval / (phys.wci * grid.dt)));
   outf_params.fields.tfield_interval =
     int((output_field_interval / (phys.wci * grid.dt)));
-  OutputFields<MfieldsState, Mparticles> outf{grid, outf_params};
+  OutputFields<MfieldsState, Mparticles, dim_xz> outf{grid, outf_params};
 
   OutputParticlesParams outp_params{};
   outp_params.every_step =

--- a/src/psc_whistler.cxx
+++ b/src/psc_whistler.cxx
@@ -312,7 +312,7 @@ void run()
   // -- output fields
   OutputFieldsParams outf_params{};
   outf_params.fields.pfield_interval = 200;
-  OutputFields outf{grid, outf_params};
+  OutputFields<MfieldsState, Mparticles> outf{grid, outf_params};
 
   // -- output particles
   OutputParticlesParams outp_params{};

--- a/src/psc_whistler.cxx
+++ b/src/psc_whistler.cxx
@@ -312,7 +312,7 @@ void run()
   // -- output fields
   OutputFieldsParams outf_params{};
   outf_params.fields.pfield_interval = 200;
-  OutputFields<MfieldsState, Mparticles> outf{grid, outf_params};
+  OutputFields<MfieldsState, Mparticles, Dim> outf{grid, outf_params};
 
   // -- output particles
   OutputParticlesParams outp_params{};


### PR DESCRIPTION
This was the most immediate goal of the gtensor use: Making it easier to do stuff either on the CPU or the GPU without having to special case stuff everywhere. Obviously, there's way more opportunity to clean things up further.