### PR TITLE
implement I/O in a separate thread

### DIFF
--- a/src/include/OutputFieldsDefault.h
+++ b/src/include/OutputFieldsDefault.h
@@ -109,10 +109,8 @@ public:
         mpi_printf(item.grid().comm(), "***** Writing PFD output for '%s'\n",
                    item.name());
         pfield_next_ += pfield_interval;
-        io_pfd_.begin_step(item.grid());
-        io_pfd_.set_subset(item.grid(), rn, rx);
-        io_pfd_.write(pfd, item.grid(), item.name(), item.comp_names());
-        io_pfd_.end_step();
+        io_pfd_.write_step(item.grid(), rn, rx, pfd, item.name(),
+                           item.comp_names());
       }
 
       if (doaccum_tfield) {

--- a/src/include/writer_adios2.hxx
+++ b/src/include/writer_adios2.hxx
@@ -69,6 +69,17 @@ public:
     prof_stop(pr_write);
   }
 
+  template <typename E>
+  void write_step(const Grid_t& grid, const Int3& rn, const Int3& rx,
+                  const E& expr, const std::string& name,
+                  const std::vector<std::string>& comp_names)
+  {
+    begin_step(grid);
+    set_subset(grid, rn, rx);
+    write(expr, grid, name, comp_names);
+    end_step();
+  }
+
 private:
   kg::io::IOAdios2 io__;
   kg::io::Engine file_;

--- a/src/include/writer_adios2.hxx
+++ b/src/include/writer_adios2.hxx
@@ -7,10 +7,68 @@
 
 #include <cstdio>
 
+#define PSC_USE_IO_THREADS
+
+#ifdef PSC_USE_IO_THREADS
+
+#include <thread>
+#include <mutex>
+
+static std::mutex writer_mutex;
+
+void WriterThread(std::reference_wrapper<const Grid_t> grid_ref,
+                  std::reference_wrapper<kg::io::IOAdios2> io, std::string pfx,
+                  std::string dir, int step, double time,
+                  gt::gtensor<double, 5>&& h_expr, std::string name,
+                  std::vector<std::string> comp_names)
+{
+  static int pr;
+  if (!pr) {
+    pr = prof_register("writer thread", 1., 0, 0);
+  }
+
+  prof_start(pr);
+  MPI_Comm comm;
+  MPI_Comm_dup(MPI_COMM_WORLD, &comm);
+
+  const Grid_t& g = grid_ref;
+  Grid_t grid(g.domain, g.bc, g.kinds, g.norm, g.dt, g.n_patches(), g.ibn);
+
+  Mfields<double> h_mflds(grid, h_expr.shape(3), {});
+  h_mflds.gt() = h_expr;
+
+  char filename[dir.size() + pfx.size() + 20];
+  sprintf(filename, "%s/%s.%09d.bp", dir.c_str(), pfx.c_str(), step);
+  {
+    std::lock_guard<std::mutex> guard(writer_mutex);
+    auto file = io.get().open(filename, kg::io::Mode::Write, comm, pfx);
+
+    file.beginStep(kg::io::StepMode::Append);
+    file.put("step", step);
+    file.put("time", time);
+
+    file.put(name, h_mflds);
+    file.performPuts();
+    file.endStep();
+    file.close();
+  }
+  MPI_Comm_free(&comm);
+  prof_stop(pr);
+}
+
+#endif
+
 class WriterADIOS2
 {
 public:
   explicit operator bool() const { return pfx_.size() != 0; }
+
+  ~WriterADIOS2()
+  {
+    if (writer_thread_.joinable()) {
+      writer_thread_.join();
+    }
+  }
 
   void open(const std::string& pfx, const std::string& dir = ".")
   {
@@ -74,10 +132,46 @@ public:
                   const E& expr, const std::string& name,
                   const std::vector<std::string>& comp_names)
   {
+
+    static int pr, pr_copy, pr_wait, pr_write;
+    if (!pr) {
+      pr = prof_register("write_step", 1., 0, 0);
+      pr_copy = prof_register("ws copy", 1., 0, 0);
+      pr_wait = prof_register("ws wait", 1., 0, 0);
+      pr_write = prof_register("ws write", 1., 0, 0);
+    }
+
+    prof_start(pr);
+
+    // FIXME? rn, rx ignored
+    prof_start(pr_copy);
+    auto h_expr = gt::host_mirror(expr);
+    gt::copy(gt::eval(expr), h_expr);
+    prof_stop(pr_copy);
+
+#ifdef PSC_USE_IO_THREADS
+    if (writer_thread_.joinable()) {
+      // make sure previous I/O is finished
+      prof_start(pr_wait);
+      writer_thread_.join();
+      prof_stop(pr_wait);
+    }
+    prof_start(pr_write);
+    int step = grid.timestep();
+    double time = step * grid.dt;
+    writer_thread_ = std::thread{
+      WriterThread, std::cref(grid),   std::ref(io__), pfx_,      dir_, step,
+      time,         std::move(h_expr), name,           comp_names};
+    prof_stop(pr_write);
+#else
+    prof_start(pr_write);
     begin_step(grid);
     set_subset(grid, rn, rx);
     write(expr, grid, name, comp_names);
     end_step();
+    prof_stop(pr_write);
+#endif
+    prof_stop(pr);
   }
 
 private:
@@ -85,4 +179,7 @@ private:
   kg::io::Engine file_;
   std::string pfx_;
   std::string dir_;
+#ifdef PSC_USE_IO_THREADS
+  std::thread writer_thread_;
+#endif
 };

--- a/src/include/writer_mrc.hxx
+++ b/src/include/writer_mrc.hxx
@@ -104,6 +104,17 @@ public:
     mrc_fld_destroy(fld);
   }
 
+  template <typename E>
+  void write_step(const Grid_t& grid, const Int3& rn, const Int3& rx,
+                  const E& expr, const std::string& name,
+                  const std::vector<std::string>& comp_names)
+  {
+    begin_step(grid);
+    set_subset(grid, rn, rx);
+    write(expr, grid, name, comp_names);
+    end_step();
+  }
+
 private:
   std::unique_ptr<struct mrc_io, decltype(&mrc_io_close)> io_;
 };


### PR DESCRIPTION
Like so many things, this could and should be done more nicely, but for now it does the job, ie., launches a separate thread for writing field output so that the simulation can continue while that is happening.