### PR TITLE
balance: find new mapping via divide-and-conquer

### DIFF
--- a/src/libpsc/psc_balance/psc_balance_impl.hxx
+++ b/src/libpsc/psc_balance/psc_balance_impl.hxx
@@ -27,18 +27,17 @@ namespace balance
 
 inline void best_mapping(const std::vector<double>& capability,
                          const std::vector<double>& loads_all,
-                         std::vector<int>& nr_patches_all_new,
-                         bool print_loads_)
+                         std::vector<int>& nr_patches_all_new)
 {
   int size = capability.size();
 
   double loads_sum = 0.;
-  for (int i = 0; i < loads_all.size(); i++) {
-    loads_sum += loads_all[i];
+  for (auto load : loads_all) {
+    loads_sum += load;
   }
   double capability_sum = 0.;
-  for (int p = 0; p < size; p++) {
-    capability_sum += capability[p];
+  for (auto cap : capability) {
+    capability_sum += cap;
   }
   double load_target = loads_sum / capability_sum;
   mprintf("psc_balance: loads_sum %g capability_sum %g load_target %g\n",
@@ -71,19 +70,35 @@ inline void best_mapping(const std::vector<double>& capability,
       nr_patches_all_new[size - 1] = nr_new_patches;
     }
   }
+}
+
+inline void print_stats(const std::vector<int>& nr_patches_all_new,
+                        const std::vector<double>& capability,
+                        const std::vector<double>& loads_all, bool verbose)
+{
+  double loads_sum = 0.;
+  for (auto load : loads_all) {
+    loads_sum += load;
+  }
+  double capability_sum = 0.;
+  for (auto cap : capability) {
+    capability_sum += cap;
+  }
+  double load_target = loads_sum / capability_sum;
+  int n_procs = capability.size();
 
   int pp = 0;
   double min_diff = 0, max_diff = 0;
-  for (int p = 0; p < size; p++) {
+  for (int p = 0; p < n_procs; p++) {
     double load = 0.;
     for (int i = 0; i < nr_patches_all_new[p]; i++) {
       load += loads_all[pp++];
-      if (print_loads_) {
+      if (verbose) {
         mprintf("  pp %d load %g : %g\n", pp - 1, loads_all[pp - 1], load);
       }
     }
     double diff = load - load_target * capability[p];
-    if (print_loads_) {
+    if (verbose) {
       mprintf("p %d # = %d load %g / %g : diff %g %%\n", p,
               nr_patches_all_new[p], load, load_target * capability[p],
               100. * diff / (load_target * capability[p]));
@@ -564,8 +579,9 @@ private:
         capability[p] = capability_default(p);
       }
 
-      psc::balance::best_mapping(capability, loads_all, nr_patches_all_new,
-                                 print_loads_);
+      psc::balance::best_mapping(capability, loads_all, nr_patches_all_new);
+      psc::balance::print_stats(nr_patches_all_new, capability, loads_all,
+                                print_loads_);
 
       if (write_loads_) {
         int gp = 0;

--- a/src/libpsc/psc_balance/psc_balance_impl.hxx
+++ b/src/libpsc/psc_balance/psc_balance_impl.hxx
@@ -18,15 +18,6 @@ static double capability_default(int p)
   return 1.;
 }
 
-static double _mrc_unused capability_jaguar(int p)
-{
-  if (p % 16 == 0) {
-    return 16.;
-  } else {
-    return 1.;
-  }
-}
-
 // ======================================================================
 // Communicate
 

--- a/src/libpsc/psc_balance/psc_balance_impl.hxx
+++ b/src/libpsc/psc_balance/psc_balance_impl.hxx
@@ -126,6 +126,25 @@ inline void print_stats(const input& input,
           100 * min_diff / load_target, 100 * max_diff / load_target);
 }
 
+inline void write_loads(const input& input,
+                        const std::vector<int>& nr_patches_all_new,
+                        int timestep)
+{
+  char s[20];
+  sprintf(s, "loads2-%06d.asc", timestep);
+  FILE* f = fopen(s, "w");
+
+  int gp = 0;
+  for (int r = 0; r < nr_patches_all_new.size(); r++) {
+    for (int p = 0; p < nr_patches_all_new[r]; p++) {
+      fprintf(f, "%d %g %d\n", gp, input.load_by_patch[gp], r);
+      gp++;
+    }
+  }
+
+  fclose(f);
+}
+
 } // namespace balance
 } // namespace psc
 
@@ -596,17 +615,8 @@ private:
                                 print_loads_);
 
       if (write_loads_) {
-        int gp = 0;
-        char s[20];
-        sprintf(s, "loads2-%06d.asc", grid.timestep());
-        FILE* f = fopen(s, "w");
-        for (int r = 0; r < size; r++) {
-          for (int p = 0; p < nr_patches_all_new[r]; p++) {
-            fprintf(f, "%d %g %d\n", gp, loads_all[gp], r);
-            gp++;
-          }
-        }
-        fclose(f);
+        psc::balance::write_loads({capability, loads_all}, nr_patches_all_new,
+                                  grid.timestep());
       }
 
       if (nr_patches_all_new == nr_patches_all_old) {

--- a/src/libpsc/tests/test_balance.cxx
+++ b/src/libpsc/tests/test_balance.cxx
@@ -230,6 +230,28 @@ TYPED_TEST(BalanceTest, Every1)
   balance(this->grid_, mprts);
 }
 
+TEST(Balance, best_mapping)
+{
+  const int n_procs = 3;
+  const int n_patches = 10;
+  std::vector<double> capability(n_procs, 1.);
+  std::vector<double> loads(n_patches);
+  std::iota(loads.begin(), loads.end(), 1.);
+
+  std::cout << "capability ";
+  std::copy(capability.begin(), capability.end(),
+            std::ostream_iterator<double>(std::cout, " "));
+  std::cout << "\n";
+
+  std::cout << "loads ";
+  std::copy(loads.begin(), loads.end(),
+            std::ostream_iterator<double>(std::cout, " "));
+  std::cout << "\n";
+
+  std::vector<int> n_patches_all(n_procs);
+  psc::balance::best_mapping(capability, loads, n_patches_all, true);
+}
+
 int main(int argc, char** argv)
 {
   MPI_Init(&argc, &argv);

--- a/src/libpsc/tests/test_balance.cxx
+++ b/src/libpsc/tests/test_balance.cxx
@@ -249,8 +249,8 @@ TEST(Balance, best_mapping)
   std::cout << "\n";
 
   std::vector<int> n_patches_all(n_procs);
-  psc::balance::best_mapping(capability, loads, n_patches_all);
-  psc::balance::print_stats(n_patches_all, capability, loads, true);
+  psc::balance::best_mapping({capability, loads}, n_patches_all);
+  psc::balance::print_stats({capability, loads}, n_patches_all, true);
 }
 
 int main(int argc, char** argv)

--- a/src/libpsc/tests/test_balance.cxx
+++ b/src/libpsc/tests/test_balance.cxx
@@ -248,8 +248,7 @@ TEST(Balance, best_mapping)
             std::ostream_iterator<double>(std::cout, " "));
   std::cout << "\n";
 
-  std::vector<int> n_patches_all(n_procs);
-  psc::balance::best_mapping({capability, loads}, n_patches_all);
+  auto n_patches_all = psc::balance::best_mapping({capability, loads});
   psc::balance::print_stats({capability, loads}, n_patches_all, true);
 }
 

--- a/src/libpsc/tests/test_balance.cxx
+++ b/src/libpsc/tests/test_balance.cxx
@@ -249,7 +249,8 @@ TEST(Balance, best_mapping)
   std::cout << "\n";
 
   std::vector<int> n_patches_all(n_procs);
-  psc::balance::best_mapping(capability, loads, n_patches_all, true);
+  psc::balance::best_mapping(capability, loads, n_patches_all);
+  psc::balance::print_stats(n_patches_all, capability, loads, true);
 }
 
 int main(int argc, char** argv)


### PR DESCRIPTION
This makes it easier to implement additional constraints (the goal being to constrain memory usage per-GPU), though right
now it pretty much does the same thing as before, optimizing "load" per GPU with the only constraint being at least one patch per GPU.