### PR TITLE
libmrc: link math library

### DIFF
--- a/src/libmrc/CMakeLists.txt
+++ b/src/libmrc/CMakeLists.txt
@@ -46,6 +46,7 @@ target_include_directories(mrc
 )
 target_link_libraries(mrc
   PUBLIC
+    m
     MPI::MPI_C
     HDF5::HL
 )


### PR DESCRIPTION
Not sure why this is showing up now (on Summit), but at least
it's an easy fix.