### PR TITLE
cuda: switch to new rmm exec_policy

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -98,7 +98,7 @@ endif()
 
 # RMM
 if (PSC_USE_RMM)
-  find_package(rmm CONFIG REQUIRED)
+  find_package(rmm 0.18.0 CONFIG REQUIRED)
   set(PSC_HAVE_RMM 1)
 endif()
 

--- a/src/libpsc/cuda/cuda_base.cu
+++ b/src/libpsc/cuda/cuda_base.cu
@@ -5,7 +5,6 @@
 #include <rmm/mr/device/pool_memory_resource.hpp>
 #include <rmm/mr/device/per_device_resource.hpp>
 #include <rmm/mr/device/logging_resource_adaptor.hpp>
-#include <rmm/thrust_rmm_allocator.h>
 #endif
 
 #include <cstdio>

--- a/src/libpsc/cuda/cuda_bits.h
+++ b/src/libpsc/cuda/cuda_bits.h
@@ -5,7 +5,8 @@
 #include "PscConfig.h"
 
 #ifdef PSC_HAVE_RMM
-#include <rmm/thrust_rmm_allocator.h>
+#include <rmm/device_vector.hpp>
+#include <rmm/exec_policy.hpp>
 
 namespace psc
 {

--- a/src/libpsc/cuda/cuda_bndp.cu
+++ b/src/libpsc/cuda/cuda_bndp.cu
@@ -211,8 +211,8 @@ uint cuda_bndp<CudaMparticles, dim_yz>::convert_and_copy_to_dev(
   cmprts->resize(cmprts->n_prts + n_recv);
 
 #ifdef PSC_HAVE_RMM
-  thrust::copy(rmm::exec_policy(0)->on(0), h_bnd_storage.begin(),
-               h_bnd_storage.end(), cmprts->storage.begin() + cmprts->n_prts);
+  thrust::copy(rmm::exec_policy(), h_bnd_storage.begin(), h_bnd_storage.end(),
+               cmprts->storage.begin() + cmprts->n_prts);
 #else
   thrust::copy(h_bnd_storage.begin(), h_bnd_storage.end(),
                cmprts->storage.begin() + cmprts->n_prts);
@@ -311,7 +311,7 @@ uint cuda_bndp<CudaMparticles, DIM>::convert_and_copy_to_dev(
   cmprts->resize(cmprts->n_prts + n_recv);
 
 #ifdef PSC_HAVE_RMM
-  thrust::copy(rmm::exec_policy(0)->on(0), h_bnd.begin(), h_bnd.end(),
+  thrust::copy(rmm::exec_policy(), h_bnd.begin(), h_bnd.end(),
                cmprts->storage.begin() + cmprts->n_prts);
 #else
   thrust::copy(h_bnd.begin(), h_bnd.end(),
@@ -341,8 +341,8 @@ void cuda_bndp<CudaMparticles, DIM>::post(CudaMparticles* _cmprts)
 
   thrust::sequence(cmprts.by_block_.d_id.begin(), cmprts.by_block_.d_id.end());
 #ifdef PSC_HAVE_RMM
-  thrust::stable_sort_by_key(rmm::exec_policy(0)->on(0), d_bidx.begin(),
-                             d_bidx.end(), cmprts.by_block_.d_id.begin());
+  thrust::stable_sort_by_key(rmm::exec_policy(), d_bidx.begin(), d_bidx.end(),
+                             cmprts.by_block_.d_id.begin());
 #else
   thrust::stable_sort_by_key(d_bidx.begin(), d_bidx.end(),
                              cmprts.by_block_.d_id.begin());

--- a/src/libpsc/cuda/cuda_bndp.h
+++ b/src/libpsc/cuda/cuda_bndp.h
@@ -44,7 +44,7 @@ struct cuda_bndp : cuda_mparticles_indexer<typename CudaMparticles::BS>
     auto& d_bidx = cmprts.by_block_.d_idx;
 
 #ifdef PSC_HAVE_RMM
-    auto oob = thrust::count_if(rmm::exec_policy(0)->on(0), d_bidx.begin(),
+    auto oob = thrust::count_if(rmm::exec_policy(), d_bidx.begin(),
                                 d_bidx.end(), is_outside(cmprts.n_blocks));
 #else
     auto oob = thrust::count_if(d_bidx.begin(), d_bidx.end(),
@@ -61,8 +61,8 @@ struct cuda_bndp : cuda_mparticles_indexer<typename CudaMparticles::BS>
     auto end = begin + sz;
 
 #ifdef PSC_HAVE_RMM
-    auto oob_end = thrust::copy_if(rmm::exec_policy(0)->on(0), begin, end,
-                                   begin + sz, is_outside(cmprts.n_blocks));
+    auto oob_end = thrust::copy_if(rmm::exec_policy(), begin, end, begin + sz,
+                                   is_outside(cmprts.n_blocks));
 #else
     auto oob_end =
       thrust::copy_if(begin, end, begin + sz, is_outside(cmprts.n_blocks));
@@ -93,7 +93,7 @@ struct cuda_bndp : cuda_mparticles_indexer<typename CudaMparticles::BS>
     assert(cmprts->storage.size() == n_prts + n_prts_send);
 
 #ifdef PSC_HAVE_RMM
-    thrust::copy(rmm::exec_policy(0)->on(0), cmprts->storage.begin() + n_prts,
+    thrust::copy(rmm::exec_policy(), cmprts->storage.begin() + n_prts,
                  cmprts->storage.end(), h_bnd_storage.begin());
 #else
     thrust::copy(cmprts->storage.begin() + n_prts, cmprts->storage.end(),

--- a/src/libpsc/cuda/cuda_mparticles_sort.cuh
+++ b/src/libpsc/cuda/cuda_mparticles_sort.cuh
@@ -182,8 +182,8 @@ struct cuda_mparticles_sort
   void stable_sort_cidx()
   {
 #ifdef PSC_HAVE_RMM
-    thrust::stable_sort_by_key(rmm::exec_policy(0)->on(0), d_idx.begin(),
-                               d_idx.end(), d_id.begin());
+    thrust::stable_sort_by_key(rmm::exec_policy(), d_idx.begin(), d_idx.end(),
+                               d_id.begin());
 #else
     thrust::stable_sort_by_key(d_idx.begin(), d_idx.end(), d_id.begin());
 #endif
@@ -262,7 +262,7 @@ struct cuda_mparticles_randomize_sort
   void sort()
   {
 #ifdef PSC_HAVE_RMM
-    thrust::sort_by_key(rmm::exec_policy(0)->on(0), d_random_idx.begin(),
+    thrust::sort_by_key(rmm::exec_policy(), d_random_idx.begin(),
                         d_random_idx.end(), d_id.begin());
 #else
     thrust::sort_by_key(d_random_idx.begin(), d_random_idx.end(), d_id.begin());
@@ -307,8 +307,8 @@ struct cuda_mparticles_sort_by_block
   void stable_sort()
   {
 #ifdef PSC_HAVE_RMM
-    thrust::stable_sort_by_key(rmm::exec_policy(0)->on(0), d_idx.begin(),
-                               d_idx.end(), d_id.begin());
+    thrust::stable_sort_by_key(rmm::exec_policy(), d_idx.begin(), d_idx.end(),
+                               d_id.begin());
 #else
     thrust::stable_sort_by_key(d_idx.begin(), d_idx.end(), d_id.begin());
 #endif


### PR DESCRIPTION
In later RMM, it's a little less awkward to use. It may now be possible
to create the policy once and use it throughout, which would simplify
things a bit, but I haven't tried.