### PR TITLE
checkpoint improvements

### DIFF
--- a/src/include/checkpoint.hxx
+++ b/src/include/checkpoint.hxx
@@ -32,7 +32,8 @@ void write_checkpoint(const Grid_t& grid, Mparticles& mprts,
     "checkpoint_" + std::to_string(grid.timestep()) + ".bp";
 
   auto io = kg::io::IOAdios2{};
-  auto writer = io.open(filename, kg::io::Mode::Write);
+  auto writer =
+    io.open(filename, kg::io::Mode::Write, grid.comm(), "checkpoint");
   writer.put("grid", grid);
   writer.put("mprts", mprts);
   writer.put("mflds", mflds);

--- a/src/include/psc.hxx
+++ b/src/include/psc.hxx
@@ -218,6 +218,13 @@ struct Psc
 #else
     initialize_default();
 #endif
+    bndf_.fill_ghosts_H(mflds_);
+    bnd_.fill_ghosts(mflds_, HX, HX + 3);
+
+    bnd_.fill_ghosts(mflds_, JXI, JXI + 3);
+
+    bndf_.fill_ghosts_E(mflds_);
+    bnd_.fill_ghosts(mflds_, EX, EX + 3);
 
     // initial output / stats
     mpi_printf(grid().comm(), "Performing initial diagnostics.\n");


### PR DESCRIPTION
This makes sure that ghost points are filled after reading a checkpoint, though I didn't see it making an actual difference.

Also assigns an ADIOS2 io name to the checkpointing mechanism so that parameters can be set via adios2cfg.xml.