### PR TITLE
cmake: export compiler commands (for vscode)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,6 +12,8 @@ endforeach()
 
 project(PSC)
 
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+
 include(cmake/CPM.cmake)
 
 include(CTest)


### PR DESCRIPTION
For this to matter, you also need .vscode/c_cpp_properties.json with
"configurations": [
    "name": <name>,
    "compileCommands": "${workspaceFolder}/build/compile_commands.json"
]
(see the C/C++ extension for details)