### PR TITLE
checks: dump using adios2 (if available)

### DIFF
--- a/src/include/writer_adios2.hxx
+++ b/src/include/writer_adios2.hxx
@@ -16,11 +16,11 @@
 
 static std::mutex writer_mutex;
 
-void WriterThread(std::reference_wrapper<const Grid_t> grid_ref,
-                  std::reference_wrapper<kg::io::IOAdios2> io, std::string pfx,
-                  std::string dir, int step, double time,
-                  gt::gtensor<double, 5>&& h_expr, std::string name,
-                  std::vector<std::string> comp_names)
+inline void WriterThread(std::reference_wrapper<const Grid_t> grid_ref,
+                         std::reference_wrapper<kg::io::IOAdios2> io,
+                         std::string pfx, std::string dir, int step,
+                         double time, gt::gtensor<double, 5>&& h_expr,
+                         std::string name, std::vector<std::string> comp_names)
 {
   static int pr;
   if (!pr) {

--- a/src/libpsc/cuda/checks_cuda_impl.hxx
+++ b/src/libpsc/cuda/checks_cuda_impl.hxx
@@ -5,6 +5,18 @@
 
 #include "fields_item_moments_1st_cuda.hxx"
 
+#ifdef PSC_HAVE_ADIOS2
+
+#include "writer_adios2.hxx"
+using WriterDefault = WriterADIOS2;
+
+#else
+
+#include "writer_mrc.hxx"
+using WriterDefault = WriterMRC;
+
+#endif
+
 // FIXME!!! need to get Dim from Mparticles directly!
 
 template <typename BS>
@@ -98,7 +110,7 @@ struct ChecksCuda
     }
 
     if (continuity_dump_always || max_err >= eps) {
-      static WriterMRC writer;
+      static WriterDefault writer;
       if (!writer) {
         writer.open("continuity");
       }
@@ -107,6 +119,7 @@ struct ChecksCuda
       writer.write(d_rho, grid, "d_rho", {"d_rho"});
       writer.end_step();
     }
+    MPI_Barrier(grid.comm());
 
     assert(max_err < eps);
   }
@@ -170,7 +183,7 @@ struct ChecksCuda
     }
 
     if (gauss_dump_always || max_err >= eps) {
-      static WriterMRC writer;
+      static WriterDefault writer;
       if (!writer) {
         writer.open("gauss");
       }
@@ -180,6 +193,7 @@ struct ChecksCuda
       writer.end_step();
     }
 
+    MPI_Barrier(grid.comm());
     assert(max_err < eps);
   }
 

--- a/src/libpsc/psc_checks/checks_impl.hxx
+++ b/src/libpsc/psc_checks/checks_impl.hxx
@@ -4,12 +4,23 @@
 #include "fields.hxx"
 #include "fields_item.hxx"
 #include "checks.hxx"
-#include "writer_mrc.hxx"
 #include "../libpsc/psc_output_fields/fields_item_fields.hxx"
 #include "../libpsc/psc_output_fields/psc_output_fields_item_moments_1st_nc.cxx"
 #include "../libpsc/psc_output_fields/psc_output_fields_item_moments_2nd_nc.cxx"
 
 #include <mrc_io.h>
+
+#ifdef PSC_HAVE_ADIOS2
+
+#include "writer_adios2.hxx"
+using WriterDefault = WriterADIOS2;
+
+#else
+
+#include "writer_mrc.hxx"
+using WriterDefault = WriterMRC;
+
+#endif
 
 struct checks_order_1st
 {
@@ -109,7 +120,7 @@ struct Checks_
     }
 
     if (continuity_dump_always || max_err >= eps) {
-      static WriterMRC writer;
+      static WriterDefault writer;
       if (!writer) {
         writer.open("continuity");
       }
@@ -117,6 +128,7 @@ struct Checks_
       writer.write(divj_.gt(), grid, "div_j", {"div_j"});
       writer.write(d_rho.gt(), grid, "d_rho", {"d_rho"});
       writer.end_step();
+      MPI_Barrier(grid.comm());
     }
 
     assert(max_err < eps);
@@ -179,7 +191,7 @@ struct Checks_
     }
 
     if (gauss_dump_always || max_err >= eps) {
-      static WriterMRC writer;
+      static WriterDefault writer;
       if (!writer) {
         writer.open("gauss");
       }


### PR DESCRIPTION
Like all of the writing stuff, it'd be nicer to have this configurable rather than chosen depending on whether adios2 is available or not, but it'll do for now.

The real reason I did this, i think, is that my new xarray way of looking at data doesn't support hdf5 yet....