### PR TITLE
fix (disabled) threaded I/O

### DIFF
--- a/src/include/writer_adios2.hxx
+++ b/src/include/writer_adios2.hxx
@@ -7,7 +7,7 @@
 
 #include <cstdio>
 
-#define PSC_USE_IO_THREADS
+//#define PSC_USE_IO_THREADS
 
 #ifdef PSC_USE_IO_THREADS
 

--- a/src/include/writer_adios2.hxx
+++ b/src/include/writer_adios2.hxx
@@ -65,9 +65,11 @@ public:
 
   ~WriterADIOS2()
   {
+#ifdef PSC_USE_IO_THREADS
     if (writer_thread_.joinable()) {
       writer_thread_.join();
     }
+#endif
   }
 
   void open(const std::string& pfx, const std::string& dir = ".")

--- a/src/libpsc/vpic/vpic_base.cxx
+++ b/src/libpsc/vpic/vpic_base.cxx
@@ -34,7 +34,8 @@ void vpic_base_init(int* pargc, char*** pargv)
 
     boot_mp(pargc, pargv);
 #else
-    MPI_Init(pargc, pargv);
+    int provided;
+    MPI_Init_thread(pargc, pargv, MPI_THREAD_MULTIPLE, &provided);
 #endif
 
     MPI_Comm_dup(MPI_COMM_WORLD, &psc_comm_world);


### PR DESCRIPTION
Summit's MPI doesn't like new threads to be launched repeatedly, so this reverts back to the regular I/O for now.