### PR TITLE
reduce mem usage in bnd/cuda, free during rebalance

### DIFF
--- a/src/libpsc/cuda/bnd_cuda_3_impl.cu
+++ b/src/libpsc/cuda/bnd_cuda_3_impl.cu
@@ -74,6 +74,12 @@ void BndCuda3<MF>::add_ghosts(MfieldsStateCuda& mflds, int mb, int me)
 }
 
 template <typename MF>
+void BndCuda3<MF>::clear()
+{
+  cbnd_->clear();
+}
+
+template <typename MF>
 int BndCuda3<MF>::balance_generation_cnt_;
 template <typename MF>
 CudaBnd* BndCuda3<MF>::cbnd_;

--- a/src/libpsc/cuda/bnd_cuda_3_impl.hxx
+++ b/src/libpsc/cuda/bnd_cuda_3_impl.hxx
@@ -25,6 +25,8 @@ struct BndCuda3 : BndBase
   void fill_ghosts(MfieldsCuda& mflds, int mb, int me);
   void fill_ghosts(MfieldsStateCuda& mflds, int mb, int me);
 
+  static void clear();
+
 private:
   static CudaBnd* cbnd_;
   static int balance_generation_cnt_;

--- a/src/libpsc/cuda/cuda_bnd.cuh
+++ b/src/libpsc/cuda/cuda_bnd.cuh
@@ -481,6 +481,12 @@ struct CudaBnd
     }
   }
 
+  void clear()
+  {
+    maps_add_.clear();
+    maps_fill_.clear();
+  }
+
 private:
   mrc_ddc* ddc_;
   std::unordered_map<int, Maps> maps_add_;

--- a/src/libpsc/cuda/cuda_bnd.cuh
+++ b/src/libpsc/cuda/cuda_bnd.cuh
@@ -125,6 +125,10 @@ struct CudaBnd
     prof_stop(pr);
   }
 
+  CudaBnd(const CudaBnd& bnd) = delete;
+
+  CudaBnd& operator=(const CudaBnd& bnd) = delete;
+
   // ----------------------------------------------------------------------
   // dtor
 


### PR DESCRIPTION
Use temporary buffers where appropriate, and clear the maps during rebalancing.