### PR TITLE
flatfoil: change mass ratio back to 100

### DIFF
--- a/src/psc_flatfoil_yz.cxx
+++ b/src/psc_flatfoil_yz.cxx
@@ -257,7 +257,7 @@ void setupParameters()
 #if CASE == CASE_2D_SMALL
   g.mass_ratio = 100.;
 #else
-  g.mass_ratio = 64.;
+  g.mass_ratio = 100.;
 #endif
   g.lambda0 = 20.;
 


### PR DESCRIPTION
Not sure when that changed, but this actually lead to a slightly off
location for the heating spot, since that's specified based on d_i.