### PR TITLE
Pr/fix-filename-overflow

### DIFF
--- a/src/libmrc/src/mrc_io.c
+++ b/src/libmrc/src/mrc_io.c
@@ -14,25 +14,25 @@
 // ======================================================================
 // mrc_io
 
-static inline struct mrc_io_ops *
-mrc_io_ops(struct mrc_io *io)
+static inline struct mrc_io_ops* mrc_io_ops(struct mrc_io* io)
 {
-  return (struct mrc_io_ops *) io->obj.ops;
+  return (struct mrc_io_ops*)io->obj.ops;
 }
 
 // ----------------------------------------------------------------------
 
-struct mrc_obj_entry {
-  struct mrc_obj *obj;
-  char *path;
+struct mrc_obj_entry
+{
+  struct mrc_obj* obj;
+  char* path;
   list_t entry;
 };
 
-struct mrc_obj *
-mrc_io_find_obj(struct mrc_io *io, const char *path)
+struct mrc_obj* mrc_io_find_obj(struct mrc_io* io, const char* path)
 {
-  struct mrc_obj_entry *p;
-  __list_for_each_entry(p, &io->obj_list, entry, struct mrc_obj_entry) {
+  struct mrc_obj_entry* p;
+  __list_for_each_entry(p, &io->obj_list, entry, struct mrc_obj_entry)
+  {
     if (strcmp(p->path, path) == 0) {
       return p->obj;
     }
@@ -40,11 +40,11 @@ mrc_io_find_obj(struct mrc_io *io, const char *path)
   return NULL;
 }
 
-const char *
-__mrc_io_obj_path(struct mrc_io *io, struct mrc_obj *obj)
+const char* __mrc_io_obj_path(struct mrc_io* io, struct mrc_obj* obj)
 {
-  struct mrc_obj_entry *p;
-  __list_for_each_entry(p, &io->obj_list, entry, struct mrc_obj_entry) {
+  struct mrc_obj_entry* p;
+  __list_for_each_entry(p, &io->obj_list, entry, struct mrc_obj_entry)
+  {
     if (p->obj == obj) {
       return p->path;
     }
@@ -52,11 +52,10 @@ __mrc_io_obj_path(struct mrc_io *io, struct mrc_obj *obj)
   return NULL;
 }
 
-int
-mrc_io_add_obj(struct mrc_io *io, struct mrc_obj *obj, const char *_path)
+int mrc_io_add_obj(struct mrc_io* io, struct mrc_obj* obj, const char* _path)
 {
-  char *path = strdup(_path);
-  struct mrc_obj *obj2 = mrc_io_find_obj(io, path);
+  char* path = strdup(_path);
+  struct mrc_obj* obj2 = mrc_io_find_obj(io, path);
   if (obj2) { // exists
     if (obj != obj2) {
       mprintf("!!! obj  %p '%s' (%s)\n", obj, path, obj->cls->name);
@@ -66,7 +65,7 @@ mrc_io_add_obj(struct mrc_io *io, struct mrc_obj *obj, const char *_path)
     free(path);
     return 1;
   }
-  struct mrc_obj_entry *p = malloc(sizeof(*p));
+  struct mrc_obj_entry* p = malloc(sizeof(*p));
   p->obj = mrc_obj_get(obj);
   p->path = path;
   list_add_tail(&p->entry, &io->obj_list);
@@ -76,8 +75,7 @@ mrc_io_add_obj(struct mrc_io *io, struct mrc_obj *obj, const char *_path)
 // ----------------------------------------------------------------------
 // mrc_io_setup
 
-static void
-_mrc_io_setup(struct mrc_io *io)
+static void _mrc_io_setup(struct mrc_io* io)
 {
   MPI_Comm_rank(io->obj.comm, &io->rank);
   MPI_Comm_size(io->obj.comm, &io->size);
@@ -86,12 +84,11 @@ _mrc_io_setup(struct mrc_io *io)
 // ----------------------------------------------------------------------
 // mrc_io_open
 
-void
-mrc_io_open(struct mrc_io *io, const char *mode, int step, float time)
+void mrc_io_open(struct mrc_io* io, const char* mode, int step, float time)
 {
   assert(mrc_io_is_setup(io));
 
-  struct mrc_io_ops *ops = mrc_io_ops(io);
+  struct mrc_io_ops* ops = mrc_io_ops(io);
   io->step = step;
   io->time = time;
   INIT_LIST_HEAD(&io->obj_list);
@@ -102,13 +99,12 @@ mrc_io_open(struct mrc_io *io, const char *mode, int step, float time)
 // ----------------------------------------------------------------------
 // mrc_io_close
 
-void
-mrc_io_close(struct mrc_io *io)
+void mrc_io_close(struct mrc_io* io)
 {
-  struct mrc_io_ops *ops = mrc_io_ops(io);
+  struct mrc_io_ops* ops = mrc_io_ops(io);
   while (!list_empty(&io->obj_list)) {
-    struct mrc_obj_entry *p = list_entry(io->obj_list.next, struct mrc_obj_entry,
-					 entry);
+    struct mrc_obj_entry* p =
+      list_entry(io->obj_list.next, struct mrc_obj_entry, entry);
     list_del(&p->entry);
     mrc_obj_put(p->obj);
     free(p->path);
@@ -123,25 +119,26 @@ mrc_io_close(struct mrc_io *io)
 // ----------------------------------------------------------------------
 // mrc_io_read_f3
 
-void
-mrc_io_read_f3(struct mrc_io *io, const char *path, struct mrc_fld *fld)
+void mrc_io_read_f3(struct mrc_io* io, const char* path, struct mrc_fld* fld)
 {
-  struct mrc_io_ops *ops = mrc_io_ops(io);
+  struct mrc_io_ops* ops = mrc_io_ops(io);
   if (ops->read_f3) {
     ops->read_f3(io, path, fld);
   } else {
     assert(fld->_domain);
-    struct mrc_fld *m3 = mrc_domain_m3_create(fld->_domain);
+    struct mrc_fld* m3 = mrc_domain_m3_create(fld->_domain);
     mrc_fld_set_param_int(m3, "nr_ghosts", fld->_sw.vals[0]);
     mrc_fld_set_param_int(m3, "nr_comps", mrc_fld_nr_comps(fld));
     mrc_fld_setup(m3);
     mrc_io_read_m3(io, path, m3);
 
-    struct mrc_fld_patch *m3p = mrc_fld_patch_get(m3, 0);
+    struct mrc_fld_patch* m3p = mrc_fld_patch_get(m3, 0);
     for (int m = 0; m < mrc_fld_nr_comps(m3); m++) {
-      mrc_m3_foreach_bnd(m3p, ix,iy,iz) {
-	MRC_F3(fld, m, ix,iy,iz) = MRC_M3(m3p, m, ix,iy,iz);
-      } mrc_m3_foreach_end;
+      mrc_m3_foreach_bnd(m3p, ix, iy, iz)
+      {
+        MRC_F3(fld, m, ix, iy, iz) = MRC_M3(m3p, m, ix, iy, iz);
+      }
+      mrc_m3_foreach_end;
     }
     mrc_fld_patch_put(m3);
     mrc_fld_destroy(m3);
@@ -151,10 +148,9 @@ mrc_io_read_f3(struct mrc_io *io, const char *path, struct mrc_fld *fld)
 // ----------------------------------------------------------------------
 // mrc_io_read_fld
 
-void
-mrc_io_read_fld(struct mrc_io *io, const char *path, struct mrc_fld *fld)
+void mrc_io_read_fld(struct mrc_io* io, const char* path, struct mrc_fld* fld)
 {
-  struct mrc_io_ops *ops = mrc_io_ops(io);
+  struct mrc_io_ops* ops = mrc_io_ops(io);
   if (ops->read_fld) {
     ops->read_fld(io, path, fld);
   } else if (fld->_dims.nr_vals == 3) {
@@ -167,15 +163,16 @@ mrc_io_read_fld(struct mrc_io *io, const char *path, struct mrc_fld *fld)
     assert(0);
   }
   // FIXME: To save/recover comp names, just write them as attributes
-  for ( int m=0; m < mrc_fld_nr_comps(fld); m++) {
+  for (int m = 0; m < mrc_fld_nr_comps(fld); m++) {
     char comp_label[100];
     sprintf(comp_label, "comp_name_%d", m);
-    char *comp_name = NULL;
+    char* comp_name = NULL;
     // FIXME: Is the string memory returned from this leaked?
-    mrc_io_read_attr_string(io, path, (const char *) comp_label, &comp_name);
+    mrc_io_read_attr_string(io, path, (const char*)comp_label, &comp_name);
     if (comp_name) {
-      mrc_fld_set_comp_name(fld, m, (const char *) comp_name);
-      free(comp_name); // I think this free is needed, otherwise we leak the returned memory
+      mrc_fld_set_comp_name(fld, m, (const char*)comp_name);
+      free(comp_name); // I think this free is needed, otherwise we leak the
+                       // returned memory
     }
   }
 }
@@ -183,10 +180,9 @@ mrc_io_read_fld(struct mrc_io *io, const char *path, struct mrc_fld *fld)
 // ----------------------------------------------------------------------
 // mrc_io_write_fld
 
-void
-mrc_io_write_fld(struct mrc_io *io, const char *path, struct mrc_fld *fld)
+void mrc_io_write_fld(struct mrc_io* io, const char* path, struct mrc_fld* fld)
 {
-  struct mrc_io_ops *ops = mrc_io_ops(io);
+  struct mrc_io_ops* ops = mrc_io_ops(io);
   if (ops->write_fld) {
     ops->write_fld(io, path, fld);
   } else if (fld->_dims.nr_vals == 3) {
@@ -201,20 +197,20 @@ mrc_io_write_fld(struct mrc_io *io, const char *path, struct mrc_fld *fld)
     assert(0);
   }
   // FIXME: To save/recover comp names, just write them as attributes
-  for ( int m=0; m < mrc_fld_nr_comps(fld); m++) {
+  for (int m = 0; m < mrc_fld_nr_comps(fld); m++) {
     char comp_label[100];
     sprintf(comp_label, "comp_name_%d", m);
-    mrc_io_write_attr_string(io, path, (const char *) comp_label, mrc_fld_comp_name(fld, m));
+    mrc_io_write_attr_string(io, path, (const char*)comp_label,
+                             mrc_fld_comp_name(fld, m));
   }
 }
 
 // ----------------------------------------------------------------------
 // mrc_io_write_m1
 
-void
-mrc_io_write_m1(struct mrc_io *io, const char *path, struct mrc_fld *fld)
+void mrc_io_write_m1(struct mrc_io* io, const char* path, struct mrc_fld* fld)
 {
-  struct mrc_io_ops *ops = mrc_io_ops(io);
+  struct mrc_io_ops* ops = mrc_io_ops(io);
   if (ops->write_m1) {
     ops->write_m1(io, path, fld);
   } else {
@@ -225,10 +221,9 @@ mrc_io_write_m1(struct mrc_io *io, const char *path, struct mrc_fld *fld)
 // ----------------------------------------------------------------------
 // mrc_io_read_m1
 
-void
-mrc_io_read_m1(struct mrc_io *io, const char *path, struct mrc_fld *fld)
+void mrc_io_read_m1(struct mrc_io* io, const char* path, struct mrc_fld* fld)
 {
-  struct mrc_io_ops *ops = mrc_io_ops(io);
+  struct mrc_io_ops* ops = mrc_io_ops(io);
   if (ops->read_m1) {
     ops->read_m1(io, path, fld);
   } else {
@@ -239,10 +234,9 @@ mrc_io_read_m1(struct mrc_io *io, const char *path, struct mrc_fld *fld)
 // ----------------------------------------------------------------------
 // mrc_io_write_m3
 
-void
-mrc_io_write_m3(struct mrc_io *io, const char *path, struct mrc_fld *fld)
+void mrc_io_write_m3(struct mrc_io* io, const char* path, struct mrc_fld* fld)
 {
-  struct mrc_io_ops *ops = mrc_io_ops(io);
+  struct mrc_io_ops* ops = mrc_io_ops(io);
   if (ops->write_m3) {
     ops->write_m3(io, path, fld);
   } else if (ops->write_field) {
@@ -260,10 +254,9 @@ mrc_io_write_m3(struct mrc_io *io, const char *path, struct mrc_fld *fld)
 // ----------------------------------------------------------------------
 // mrc_io_read_m3
 
-void
-mrc_io_read_m3(struct mrc_io *io, const char *path, struct mrc_fld *fld)
+void mrc_io_read_m3(struct mrc_io* io, const char* path, struct mrc_fld* fld)
 {
-  struct mrc_io_ops *ops = mrc_io_ops(io);
+  struct mrc_io_ops* ops = mrc_io_ops(io);
   if (ops->read_m3) {
     ops->read_m3(io, path, fld);
   } else if (ops->read_f3) {
@@ -277,11 +270,10 @@ mrc_io_read_m3(struct mrc_io *io, const char *path, struct mrc_fld *fld)
 // ----------------------------------------------------------------------
 // mrc_io_write_field2d
 
-void
-mrc_io_write_field2d(struct mrc_io *io, float scale, struct mrc_fld *fld,
-		     int outtype, float sheet)
+void mrc_io_write_field2d(struct mrc_io* io, float scale, struct mrc_fld* fld,
+                          int outtype, float sheet)
 {
-  struct mrc_io_ops *ops = mrc_io_ops(io);
+  struct mrc_io_ops* ops = mrc_io_ops(io);
   assert(mrc_fld_comp_name(fld, 0));
   assert(ops->write_field2d);
   ops->write_field2d(io, scale, fld, outtype, sheet);
@@ -290,88 +282,91 @@ mrc_io_write_field2d(struct mrc_io *io, float scale, struct mrc_fld *fld,
 // ----------------------------------------------------------------------
 // mrc_io_write_field_slice
 
-void
-mrc_io_write_field_slice(struct mrc_io *io, float scale, struct mrc_fld *fld,
-			 int outtype, float sheet)
+void mrc_io_write_field_slice(struct mrc_io* io, float scale,
+                              struct mrc_fld* fld, int outtype, float sheet)
 {
-  struct mrc_io_ops *ops = mrc_io_ops(io);
+  struct mrc_io_ops* ops = mrc_io_ops(io);
 
-  //dig out a sheet of constant x/y/z
+  // dig out a sheet of constant x/y/z
 
   assert(outtype >= DIAG_TYPE_2D_X && outtype <= DIAG_TYPE_2D_Z);
   int dim = outtype - DIAG_TYPE_2D_X;
 
   int nr_patches;
-  struct mrc_patch *patches = mrc_domain_get_patches(fld->_domain, &nr_patches);
+  struct mrc_patch* patches = mrc_domain_get_patches(fld->_domain, &nr_patches);
   assert(nr_patches == 1);
-  int *dims = patches[0].ldims;
+  int* dims = patches[0].ldims;
 
-  struct mrc_fld *f2 = mrc_fld_create(MPI_COMM_SELF);
-  //check for existence on local proc.
-  //0,1, nnx-2, nnx-1 are the ghostpoints
-  struct mrc_crds *crds = mrc_domain_get_crds(fld->_domain);
-  if (MRC_CRD(crds, dim, 1) < sheet && sheet <= MRC_CRD(crds, dim, dims[dim]+1)) { 
+  struct mrc_fld* f2 = mrc_fld_create(MPI_COMM_SELF);
+  // check for existence on local proc.
+  // 0,1, nnx-2, nnx-1 are the ghostpoints
+  struct mrc_crds* crds = mrc_domain_get_crds(fld->_domain);
+  if (MRC_CRD(crds, dim, 1) < sheet &&
+      sheet <= MRC_CRD(crds, dim, dims[dim] + 1)) {
     int ii;
     for (ii = 1; ii < dims[dim]; ii++) {
-      if (sheet <= MRC_CRD(crds, dim, ii+1))
-	break;
+      if (sheet <= MRC_CRD(crds, dim, ii + 1))
+        break;
     }
 
-    float s2 = (sheet - MRC_CRD(crds, dim, ii)) / 
-      (MRC_CRD(crds, dim, ii+1) - MRC_CRD(crds, dim, ii));
+    float s2 = (sheet - MRC_CRD(crds, dim, ii)) /
+               (MRC_CRD(crds, dim, ii + 1) - MRC_CRD(crds, dim, ii));
     float s1 = 1. - s2;
     s1 *= scale;
     s2 *= scale;
 
-    struct mrc_fld *f = mrc_fld_get_as(fld, "float");
+    struct mrc_fld* f = mrc_fld_get_as(fld, "float");
     switch (dim) {
-    case 0: {
-      mrc_fld_set_param_int_array(f2, "dims", 5, (int[5]) { dims[1], dims[2], 1, 1, 1 });
-      mrc_fld_setup(f2);
-      struct mrc_fld *_f2 = mrc_fld_get_as(f2, "float");
-      for(int iz = 0; iz < dims[2]; iz++) {
-	for(int iy = 0; iy < dims[1]; iy++) {
-	  MRC_F2(_f2,0, iy,iz) = (s1 * MRC_F3(f,0, ii-2,iy,iz) +
-				  s2 * MRC_F3(f,0, ii-1,iy,iz));
-	}
+      case 0: {
+        mrc_fld_set_param_int_array(f2, "dims", 5,
+                                    (int[5]){dims[1], dims[2], 1, 1, 1});
+        mrc_fld_setup(f2);
+        struct mrc_fld* _f2 = mrc_fld_get_as(f2, "float");
+        for (int iz = 0; iz < dims[2]; iz++) {
+          for (int iy = 0; iy < dims[1]; iy++) {
+            MRC_F2(_f2, 0, iy, iz) = (s1 * MRC_F3(f, 0, ii - 2, iy, iz) +
+                                      s2 * MRC_F3(f, 0, ii - 1, iy, iz));
+          }
+        }
+        mrc_fld_put_as(_f2, f2);
+      } break;
+      case 1: {
+        mrc_fld_set_param_int_array(f2, "dims", 5,
+                                    (int[5]){dims[0], dims[2], 1, 1, 1});
+        mrc_fld_setup(f2);
+        struct mrc_fld* _f2 = mrc_fld_get_as(f2, "float");
+        for (int iz = 0; iz < dims[2]; iz++) {
+          for (int ix = 0; ix < dims[0]; ix++) {
+            MRC_F2(_f2, 0, ix, iz) = (s1 * MRC_F3(f, 0, ix, ii - 2, iz) +
+                                      s2 * MRC_F3(f, 0, ix, ii - 1, iz));
+          }
+        }
+        mrc_fld_put_as(_f2, f2);
+        break;
       }
-      mrc_fld_put_as(_f2, f2);
-    }
-      break;
-    case 1: {
-      mrc_fld_set_param_int_array(f2, "dims", 5, (int[5]) { dims[0], dims[2], 1, 1, 1 });
-      mrc_fld_setup(f2);
-      struct mrc_fld *_f2 = mrc_fld_get_as(f2, "float");
-      for(int iz = 0; iz < dims[2]; iz++) {
-	for(int ix = 0; ix < dims[0]; ix++) {
-	  MRC_F2(_f2,0, ix,iz) = (s1 * MRC_F3(f,0, ix,ii-2,iz) +
-				  s2 * MRC_F3(f,0, ix,ii-1,iz));
-	}
+      case 2: {
+        mrc_fld_set_param_int_array(f2, "dims", 5,
+                                    (int[5]){dims[0], dims[1], 1, 1, 1});
+        mrc_fld_setup(f2);
+        struct mrc_fld* _f2 = mrc_fld_get_as(f2, "float");
+        for (int iy = 0; iy < dims[1]; iy++) {
+          for (int ix = 0; ix < dims[0]; ix++) {
+            MRC_F2(_f2, 0, ix, iy) = (s1 * MRC_F3(f, 0, ix, iy, ii - 2) +
+                                      s2 * MRC_F3(f, 0, ix, iy, ii - 1));
+          }
+        }
+        mrc_fld_put_as(_f2, f2);
+        break;
       }
-      mrc_fld_put_as(_f2, f2);
-      break;
-    }
-    case 2: {
-      mrc_fld_set_param_int_array(f2, "dims", 5, (int[5]) { dims[0], dims[1], 1, 1, 1 });
-      mrc_fld_setup(f2);
-      struct mrc_fld *_f2 = mrc_fld_get_as(f2, "float");
-      for(int iy = 0; iy < dims[1]; iy++) {
-	for(int ix = 0; ix < dims[0]; ix++) {
-	  MRC_F2(_f2,0, ix,iy) = (s1 * MRC_F3(f,0, ix,iy,ii-2) +
-				  s2 * MRC_F3(f,0, ix,iy,ii-1));
-	}
-      }
-      mrc_fld_put_as(_f2, f2);
-      break;
-    }
     }
     mrc_fld_put_as(f, fld);
   } else {
     // not on local proc
-    mrc_fld_set_param_int_array(f2, "dims", 5, (int[5]) { 0, 0, 0, 1, 1 });
+    mrc_fld_set_param_int_array(f2, "dims", 5, (int[5]){0, 0, 0, 1, 1});
     mrc_fld_setup(f2);
   }
-  f2->_domain = fld->_domain; // FIXME, 2D field isn't directly based on domain, so shouldn't link to it (?)
+  f2->_domain = fld->_domain; // FIXME, 2D field isn't directly based on domain,
+                              // so shouldn't link to it (?)
   mrc_fld_set_comp_name(f2, 0, mrc_fld_comp_name(fld, 0));
   ops->write_field2d(io, 1., f2, outtype, sheet);
   mrc_fld_destroy(f2);
@@ -380,10 +375,10 @@ mrc_io_write_field_slice(struct mrc_io *io, float scale, struct mrc_fld *fld,
 // ----------------------------------------------------------------------
 // mrc_io_write_ndarray
 
-void
-mrc_io_write_ndarray(struct mrc_io *io, const char *path, struct mrc_ndarray *nd)
+void mrc_io_write_ndarray(struct mrc_io* io, const char* path,
+                          struct mrc_ndarray* nd)
 {
-  struct mrc_io_ops *ops = mrc_io_ops(io);
+  struct mrc_io_ops* ops = mrc_io_ops(io);
   assert(ops && ops->write_ndarray);
 
   ops->write_ndarray(io, path, nd);
@@ -392,10 +387,10 @@ mrc_io_write_ndarray(struct mrc_io *io, const char *path, struct mrc_ndarray *nd
 // ----------------------------------------------------------------------
 // mrc_io_read_ndarray
 
-void
-mrc_io_read_ndarray(struct mrc_io *io, const char *path, struct mrc_ndarray *nd)
+void mrc_io_read_ndarray(struct mrc_io* io, const char* path,
+                         struct mrc_ndarray* nd)
 {
-  struct mrc_io_ops *ops = mrc_io_ops(io);
+  struct mrc_io_ops* ops = mrc_io_ops(io);
   assert(ops && ops->read_ndarray);
 
   ops->read_ndarray(io, path, nd);
@@ -404,31 +399,28 @@ mrc_io_read_ndarray(struct mrc_io *io, const char *path, struct mrc_ndarray *nd)
 // ----------------------------------------------------------------------
 // mrc_io_read_attr
 
-void
-mrc_io_read_attr(struct mrc_io *io, const char *path, int type, const char *name,
-		 union param_u *pv)
+void mrc_io_read_attr(struct mrc_io* io, const char* path, int type,
+                      const char* name, union param_u* pv)
 {
-  struct mrc_io_ops *ops = mrc_io_ops(io);
+  struct mrc_io_ops* ops = mrc_io_ops(io);
   assert(ops->read_attr);
   ops->read_attr(io, path, type, name, pv);
 }
 
-void
-mrc_io_read_attr_int(struct mrc_io *io, const char *path, const char *name,
-		     int *val)
+void mrc_io_read_attr_int(struct mrc_io* io, const char* path, const char* name,
+                          int* val)
 {
-  struct mrc_io_ops *ops = mrc_io_ops(io);
+  struct mrc_io_ops* ops = mrc_io_ops(io);
   assert(ops->read_attr);
   union param_u u;
   ops->read_attr(io, path, PT_INT, name, &u);
   *val = u.u_int;
 }
 
-void
-mrc_io_read_attr_int3(struct mrc_io *io, const char *path, const char *name,
-		      int (*val)[3])
+void mrc_io_read_attr_int3(struct mrc_io* io, const char* path,
+                           const char* name, int (*val)[3])
 {
-  struct mrc_io_ops *ops = mrc_io_ops(io);
+  struct mrc_io_ops* ops = mrc_io_ops(io);
   assert(ops->read_attr);
   union param_u u;
   ops->read_attr(io, path, PT_INT3, name, &u);
@@ -437,22 +429,20 @@ mrc_io_read_attr_int3(struct mrc_io *io, const char *path, const char *name,
   }
 }
 
-void
-mrc_io_read_attr_float(struct mrc_io *io, const char *path, const char *name,
-		     float *val)
+void mrc_io_read_attr_float(struct mrc_io* io, const char* path,
+                            const char* name, float* val)
 {
-  struct mrc_io_ops *ops = mrc_io_ops(io);
+  struct mrc_io_ops* ops = mrc_io_ops(io);
   assert(ops->read_attr);
   union param_u u;
   ops->read_attr(io, path, PT_FLOAT, name, &u);
   *val = u.u_float;
 }
 
-void
-mrc_io_read_attr_float3(struct mrc_io *io, const char *path, const char *name,
-		      float (*val)[3])
+void mrc_io_read_attr_float3(struct mrc_io* io, const char* path,
+                             const char* name, float (*val)[3])
 {
-  struct mrc_io_ops *ops = mrc_io_ops(io);
+  struct mrc_io_ops* ops = mrc_io_ops(io);
   assert(ops->read_attr);
   union param_u u;
   ops->read_attr(io, path, PT_FLOAT3, name, &u);
@@ -461,22 +451,20 @@ mrc_io_read_attr_float3(struct mrc_io *io, const char *path, const char *name,
   }
 }
 
-void
-mrc_io_read_attr_double(struct mrc_io *io, const char *path, const char *name,
-			double *val)
+void mrc_io_read_attr_double(struct mrc_io* io, const char* path,
+                             const char* name, double* val)
 {
-  struct mrc_io_ops *ops = mrc_io_ops(io);
+  struct mrc_io_ops* ops = mrc_io_ops(io);
   assert(ops->read_attr);
   union param_u u;
   ops->read_attr(io, path, PT_DOUBLE, name, &u);
   *val = u.u_double;
 }
 
-void
-mrc_io_read_attr_double3(struct mrc_io *io, const char *path, const char *name,
-		      double (*val)[3])
+void mrc_io_read_attr_double3(struct mrc_io* io, const char* path,
+                              const char* name, double (*val)[3])
 {
-  struct mrc_io_ops *ops = mrc_io_ops(io);
+  struct mrc_io_ops* ops = mrc_io_ops(io);
   assert(ops->read_attr);
   union param_u u;
   ops->read_attr(io, path, PT_DOUBLE3, name, &u);
@@ -485,131 +473,114 @@ mrc_io_read_attr_double3(struct mrc_io *io, const char *path, const char *name,
   }
 }
 
-
-void
-mrc_io_read_attr_string(struct mrc_io *io, const char *path, const char *name,
-			char **val)
+void mrc_io_read_attr_string(struct mrc_io* io, const char* path,
+                             const char* name, char** val)
 {
-  struct mrc_io_ops *ops = mrc_io_ops(io);
+  struct mrc_io_ops* ops = mrc_io_ops(io);
   assert(ops->read_attr);
   union param_u u;
   ops->read_attr(io, path, PT_STRING, name, &u);
-  *val = (char *) u.u_string;
+  *val = (char*)u.u_string;
 }
 
-void
-mrc_io_read_attr_bool(struct mrc_io *io, const char *path, const char *name,
-		      bool *val)
+void mrc_io_read_attr_bool(struct mrc_io* io, const char* path,
+                           const char* name, bool* val)
 {
-  struct mrc_io_ops *ops = mrc_io_ops(io);
+  struct mrc_io_ops* ops = mrc_io_ops(io);
   assert(ops->read_attr);
   union param_u u;
   ops->read_attr(io, path, PT_BOOL, name, &u);
   *val = u.u_bool;
 }
 
-
 // ----------------------------------------------------------------------
 // mrc_io_write_attr
 
-void
-mrc_io_write_attr(struct mrc_io *io, const char *path, int type, const char *name,
-		  union param_u *pv)
+void mrc_io_write_attr(struct mrc_io* io, const char* path, int type,
+                       const char* name, union param_u* pv)
 {
-  struct mrc_io_ops *ops = mrc_io_ops(io);
+  struct mrc_io_ops* ops = mrc_io_ops(io);
   if (ops->write_attr) {
     ops->write_attr(io, path, type, name, pv);
   }
 }
 
-void
-mrc_io_write_attr_int(struct mrc_io *io, const char *path, const char *name,
-		      int val)
+void mrc_io_write_attr_int(struct mrc_io* io, const char* path,
+                           const char* name, int val)
 {
-  struct mrc_io_ops *ops = mrc_io_ops(io);
+  struct mrc_io_ops* ops = mrc_io_ops(io);
   if (ops->write_attr) {
-    union param_u u = { .u_int = val };
+    union param_u u = {.u_int = val};
     ops->write_attr(io, path, PT_INT, name, &u);
   }
 }
 
-void
-mrc_io_write_attr_int3(struct mrc_io *io, const char *path, const char *name,
-		       int val[3])
+void mrc_io_write_attr_int3(struct mrc_io* io, const char* path,
+                            const char* name, int val[3])
 {
-  struct mrc_io_ops *ops = mrc_io_ops(io);
+  struct mrc_io_ops* ops = mrc_io_ops(io);
   if (ops->write_attr) {
-    union param_u u = { .u_int3 = { val[0], val[1], val[2] } };
+    union param_u u = {.u_int3 = {val[0], val[1], val[2]}};
     ops->write_attr(io, path, PT_INT3, name, &u);
   }
 }
 
-
-
-void
-mrc_io_write_attr_float(struct mrc_io *io, const char *path, const char *name,
-		      float val)
+void mrc_io_write_attr_float(struct mrc_io* io, const char* path,
+                             const char* name, float val)
 {
-  struct mrc_io_ops *ops = mrc_io_ops(io);
+  struct mrc_io_ops* ops = mrc_io_ops(io);
   if (ops->write_attr) {
-    union param_u u = { .u_float = val };
+    union param_u u = {.u_float = val};
     ops->write_attr(io, path, PT_FLOAT, name, &u);
   }
 }
 
-void
-mrc_io_write_attr_float3(struct mrc_io *io, const char *path, const char *name,
-		       float val[3])
+void mrc_io_write_attr_float3(struct mrc_io* io, const char* path,
+                              const char* name, float val[3])
 {
-  struct mrc_io_ops *ops = mrc_io_ops(io);
+  struct mrc_io_ops* ops = mrc_io_ops(io);
   if (ops->write_attr) {
-    union param_u u = { .u_float3 = { val[0], val[1], val[2] } };
+    union param_u u = {.u_float3 = {val[0], val[1], val[2]}};
     ops->write_attr(io, path, PT_FLOAT3, name, &u);
   }
 }
 
-
-
-void
-mrc_io_write_attr_string(struct mrc_io *io, const char *path, const char *name,
-			 const char *val)
+void mrc_io_write_attr_string(struct mrc_io* io, const char* path,
+                              const char* name, const char* val)
 {
-  struct mrc_io_ops *ops = mrc_io_ops(io);
+  struct mrc_io_ops* ops = mrc_io_ops(io);
   if (ops->write_attr) {
-    union param_u u = { .u_string = val };
+    union param_u u = {.u_string = val};
     ops->write_attr(io, path, PT_STRING, name, &u);
   }
 }
 
-void
-mrc_io_write_attr_double(struct mrc_io *io, const char *path, const char *name,
-			 double val)
+void mrc_io_write_attr_double(struct mrc_io* io, const char* path,
+                              const char* name, double val)
 {
-  struct mrc_io_ops *ops = mrc_io_ops(io);
+  struct mrc_io_ops* ops = mrc_io_ops(io);
   if (ops->write_attr) {
-    union param_u u = { .u_double = val };
+    union param_u u = {.u_double = val};
     ops->write_attr(io, path, PT_DOUBLE, name, &u);
   }
 }
 
-void
-mrc_io_write_attr_double3(struct mrc_io *io, const char *path, const char *name,
-		       double val[3])
+void mrc_io_write_attr_double3(struct mrc_io* io, const char* path,
+                               const char* name, double val[3])
 {
-  struct mrc_io_ops *ops = mrc_io_ops(io);
+  struct mrc_io_ops* ops = mrc_io_ops(io);
   if (ops->write_attr) {
-    union param_u u = { .u_double3 = { val[0], val[1], val[2] } };
+    union param_u u = {.u_double3 = {val[0], val[1], val[2]}};
     ops->write_attr(io, path, PT_DOUBLE3, name, &u);
   }
 }
 
-void
-mrc_io_write_attr_bool(struct mrc_io *io, const char *path, const char *name,
-		       bool val)
+void mrc_io_write_attr_bool(struct mrc_io* io, const char* path,
+                            const char* name, bool val)
 {
-  struct mrc_io_ops *ops = mrc_io_ops(io);
+  struct mrc_io_ops* ops = mrc_io_ops(io);
   if (ops->write_attr) {
-    union param_u u = { .u_bool = val };
+    union param_u u = {.u_bool = val};
     ops->write_attr(io, path, PT_BOOL, name, &u);
   }
 }
@@ -617,10 +588,9 @@ mrc_io_write_attr_bool(struct mrc_io *io, const char *path, const char *name,
 // ----------------------------------------------------------------------
 // mrc_io_get_h5_file
 
-void
-mrc_io_get_h5_file(struct mrc_io *io, long *h5_file)
+void mrc_io_get_h5_file(struct mrc_io* io, long* h5_file)
 {
-  struct mrc_io_ops *ops = mrc_io_ops(io);
+  struct mrc_io_ops* ops = mrc_io_ops(io);
   assert(ops->get_h5_file);
   ops->get_h5_file(io, h5_file);
 }
@@ -628,13 +598,12 @@ mrc_io_get_h5_file(struct mrc_io *io, long *h5_file)
 // ----------------------------------------------------------------------
 // __mrc_io_read_path
 
-struct mrc_obj *
-__mrc_io_read_path(struct mrc_io *io, const char *path, const char *name,
-		   struct mrc_class *class)
+struct mrc_obj* __mrc_io_read_path(struct mrc_io* io, const char* path,
+                                   const char* name, struct mrc_class* class)
 {
-  char *s;
+  char* s;
   mrc_io_read_attr_string(io, path, name, &s);
-  struct mrc_obj *obj = mrc_obj_read(io, s, class);
+  struct mrc_obj* obj = mrc_obj_read(io, s, class);
   free(s);
   return obj;
 }
@@ -642,16 +611,15 @@ __mrc_io_read_path(struct mrc_io *io, const char *path, const char *name,
 // ----------------------------------------------------------------------
 // __mrc_io_read_ref
 
-struct mrc_obj *
-__mrc_io_read_ref(struct mrc_io *io, struct mrc_obj *obj_parent, const char *name,
-		  struct mrc_class *class)
+struct mrc_obj* __mrc_io_read_ref(struct mrc_io* io, struct mrc_obj* obj_parent,
+                                  const char* name, struct mrc_class* class)
 {
-  char *s;
+  char* s;
   mrc_io_read_attr_string(io, mrc_io_obj_path(io, obj_parent), name, &s);
   if (!s) {
     return NULL;
   }
-  struct mrc_obj *obj = mrc_obj_read(io, s, class);
+  struct mrc_obj* obj = mrc_obj_read(io, s, class);
   free(s);
   return obj;
 }
@@ -659,16 +627,17 @@ __mrc_io_read_ref(struct mrc_io *io, struct mrc_obj *obj_parent, const char *nam
 // ----------------------------------------------------------------------
 // __mrc_io_read_ref_comm
 
-struct mrc_obj *
-__mrc_io_read_ref_comm(struct mrc_io *io, struct mrc_obj *obj_parent, const char *name,
-		       struct mrc_class *class, MPI_Comm comm)
+struct mrc_obj* __mrc_io_read_ref_comm(struct mrc_io* io,
+                                       struct mrc_obj* obj_parent,
+                                       const char* name,
+                                       struct mrc_class* class, MPI_Comm comm)
 {
-  char *s;
+  char* s;
   mrc_io_read_attr_string(io, mrc_io_obj_path(io, obj_parent), name, &s);
   if (!s) {
     return NULL;
   }
-  struct mrc_obj *obj = mrc_obj_read_comm(io, s, class, comm);
+  struct mrc_obj* obj = mrc_obj_read_comm(io, s, class, comm);
   free(s);
   return obj;
 }
@@ -676,9 +645,8 @@ __mrc_io_read_ref_comm(struct mrc_io *io, struct mrc_obj *obj_parent, const char
 // ----------------------------------------------------------------------
 // __mrc_io_write_path
 
-void
-__mrc_io_write_path(struct mrc_io *io, const char *path, const char *name,
-		    struct mrc_obj *obj)
+void __mrc_io_write_path(struct mrc_io* io, const char* path, const char* name,
+                         struct mrc_obj* obj)
 {
   mrc_obj_write(obj, io);
   mrc_io_write_attr_string(io, path, name, mrc_io_obj_path(io, obj));
@@ -687,25 +655,23 @@ __mrc_io_write_path(struct mrc_io *io, const char *path, const char *name,
 // ----------------------------------------------------------------------
 // __mrc_io_write_ref
 
-void
-__mrc_io_write_ref(struct mrc_io *io, struct mrc_obj *obj_parent, const char *name,
-		   struct mrc_obj *obj)
+void __mrc_io_write_ref(struct mrc_io* io, struct mrc_obj* obj_parent,
+                        const char* name, struct mrc_obj* obj)
 {
   if (obj) {
     mrc_obj_write(obj, io);
     mrc_io_write_attr_string(io, mrc_io_obj_path(io, obj_parent), name,
-			     mrc_io_obj_path(io, obj));
+                             mrc_io_obj_path(io, obj));
   } else {
     mrc_io_write_attr_string(io, mrc_io_obj_path(io, obj_parent), name,
-			     "(NULL)");
+                             "(NULL)");
   }
 }
 
 // ======================================================================
 // mrc_io_init
 
-static void
-mrc_io_init()
+static void mrc_io_init()
 {
 #ifdef HAVE_HDF5
   mrc_class_register_subclass(&mrc_class_mrc_io, &mrc_io_xdmf_collective_ops);
@@ -726,26 +692,24 @@ mrc_io_init()
   // Deprecated / eternally broken io types (FIXME)
   // ====================
   // mrc_class_register_subclass(&mrc_class_mrc_io, &mrc_io_xdmf2_parallel_ops);
-
 }
 
 // ======================================================================
 // mrc_io class
 
-#define VAR(x) (void *)offsetof(struct mrc_io_params, x)
+#define VAR(x) (void*)offsetof(struct mrc_io_params, x)
 static struct param mrc_io_params_descr[] = {
-  { "outdir"          , VAR(outdir)       , PARAM_STRING(".")      },
-  { "basename"        , VAR(basename)     , PARAM_STRING("run")    },
+  {"outdir", VAR(outdir), PARAM_STRING(".")},
+  {"basename", VAR(basename), PARAM_STRING("run")},
   {},
 };
 #undef VAR
 
 struct mrc_class_mrc_io mrc_class_mrc_io = {
-  .name         = "mrc_io",
-  .size         = sizeof(struct mrc_io),
-  .param_descr  = mrc_io_params_descr,
+  .name = "mrc_io",
+  .size = sizeof(struct mrc_io),
+  .param_descr = mrc_io_params_descr,
   .param_offset = offsetof(struct mrc_io, par),
-  .init         = mrc_io_init,
-  .setup        = _mrc_io_setup,
+  .init = mrc_io_init,
+  .setup = _mrc_io_setup,
 };
-

--- a/src/libmrc/src/mrc_io_asc.c
+++ b/src/libmrc/src/mrc_io_asc.c
@@ -10,44 +10,42 @@
 // ----------------------------------------------------------------------
 // diag server ascii
 
-struct mrc_io_ascii {
-  FILE *file;
+struct mrc_io_ascii
+{
+  FILE* file;
 };
 
-#define to_mrc_io_ascii(io) ((struct mrc_io_ascii *)io->obj.subctx)
+#define to_mrc_io_ascii(io) ((struct mrc_io_ascii*)io->obj.subctx)
 
-static void
-ds_ascii_open(struct mrc_io *io, const char *mode) 
+static void ds_ascii_open(struct mrc_io* io, const char* mode)
 {
   assert(strcmp(mode, "w") == 0); // only writing supported
 
-  struct mrc_io_ascii *ascii = to_mrc_io_ascii(io);
-  char *filename = diagc_make_filename(io, ".asc");
+  struct mrc_io_ascii* ascii = to_mrc_io_ascii(io);
+  char* filename = diagc_make_filename(io, ".asc");
   ascii->file = fopen(filename, mode);
   free(filename);
 }
 
-static void
-ds_ascii_close(struct mrc_io *io)
+static void ds_ascii_close(struct mrc_io* io)
 {
-  struct mrc_io_ascii *ascii = to_mrc_io_ascii(io);
+  struct mrc_io_ascii* ascii = to_mrc_io_ascii(io);
   fclose(ascii->file);
   ascii->file = NULL;
 }
 
-static void
-ds_ascii_write_field(struct mrc_io *io, const char *path,
-		     float scale, struct mrc_fld *fld, int m)
+static void ds_ascii_write_field(struct mrc_io* io, const char* path,
+                                 float scale, struct mrc_fld* fld, int m)
 {
-  struct mrc_io_ascii *ascii = to_mrc_io_ascii(io);
-  FILE *file = ascii->file;
+  struct mrc_io_ascii* ascii = to_mrc_io_ascii(io);
+  FILE* file = ascii->file;
   fprintf(file, "# %s\n", mrc_fld_comp_name(fld, m));
 
-  const int *dims = mrc_fld_dims(fld);
+  const int* dims = mrc_fld_dims(fld);
   for (int iz = 0; iz < dims[2]; iz++) {
     for (int iy = 0; iy < dims[1]; iy++) {
       for (int ix = 0; ix < dims[0]; ix++) {
-	fprintf(file, "%d %d %d %g\n", ix, iy, iz, MRC_F3(fld,m, ix,iy,iz));
+        fprintf(file, "%d %d %d %g\n", ix, iy, iz, MRC_F3(fld, m, ix, iy, iz));
       }
       fprintf(file, "\n");
     }
@@ -55,71 +53,64 @@ ds_ascii_write_field(struct mrc_io *io, const char *path,
   }
 }
 
-static void
-ds_ascii_write_m3(struct mrc_io *io, const char *path, struct mrc_fld *m3)
+static void ds_ascii_write_m3(struct mrc_io* io, const char* path,
+                              struct mrc_fld* m3)
 {
-  struct mrc_io_ascii *ascii = to_mrc_io_ascii(io);
-  
-  struct mrc_io_params *par = &io->par;
+  struct mrc_io_ascii* ascii = to_mrc_io_ascii(io);
+
+  struct mrc_io_params* par = &io->par;
 
   for (int p = 0; p < mrc_fld_nr_patches(m3); p++) {
     char filename[strlen(par->outdir) + strlen(par->basename) + 30];
     sprintf(filename, "%s/%s.%06d_p%06d_%s.asc", par->outdir, par->basename,
-	    io->step, p, mrc_fld_name(m3));
+            io->step, p, mrc_fld_name(m3));
     fprintf(ascii->file, "# see %s\n", filename);
-    FILE *file = fopen(filename, "w");
+    FILE* file = fopen(filename, "w");
     fprintf(file, "# ix iy iz");
     for (int m = 0; m < mrc_fld_nr_comps(m3); m++) {
       fprintf(file, " %s", mrc_fld_comp_name(m3, m));
     }
     fprintf(file, "\n");
 
-    struct mrc_fld_patch *m3p = mrc_fld_patch_get(m3, p);
-    mrc_m3_foreach(m3p, ix,iy,iz, 0,0) {
+    struct mrc_fld_patch* m3p = mrc_fld_patch_get(m3, p);
+    mrc_m3_foreach(m3p, ix, iy, iz, 0, 0)
+    {
       fprintf(file, "%d %d %d", ix, iy, iz);
       for (int m = 0; m < mrc_fld_nr_comps(m3); m++) {
-	fprintf(file, " %g", MRC_M3(m3p, m, ix,iy,iz));
+        fprintf(file, " %g", MRC_M3(m3p, m, ix, iy, iz));
       }
       fprintf(file, "\n");
-    } mrc_m3_foreach_end;
+    }
+    mrc_m3_foreach_end;
 
     fclose(file);
   }
 }
 
-static void
-ds_ascii_write_attr(struct mrc_io *io, const char *path, int type,
-		    const char *name, union param_u *pv)
+static void ds_ascii_write_attr(struct mrc_io* io, const char* path, int type,
+                                const char* name, union param_u* pv)
 {
-  struct mrc_io_ascii *ascii = to_mrc_io_ascii(io);
-  FILE *file = ascii->file;
+  struct mrc_io_ascii* ascii = to_mrc_io_ascii(io);
+  FILE* file = ascii->file;
 
   switch (type) {
-  case PT_INT:
-  case PT_SELECT:
-    fprintf(file, "# %-20s| %d\n", name, pv->u_int);
-    break;
-  case PT_BOOL:
-    fprintf(file, "# %-20s| %s\n", name, pv->u_bool ? "yes" : "no");
-    break;
-  case PT_FLOAT:
-    fprintf(file, "# %-20s| %g\n", name, pv->u_float);
-    break;
-  case PT_DOUBLE:
-    fprintf(file, "# %-20s| %g\n", name, pv->u_double);
-    break;
-  case PT_STRING:
-    fprintf(file, "# %-20s| %s\n", name, pv->u_string);
-    break;
+    case PT_INT:
+    case PT_SELECT: fprintf(file, "# %-20s| %d\n", name, pv->u_int); break;
+    case PT_BOOL:
+      fprintf(file, "# %-20s| %s\n", name, pv->u_bool ? "yes" : "no");
+      break;
+    case PT_FLOAT: fprintf(file, "# %-20s| %g\n", name, pv->u_float); break;
+    case PT_DOUBLE: fprintf(file, "# %-20s| %g\n", name, pv->u_double); break;
+    case PT_STRING: fprintf(file, "# %-20s| %s\n", name, pv->u_string); break;
   }
 }
 
 struct mrc_io_ops mrc_io_ascii_ops = {
-  .name        = "ascii",
-  .size        = sizeof(struct mrc_io_ascii),
-  .open        = ds_ascii_open,
-  .close       = ds_ascii_close,
+  .name = "ascii",
+  .size = sizeof(struct mrc_io_ascii),
+  .open = ds_ascii_open,
+  .close = ds_ascii_close,
   .write_field = ds_ascii_write_field,
-  .write_m3    = ds_ascii_write_m3,
-  .write_attr  = ds_ascii_write_attr,
+  .write_m3 = ds_ascii_write_m3,
+  .write_attr = ds_ascii_write_attr,
 };

--- a/src/libmrc/src/mrc_io_hdf5_parallel.c
+++ b/src/libmrc/src/mrc_io_hdf5_parallel.c
@@ -275,7 +275,7 @@ static void hdf5_parallel_open(struct mrc_io* io, const char* mode)
   // FIXME: There may be some future speed improvement on lustre if we use
   // a real mpi_info here and set romio_[cb/ds]_write bits
 
-  char filename[strlen(io->par.outdir) + strlen(io->par.basename) + 20];
+  char filename[strlen(io->par.outdir) + strlen(io->par.basename) + 30];
   // using '.' as a separator causes all sorts of problems with io/analysis in
   // mrc-v3, but I don't want to break compatibility with the other io types
   sprintf(filename, "%s/%s%s%06d.h5", io->par.outdir, io->par.basename,

--- a/src/libmrc/src/mrc_io_srv.c
+++ b/src/libmrc/src/mrc_io_srv.c
@@ -13,7 +13,8 @@
 // scaling for serial output
 // vector/scalar
 
-enum {
+enum
+{
   ID_DIAGS = 14000,
   ID_DIAGS_CMD,
   ID_DIAGS_CREATE_OUTDIR,
@@ -35,7 +36,8 @@ enum {
   ID_DIAGS_CMD_RESPONSE,
 };
 
-enum {
+enum
+{
   DIAG_CMD_CREATE,
   DIAG_CMD_OPENFILE,
   DIAG_CMD_SHUTDOWN,
@@ -45,14 +47,15 @@ enum {
 // ======================================================================
 // diag client interface
 
-struct diagc_combined_params {
+struct diagc_combined_params
+{
   int rank_diagsrv;
 };
 
-#define VAR(x) (void *)offsetof(struct diagc_combined_params, x)
+#define VAR(x) (void*)offsetof(struct diagc_combined_params, x)
 
 static struct param diagc_combined_params_descr[] = {
-  { "rank_diagsrv"        , VAR(rank_diagsrv)      , PARAM_INT(0)       },
+  {"rank_diagsrv", VAR(rank_diagsrv), PARAM_INT(0)},
   {},
 };
 
@@ -63,17 +66,17 @@ static struct param diagc_combined_params_descr[] = {
 //
 // called once before first open, will do handshake with server
 
-static void
-diagc_combined_send_domain_info(struct mrc_io *io, struct mrc_domain *domain)
+static void diagc_combined_send_domain_info(struct mrc_io* io,
+                                            struct mrc_domain* domain)
 {
   if (io->diagc_domain_info_sent)
     return;
 
-  struct diagc_combined_params *par = io->obj.subctx;
+  struct diagc_combined_params* par = io->obj.subctx;
 
   int iw[9], *off = iw, *ldims = iw + 3, *gdims = iw + 6;
   int nr_patches;
-  struct mrc_patch *patches = mrc_domain_get_patches(domain, &nr_patches);
+  struct mrc_patch* patches = mrc_domain_get_patches(domain, &nr_patches);
   assert(nr_patches == 1);
   for (int d = 0; d < 3; d++) {
     off[d] = patches[0].off[d];
@@ -81,33 +84,34 @@ diagc_combined_send_domain_info(struct mrc_io *io, struct mrc_domain *domain)
   }
   mrc_domain_get_global_dims(domain, gdims);
   if (io->rank == 0) {
-    MPI_Send(iw, 0, MPI_CHAR, par->rank_diagsrv, ID_DIAGS_CMD_CREATE, MPI_COMM_WORLD);
+    MPI_Send(iw, 0, MPI_CHAR, par->rank_diagsrv, ID_DIAGS_CMD_CREATE,
+             MPI_COMM_WORLD);
   }
-  MPI_Send(iw, 9, MPI_INT, par->rank_diagsrv, ID_DIAGS_CMD_DOMAIN_INFO, MPI_COMM_WORLD);
+  MPI_Send(iw, 9, MPI_INT, par->rank_diagsrv, ID_DIAGS_CMD_DOMAIN_INFO,
+           MPI_COMM_WORLD);
 
-  struct mrc_crds *crds = mrc_domain_get_crds(domain);
+  struct mrc_crds* crds = mrc_domain_get_crds(domain);
   for (int d = 0; d < 3; d++) {
     MPI_Send(&MRC_CRD(crds, d, 0), ldims[d], MPI_FLOAT, par->rank_diagsrv,
-	     ID_DIAGS_CMD_CRDX + d, MPI_COMM_WORLD);
+             ID_DIAGS_CMD_CRDX + d, MPI_COMM_WORLD);
   }
 
   io->diagc_domain_info_sent = true;
 }
 
-static void
-diagc_combined_setup(struct mrc_io *io)
+static void diagc_combined_setup(struct mrc_io* io)
 {
-  struct mrc_io_params *par_io = &io->par;
-  struct diagc_combined_params *par = io->obj.subctx;
+  struct mrc_io_params* par_io = &io->par;
+  struct diagc_combined_params* par = io->obj.subctx;
 
   mrc_io_setup_super(io);
   if (io->rank == 0) {
-    int icmd[1] = { DIAG_CMD_CREATE };
+    int icmd[1] = {DIAG_CMD_CREATE};
     MPI_Send(icmd, 1, MPI_INT, par->rank_diagsrv, ID_DIAGS_CMD, MPI_COMM_WORLD);
-    MPI_Send(par_io->outdir, strlen(par_io->outdir) + 1, MPI_CHAR, par->rank_diagsrv,
-	     ID_DIAGS_CREATE_OUTDIR, MPI_COMM_WORLD);
-    MPI_Send(par_io->basename, strlen(par_io->basename) + 1, MPI_CHAR, par->rank_diagsrv,
-	     ID_DIAGS_CREATE_BASENAME, MPI_COMM_WORLD);
+    MPI_Send(par_io->outdir, strlen(par_io->outdir) + 1, MPI_CHAR,
+             par->rank_diagsrv, ID_DIAGS_CREATE_OUTDIR, MPI_COMM_WORLD);
+    MPI_Send(par_io->basename, strlen(par_io->basename) + 1, MPI_CHAR,
+             par->rank_diagsrv, ID_DIAGS_CREATE_BASENAME, MPI_COMM_WORLD);
   }
 }
 
@@ -118,33 +122,34 @@ diagc_combined_setup(struct mrc_io *io)
 // afterwards, diag_write_field() may be called repeatedly and
 // must be concluded with a call to diag_close()
 
-static void
-diagc_combined_open(struct mrc_io *io, const char *mode)
+static void diagc_combined_open(struct mrc_io* io, const char* mode)
 {
-  struct diagc_combined_params *par = io->obj.subctx;
+  struct diagc_combined_params* par = io->obj.subctx;
   assert(strcmp(mode, "w") == 0); // only writing supported for now
 
   if (io->rank == 0) {
-    int icmd[2] = { DIAG_CMD_OPENFILE, io->step };
+    int icmd[2] = {DIAG_CMD_OPENFILE, io->step};
 
-    MPI_Send(icmd, 2, MPI_INT, par->rank_diagsrv, ID_DIAGS_CMD_OPEN, MPI_COMM_WORLD);
+    MPI_Send(icmd, 2, MPI_INT, par->rank_diagsrv, ID_DIAGS_CMD_OPEN,
+             MPI_COMM_WORLD);
     MPI_Send(io->par.basename, strlen(io->par.basename) + 1, MPI_CHAR,
-	     par->rank_diagsrv, ID_DIAGS_BASENAME, MPI_COMM_WORLD);
-    MPI_Send(&io->time, 1, MPI_FLOAT, par->rank_diagsrv, ID_DIAGS_TIME, MPI_COMM_WORLD);
+             par->rank_diagsrv, ID_DIAGS_BASENAME, MPI_COMM_WORLD);
+    MPI_Send(&io->time, 1, MPI_FLOAT, par->rank_diagsrv, ID_DIAGS_TIME,
+             MPI_COMM_WORLD);
   }
 }
 
 // ----------------------------------------------------------------------
 // diagc_combined_close
 
-static void
-diagc_combined_close(struct mrc_io *io)
+static void diagc_combined_close(struct mrc_io* io)
 {
-  struct diagc_combined_params *par = io->obj.subctx;
+  struct diagc_combined_params* par = io->obj.subctx;
 
   if (io->rank == 0) {
     char str[] = "";
-    MPI_Send(str, 1, MPI_CHAR, par->rank_diagsrv, ID_DIAGS_FLDNAME, MPI_COMM_WORLD);
+    MPI_Send(str, 1, MPI_CHAR, par->rank_diagsrv, ID_DIAGS_FLDNAME,
+             MPI_COMM_WORLD);
   }
 }
 
@@ -153,14 +158,13 @@ diagc_combined_close(struct mrc_io *io)
 //
 // shuts down the diag server process
 
-static void
-diagc_combined_destroy(struct mrc_io *io)
+static void diagc_combined_destroy(struct mrc_io* io)
 {
   static int pr_diag_shutdown = 0;
   int comm_world_rank = 0;
   int wait_for_response, icmd[2];
 
-  struct diagc_combined_params *par = io->obj.subctx;
+  struct diagc_combined_params* par = io->obj.subctx;
 
   MPI_Comm_rank(MPI_COMM_WORLD, &comm_world_rank);
   if (mrc_io_is_setup(io) && comm_world_rank == 0) {
@@ -168,12 +172,12 @@ diagc_combined_destroy(struct mrc_io *io)
   } else {
     wait_for_response = 0;
   }
-  
+
   icmd[0] = DIAG_CMD_SHUTDOWN;
   icmd[1] = wait_for_response;
   MPI_Send(icmd, 2, MPI_INT, par->rank_diagsrv, ID_DIAGS_CMD, MPI_COMM_WORLD);
 
-  if (0&&wait_for_response) {
+  if (0 && wait_for_response) {
     int response = 0;
     if (pr_diag_shutdown == 0) {
       pr_diag_shutdown = prof_register("diagc_combined_shutdown", 0, 0, 0);
@@ -189,40 +193,41 @@ diagc_combined_destroy(struct mrc_io *io)
 // ----------------------------------------------------------------------
 // diagc_combined_write_field
 
-static void
-copy_and_scale(float *buf, struct mrc_fld *fld, int m, float scale)
+static void copy_and_scale(float* buf, struct mrc_fld* fld, int m, float scale)
 {
-  struct mrc_fld *f = mrc_fld_get_as(fld, "float");
+  struct mrc_fld* f = mrc_fld_get_as(fld, "float");
   int i = 0;
-  mrc_fld_foreach(f, ix,iy,iz, 0, 0) {
-    buf[i++] = scale * MRC_F3(f, m, ix,iy,iz);
-  } mrc_fld_foreach_end;
+  mrc_fld_foreach(f, ix, iy, iz, 0, 0)
+  {
+    buf[i++] = scale * MRC_F3(f, m, ix, iy, iz);
+  }
+  mrc_fld_foreach_end;
   mrc_fld_put_as(f, fld);
 }
 
-static void
-diagc_combined_write_field(struct mrc_io *io, const char *path,
-			   float scale, struct mrc_fld *fld, int m)
+static void diagc_combined_write_field(struct mrc_io* io, const char* path,
+                                       float scale, struct mrc_fld* fld, int m)
 {
-  struct diagc_combined_params *par = io->obj.subctx;
+  struct diagc_combined_params* par = io->obj.subctx;
 
   diagc_combined_send_domain_info(io, fld->_domain);
 
   int nr_patches;
-  struct mrc_patch *patches = mrc_domain_get_patches(fld->_domain, &nr_patches);
+  struct mrc_patch* patches = mrc_domain_get_patches(fld->_domain, &nr_patches);
   assert(nr_patches == 1);
-  int *ldims = patches[0].ldims;
+  int* ldims = patches[0].ldims;
   int nout = ldims[0] * ldims[1] * ldims[2];
-  float *buf = calloc(sizeof(float), nout);
+  float* buf = calloc(sizeof(float), nout);
 
   if (io->rank == 0) {
-    MPI_Send((char *)mrc_fld_name(fld), strlen(mrc_fld_name(fld)) + 1,
-	     MPI_CHAR, par->rank_diagsrv, ID_DIAGS_FLDNAME, MPI_COMM_WORLD);
-    MPI_Send((char *)mrc_fld_comp_name(fld, m), strlen(mrc_fld_comp_name(fld, m)) + 1,
-	     MPI_CHAR, par->rank_diagsrv, ID_DIAGS_FLDNAME, MPI_COMM_WORLD);
+    MPI_Send((char*)mrc_fld_name(fld), strlen(mrc_fld_name(fld)) + 1, MPI_CHAR,
+             par->rank_diagsrv, ID_DIAGS_FLDNAME, MPI_COMM_WORLD);
+    MPI_Send((char*)mrc_fld_comp_name(fld, m),
+             strlen(mrc_fld_comp_name(fld, m)) + 1, MPI_CHAR, par->rank_diagsrv,
+             ID_DIAGS_FLDNAME, MPI_COMM_WORLD);
     int outtype = DIAG_TYPE_3D;
-    MPI_Send(&outtype, 1, MPI_INT, par->rank_diagsrv,
-	     ID_DIAGS_CMD_WRITE, MPI_COMM_WORLD);
+    MPI_Send(&outtype, 1, MPI_INT, par->rank_diagsrv, ID_DIAGS_CMD_WRITE,
+             MPI_COMM_WORLD);
   }
 
   copy_and_scale(buf, fld, m, scale);
@@ -233,14 +238,16 @@ diagc_combined_write_field(struct mrc_io *io, const char *path,
     dims[d] = patches[0].ldims[d];
   }
 
-  MPI_Send(iw, 6, MPI_INT, par->rank_diagsrv, ID_DIAGS_SUBDOMAIN, MPI_COMM_WORLD);
-  MPI_Send(buf, nout, MPI_FLOAT, par->rank_diagsrv, ID_DIAGS_DATA, MPI_COMM_WORLD);
+  MPI_Send(iw, 6, MPI_INT, par->rank_diagsrv, ID_DIAGS_SUBDOMAIN,
+           MPI_COMM_WORLD);
+  MPI_Send(buf, nout, MPI_FLOAT, par->rank_diagsrv, ID_DIAGS_DATA,
+           MPI_COMM_WORLD);
 
   free(buf);
 }
 
-static void
-diagc_combined_write_m3(struct mrc_io *io, const char *path, struct mrc_fld *fld)
+static void diagc_combined_write_m3(struct mrc_io* io, const char* path,
+                                    struct mrc_fld* fld)
 {
   int nr_comps = mrc_fld_nr_comps(fld);
   for (int m = 0; m < nr_comps; m++) {
@@ -249,11 +256,11 @@ diagc_combined_write_m3(struct mrc_io *io, const char *path, struct mrc_fld *fld
   }
 }
 
-static void
-diagc_combined_write_field2d(struct mrc_io *io, float scale, struct mrc_fld *fld,
-			     int outtype, float sheet)
+static void diagc_combined_write_field2d(struct mrc_io* io, float scale,
+                                         struct mrc_fld* fld, int outtype,
+                                         float sheet)
 {
-  struct diagc_combined_params *par = io->obj.subctx;
+  struct diagc_combined_params* par = io->obj.subctx;
 
   diagc_combined_send_domain_info(io, fld->_domain);
 
@@ -262,20 +269,24 @@ diagc_combined_write_field2d(struct mrc_io *io, float scale, struct mrc_fld *fld
 
   if (io->rank == 0) {
     MPI_Send("mrc_f2", strlen("mrc_f2") + 1, MPI_CHAR, par->rank_diagsrv,
-	     ID_DIAGS_FLDNAME, MPI_COMM_WORLD);
-    MPI_Send((char *) mrc_fld_comp_name(fld, 0), strlen(mrc_fld_comp_name(fld, 0)) + 1,
-	     MPI_CHAR, par->rank_diagsrv, ID_DIAGS_FLDNAME, MPI_COMM_WORLD);
-    MPI_Send(&outtype, 1, MPI_INT, par->rank_diagsrv,
-	     ID_DIAGS_CMD_WRITE, MPI_COMM_WORLD);
-    MPI_Send(&sheet, 1, MPI_FLOAT, par->rank_diagsrv,
-	     ID_DIAGS_CMD_WRITE, MPI_COMM_WORLD);
+             ID_DIAGS_FLDNAME, MPI_COMM_WORLD);
+    MPI_Send((char*)mrc_fld_comp_name(fld, 0),
+             strlen(mrc_fld_comp_name(fld, 0)) + 1, MPI_CHAR, par->rank_diagsrv,
+             ID_DIAGS_FLDNAME, MPI_COMM_WORLD);
+    MPI_Send(&outtype, 1, MPI_INT, par->rank_diagsrv, ID_DIAGS_CMD_WRITE,
+             MPI_COMM_WORLD);
+    MPI_Send(&sheet, 1, MPI_FLOAT, par->rank_diagsrv, ID_DIAGS_CMD_WRITE,
+             MPI_COMM_WORLD);
   }
 
-  int iw[6] = { -1, };
-  if (mrc_fld_len(fld)) { // part of the slice?
+  int iw[6] = {
+    -1,
+  };
+  if (mrc_fld_len(fld)) {          // part of the slice?
     int *off = iw, *dims = iw + 3; // off, then dims
     int nr_patches;
-    struct mrc_patch *patches = mrc_domain_get_patches(fld->_domain, &nr_patches);
+    struct mrc_patch* patches =
+      mrc_domain_get_patches(fld->_domain, &nr_patches);
     assert(nr_patches == 1);
     for (int d = 0; d < 3; d++) {
       off[d] = patches[0].off[d];
@@ -284,87 +295,88 @@ diagc_combined_write_field2d(struct mrc_io *io, float scale, struct mrc_fld *fld
     off[dim] = 0;
     dims[dim] = 1;
 
-    MPI_Send(iw, 6, MPI_INT, par->rank_diagsrv, ID_DIAGS_SUBDOMAIN, MPI_COMM_WORLD);
-    struct mrc_fld *f = mrc_fld_get_as(fld, "float");
-    MPI_Send(fld->_nd->arr, mrc_fld_len(fld), MPI_FLOAT, par->rank_diagsrv, ID_DIAGS_2DDATA, MPI_COMM_WORLD);
+    MPI_Send(iw, 6, MPI_INT, par->rank_diagsrv, ID_DIAGS_SUBDOMAIN,
+             MPI_COMM_WORLD);
+    struct mrc_fld* f = mrc_fld_get_as(fld, "float");
+    MPI_Send(fld->_nd->arr, mrc_fld_len(fld), MPI_FLOAT, par->rank_diagsrv,
+             ID_DIAGS_2DDATA, MPI_COMM_WORLD);
     mrc_fld_put_as(f, fld);
   } else {
-    MPI_Send(iw, 6, MPI_INT, par->rank_diagsrv, ID_DIAGS_SUBDOMAIN, MPI_COMM_WORLD);
+    MPI_Send(iw, 6, MPI_INT, par->rank_diagsrv, ID_DIAGS_SUBDOMAIN,
+             MPI_COMM_WORLD);
   }
 }
 
-static void
-diagc_combined_write_attr(struct mrc_io *io, const char *path, int type,
-			  const char *name, union param_u *pv)
+static void diagc_combined_write_attr(struct mrc_io* io, const char* path,
+                                      int type, const char* name,
+                                      union param_u* pv)
 {
-  struct diagc_combined_params *par = io->obj.subctx;
+  struct diagc_combined_params* par = io->obj.subctx;
 
   if (io->rank == 0) {
-    MPI_Send((char *)path, strlen(path) + 1, MPI_CHAR, par->rank_diagsrv,
-	     ID_DIAGS_CMD_WRITE_ATTR, MPI_COMM_WORLD);
-    MPI_Send(&type, 1, MPI_INT, par->rank_diagsrv,
-	     ID_DIAGS_CMD_WRITE_ATTR, MPI_COMM_WORLD);
-    MPI_Send((char *)name, strlen(name) + 1, MPI_CHAR, par->rank_diagsrv,
-	     ID_DIAGS_CMD_WRITE_ATTR, MPI_COMM_WORLD);
+    MPI_Send((char*)path, strlen(path) + 1, MPI_CHAR, par->rank_diagsrv,
+             ID_DIAGS_CMD_WRITE_ATTR, MPI_COMM_WORLD);
+    MPI_Send(&type, 1, MPI_INT, par->rank_diagsrv, ID_DIAGS_CMD_WRITE_ATTR,
+             MPI_COMM_WORLD);
+    MPI_Send((char*)name, strlen(name) + 1, MPI_CHAR, par->rank_diagsrv,
+             ID_DIAGS_CMD_WRITE_ATTR, MPI_COMM_WORLD);
     switch (type) {
-    case PT_BOOL:
-    case PT_INT:
-    case PT_SELECT:
-    case MRC_VAR_INT:
-    case MRC_VAR_BOOL:
-      MPI_Send(&pv->u_int, 1, MPI_INT, par->rank_diagsrv,
-	       ID_DIAGS_CMD_WRITE_ATTR, MPI_COMM_WORLD);
-      break;
-    case PT_FLOAT:
-      MPI_Send(&pv->u_float, 1, MPI_FLOAT, par->rank_diagsrv,
-	       ID_DIAGS_CMD_WRITE_ATTR, MPI_COMM_WORLD);
-      break;
-    case PT_DOUBLE:
-    case MRC_VAR_DOUBLE:
-      MPI_Send(&pv->u_double, 1, MPI_DOUBLE, par->rank_diagsrv,
-         ID_DIAGS_CMD_WRITE_ATTR, MPI_COMM_WORLD);
-      break;
-    case PT_STRING:
-      MPI_Send((char *)pv->u_string, strlen(pv->u_string) + 1, MPI_CHAR, par->rank_diagsrv,
-	       ID_DIAGS_CMD_WRITE_ATTR, MPI_COMM_WORLD);
-      break;
-    case PT_INT3:
-      MPI_Send(pv->u_int3, 3, MPI_INT, par->rank_diagsrv,
-	       ID_DIAGS_CMD_WRITE_ATTR, MPI_COMM_WORLD);
-      break;
-    case PT_FLOAT3:
-      MPI_Send(pv->u_float3, 3, MPI_FLOAT, par->rank_diagsrv,
-	       ID_DIAGS_CMD_WRITE_ATTR, MPI_COMM_WORLD);
-      break;
-    case PT_DOUBLE3:
-    case MRC_VAR_DOUBLE3:
-      MPI_Send(pv->u_double3, 3, MPI_DOUBLE, par->rank_diagsrv,
-	       ID_DIAGS_CMD_WRITE_ATTR, MPI_COMM_WORLD);
-      break;
-    case PT_INT_ARRAY:
-      MPI_Send(&pv->u_int_array.nr_vals, 1, MPI_INT, par->rank_diagsrv,
-	       ID_DIAGS_CMD_WRITE_ATTR, MPI_COMM_WORLD);
-      MPI_Send(pv->u_int_array.vals, pv->u_int_array.nr_vals, MPI_INT, par->rank_diagsrv,
-	       ID_DIAGS_CMD_WRITE_ATTR, MPI_COMM_WORLD);
-      break;
-    default:
-      mprintf("type %d\n", type);
-      assert(0);
+      case PT_BOOL:
+      case PT_INT:
+      case PT_SELECT:
+      case MRC_VAR_INT:
+      case MRC_VAR_BOOL:
+        MPI_Send(&pv->u_int, 1, MPI_INT, par->rank_diagsrv,
+                 ID_DIAGS_CMD_WRITE_ATTR, MPI_COMM_WORLD);
+        break;
+      case PT_FLOAT:
+        MPI_Send(&pv->u_float, 1, MPI_FLOAT, par->rank_diagsrv,
+                 ID_DIAGS_CMD_WRITE_ATTR, MPI_COMM_WORLD);
+        break;
+      case PT_DOUBLE:
+      case MRC_VAR_DOUBLE:
+        MPI_Send(&pv->u_double, 1, MPI_DOUBLE, par->rank_diagsrv,
+                 ID_DIAGS_CMD_WRITE_ATTR, MPI_COMM_WORLD);
+        break;
+      case PT_STRING:
+        MPI_Send((char*)pv->u_string, strlen(pv->u_string) + 1, MPI_CHAR,
+                 par->rank_diagsrv, ID_DIAGS_CMD_WRITE_ATTR, MPI_COMM_WORLD);
+        break;
+      case PT_INT3:
+        MPI_Send(pv->u_int3, 3, MPI_INT, par->rank_diagsrv,
+                 ID_DIAGS_CMD_WRITE_ATTR, MPI_COMM_WORLD);
+        break;
+      case PT_FLOAT3:
+        MPI_Send(pv->u_float3, 3, MPI_FLOAT, par->rank_diagsrv,
+                 ID_DIAGS_CMD_WRITE_ATTR, MPI_COMM_WORLD);
+        break;
+      case PT_DOUBLE3:
+      case MRC_VAR_DOUBLE3:
+        MPI_Send(pv->u_double3, 3, MPI_DOUBLE, par->rank_diagsrv,
+                 ID_DIAGS_CMD_WRITE_ATTR, MPI_COMM_WORLD);
+        break;
+      case PT_INT_ARRAY:
+        MPI_Send(&pv->u_int_array.nr_vals, 1, MPI_INT, par->rank_diagsrv,
+                 ID_DIAGS_CMD_WRITE_ATTR, MPI_COMM_WORLD);
+        MPI_Send(pv->u_int_array.vals, pv->u_int_array.nr_vals, MPI_INT,
+                 par->rank_diagsrv, ID_DIAGS_CMD_WRITE_ATTR, MPI_COMM_WORLD);
+        break;
+      default: mprintf("type %d\n", type); assert(0);
     }
   }
 }
 
 struct mrc_io_ops mrc_io_combined_ops = {
-  .name          = "combined",
-  .size          = sizeof(struct diagc_combined_params),
-  .param_descr   = diagc_combined_params_descr,
-  .setup         = diagc_combined_setup,
-  .destroy       = diagc_combined_destroy,
-  .open          = diagc_combined_open,
-  .write_m3      = diagc_combined_write_m3,
+  .name = "combined",
+  .size = sizeof(struct diagc_combined_params),
+  .param_descr = diagc_combined_params_descr,
+  .setup = diagc_combined_setup,
+  .destroy = diagc_combined_destroy,
+  .open = diagc_combined_open,
+  .write_m3 = diagc_combined_write_m3,
   .write_field2d = diagc_combined_write_field2d,
-  .write_attr    = diagc_combined_write_attr,
-  .close         = diagc_combined_close,
+  .write_attr = diagc_combined_write_attr,
+  .close = diagc_combined_close,
 };
 
 // ======================================================================
@@ -378,48 +390,52 @@ struct mrc_io_ops mrc_io_combined_ops = {
 
 // ----------------------------------------------------------------------
 
-struct diagsrv_one {
+struct diagsrv_one
+{
   list_t mrc_io_list;
 
   // only valid from open() -> close()
-  struct mrc_io *io;
+  struct mrc_io* io;
 
-  struct diagsrv_srv_ops *srv_ops;
-  void *srv;
+  struct diagsrv_srv_ops* srv_ops;
+  void* srv;
 };
 
-struct diagsrv_srv_ops {
-  const char *name;
-  void  (*create)(struct diagsrv_one *ds);
-  void  (*set_domain)(struct diagsrv_one *ds, struct mrc_domain *domain);
-  void  (*destroy)(struct diagsrv_one *ds);
-  void  (*open)(struct diagsrv_one *ds, int step, float time);
-  struct mrc_fld *(*get_gfld_2d)(struct diagsrv_one *ds, int dims[2]);
-  struct mrc_fld *(*get_gfld_3d)(struct diagsrv_one *ds, int dims[3]);
-  void  (*put_gfld_2d)(struct diagsrv_one *ds, struct mrc_fld *fld, char *fld_name,
-		       int outtype, float sheet);
-  void  (*put_gfld_3d)(struct diagsrv_one *ds, struct mrc_fld *fld);
-  void  (*write_attr)(struct diagsrv_one *ds, const char *path, int type,
-		      const char *name, union param_u *pv);
-  void  (*close)(struct diagsrv_one *ds);
+struct diagsrv_srv_ops
+{
+  const char* name;
+  void (*create)(struct diagsrv_one* ds);
+  void (*set_domain)(struct diagsrv_one* ds, struct mrc_domain* domain);
+  void (*destroy)(struct diagsrv_one* ds);
+  void (*open)(struct diagsrv_one* ds, int step, float time);
+  struct mrc_fld* (*get_gfld_2d)(struct diagsrv_one* ds, int dims[2]);
+  struct mrc_fld* (*get_gfld_3d)(struct diagsrv_one* ds, int dims[3]);
+  void (*put_gfld_2d)(struct diagsrv_one* ds, struct mrc_fld* fld,
+                      char* fld_name, int outtype, float sheet);
+  void (*put_gfld_3d)(struct diagsrv_one* ds, struct mrc_fld* fld);
+  void (*write_attr)(struct diagsrv_one* ds, const char* path, int type,
+                     const char* name, union param_u* pv);
+  void (*close)(struct diagsrv_one* ds);
 };
 
 // ----------------------------------------------------------------------
 
-struct mrc_io_entry {
-  struct mrc_io *io;
-  struct mrc_domain *domain;
+struct mrc_io_entry
+{
+  struct mrc_io* io;
+  struct mrc_domain* domain;
   int ldims[3];
 
-  char *basename;
+  char* basename;
   list_t entry;
 };
 
-static struct mrc_io_entry *
-find_diagsrv_io(struct diagsrv_one *ds, const char *basename)
+static struct mrc_io_entry* find_diagsrv_io(struct diagsrv_one* ds,
+                                            const char* basename)
 {
-  struct mrc_io_entry *p;
-  __list_for_each_entry(p, &ds->mrc_io_list, entry, struct mrc_io_entry) {
+  struct mrc_io_entry* p;
+  __list_for_each_entry(p, &ds->mrc_io_list, entry, struct mrc_io_entry)
+  {
     if (strcmp(p->basename, basename) == 0) {
       return p;
     }
@@ -427,11 +443,10 @@ find_diagsrv_io(struct diagsrv_one *ds, const char *basename)
   return NULL;
 }
 
-static void
-create_diagsrv_io(struct diagsrv_one *ds,
-		  const char *format, const char *outdir, const char *basename)
+static void create_diagsrv_io(struct diagsrv_one* ds, const char* format,
+                              const char* outdir, const char* basename)
 {
-  struct mrc_io_entry *p = calloc(1, sizeof(*p));
+  struct mrc_io_entry* p = calloc(1, sizeof(*p));
   p->io = mrc_io_create(MPI_COMM_SELF);
   mrc_io_set_type(p->io, format);
   mrc_io_set_param_string(p->io, "outdir", outdir);
@@ -446,22 +461,21 @@ create_diagsrv_io(struct diagsrv_one *ds,
 // ----------------------------------------------------------------------
 // diagsrv_one
 
-struct diagsrv_srv {
-  float *gfld;
-  struct mrc_domain *domain;
+struct diagsrv_srv
+{
+  float* gfld;
+  struct mrc_domain* domain;
 };
 
-static void
-ds_srv_create(struct diagsrv_one *ds)
+static void ds_srv_create(struct diagsrv_one* ds)
 {
-  struct diagsrv_srv *srv = malloc(sizeof(*srv));
+  struct diagsrv_srv* srv = malloc(sizeof(*srv));
   ds->srv = srv;
 }
 
-static void
-ds_srv_set_domain(struct diagsrv_one *ds, struct mrc_domain *domain)
+static void ds_srv_set_domain(struct diagsrv_one* ds, struct mrc_domain* domain)
 {
-  struct diagsrv_srv *srv = ds->srv;
+  struct diagsrv_srv* srv = ds->srv;
   srv->domain = domain;
   int gdims[3];
   mrc_domain_get_global_dims(domain, gdims);
@@ -469,83 +483,75 @@ ds_srv_set_domain(struct diagsrv_one *ds, struct mrc_domain *domain)
   srv->gfld = malloc(nglobal * sizeof(float));
 }
 
-static void
-ds_srv_destroy(struct diagsrv_one *ds)
+static void ds_srv_destroy(struct diagsrv_one* ds)
 {
-  struct diagsrv_srv *srv = (struct diagsrv_srv *) ds->srv;
+  struct diagsrv_srv* srv = (struct diagsrv_srv*)ds->srv;
   free(srv->gfld);
   free(srv);
 }
 
-static void
-ds_srv_open(struct diagsrv_one *ds, int step, float time)
+static void ds_srv_open(struct diagsrv_one* ds, int step, float time)
 {
   mrc_io_open(ds->io, "w", step, time);
 }
 
-static struct mrc_fld *
-ds_srv_get_gfld_3d(struct diagsrv_one *ds, int gdims[3])
+static struct mrc_fld* ds_srv_get_gfld_3d(struct diagsrv_one* ds, int gdims[3])
 {
-  struct diagsrv_srv *srv = (struct diagsrv_srv *) ds->srv;
-  struct mrc_fld *fld = mrc_domain_fld_create(srv->domain, SW_0, NULL);
+  struct diagsrv_srv* srv = (struct diagsrv_srv*)ds->srv;
+  struct mrc_fld* fld = mrc_domain_fld_create(srv->domain, SW_0, NULL);
   mrc_fld_set_array(fld, srv->gfld);
   mrc_fld_setup(fld);
   return fld;
 }
 
-static struct mrc_fld *
-ds_srv_get_gfld_2d(struct diagsrv_one *ds, int gdims[2])
+static struct mrc_fld* ds_srv_get_gfld_2d(struct diagsrv_one* ds, int gdims[2])
 {
-  struct diagsrv_srv *srv = (struct diagsrv_srv *) ds->srv;
-  struct mrc_fld *f2 = mrc_fld_create(MPI_COMM_SELF);
-  mrc_fld_set_param_int_array(f2, "dims", 3, (int[3]) { gdims[0], gdims[1], 1 });
+  struct diagsrv_srv* srv = (struct diagsrv_srv*)ds->srv;
+  struct mrc_fld* f2 = mrc_fld_create(MPI_COMM_SELF);
+  mrc_fld_set_param_int_array(f2, "dims", 3, (int[3]){gdims[0], gdims[1], 1});
   mrc_fld_set_array(f2, srv->gfld);
   mrc_fld_setup(f2);
   f2->_domain = srv->domain; // FIXME, quite a hack
   return f2;
 }
 
-static void
-ds_srv_put_gfld_2d(struct diagsrv_one *ds, struct mrc_fld *gfld, char *fld_name,
-		   int outtype, float sheet)
+static void ds_srv_put_gfld_2d(struct diagsrv_one* ds, struct mrc_fld* gfld,
+                               char* fld_name, int outtype, float sheet)
 {
   mrc_fld_set_comp_name(gfld, 0, fld_name);
   mrc_io_write_field2d(ds->io, 1., gfld, outtype, sheet);
   mrc_fld_destroy(gfld);
 }
 
-static void
-ds_srv_put_gfld_3d(struct diagsrv_one *ds, struct mrc_fld *gfld)
+static void ds_srv_put_gfld_3d(struct diagsrv_one* ds, struct mrc_fld* gfld)
 {
   mrc_fld_write(gfld, ds->io);
   mrc_fld_destroy(gfld);
 }
 
-static void
-ds_srv_close(struct diagsrv_one *ds)
+static void ds_srv_close(struct diagsrv_one* ds)
 {
   mrc_io_close(ds->io);
 }
 
-static void
-ds_srv_write_attr(struct diagsrv_one *ds, const char *path, int type,
-		  const char *name, union param_u *pv)
+static void ds_srv_write_attr(struct diagsrv_one* ds, const char* path,
+                              int type, const char* name, union param_u* pv)
 {
   mrc_io_write_attr(ds->io, path, type, name, pv);
 }
 
 struct diagsrv_srv_ops ds_srv_ops = {
-  .name        = "nocache",
-  .create      = ds_srv_create,
-  .set_domain  = ds_srv_set_domain,
-  .destroy     = ds_srv_destroy,
-  .open        = ds_srv_open,
+  .name = "nocache",
+  .create = ds_srv_create,
+  .set_domain = ds_srv_set_domain,
+  .destroy = ds_srv_destroy,
+  .open = ds_srv_open,
   .get_gfld_2d = ds_srv_get_gfld_2d,
   .get_gfld_3d = ds_srv_get_gfld_3d,
   .put_gfld_2d = ds_srv_put_gfld_2d,
   .put_gfld_3d = ds_srv_put_gfld_3d,
-  .write_attr  = ds_srv_write_attr,
-  .close       = ds_srv_close,
+  .write_attr = ds_srv_write_attr,
+  .close = ds_srv_close,
 };
 
 // ----------------------------------------------------------------------
@@ -553,36 +559,37 @@ struct diagsrv_srv_ops ds_srv_ops = {
 
 #define MAX_FIELDS (21)
 
-struct mrc_attrs_entry {
-  struct mrc_obj *attrs;
-  char *path;
+struct mrc_attrs_entry
+{
+  struct mrc_obj* attrs;
+  char* path;
   list_t entry;
 };
 
-struct diagsrv_srv_cache_ctx {
-  char *obj_names[MAX_FIELDS];
-  char *fld_names[MAX_FIELDS];
+struct diagsrv_srv_cache_ctx
+{
+  char* obj_names[MAX_FIELDS];
+  char* fld_names[MAX_FIELDS];
   int outtypes[MAX_FIELDS];
   float sheets[MAX_FIELDS];
-  float *gflds[MAX_FIELDS];
-  struct mrc_domain *domain;
+  float* gflds[MAX_FIELDS];
+  struct mrc_domain* domain;
   int nr_flds;
   int step;
   float time;
   list_t attrs_list;
 };
 
-static void
-ds_srv_cache_create(struct diagsrv_one *ds)
+static void ds_srv_cache_create(struct diagsrv_one* ds)
 {
-  struct diagsrv_srv_cache_ctx *srv = calloc(1, sizeof(*srv));
+  struct diagsrv_srv_cache_ctx* srv = calloc(1, sizeof(*srv));
   ds->srv = srv;
 }
 
-static void
-ds_srv_cache_set_domain(struct diagsrv_one *ds, struct mrc_domain *domain)
+static void ds_srv_cache_set_domain(struct diagsrv_one* ds,
+                                    struct mrc_domain* domain)
 {
-  struct diagsrv_srv_cache_ctx *srv = ds->srv;
+  struct diagsrv_srv_cache_ctx* srv = ds->srv;
   srv->domain = domain;
   int gdims[3];
   mrc_domain_get_global_dims(domain, gdims);
@@ -594,20 +601,18 @@ ds_srv_cache_set_domain(struct diagsrv_one *ds, struct mrc_domain *domain)
   }
 }
 
-static void
-ds_srv_cache_open(struct diagsrv_one *ds, int step, float time)
+static void ds_srv_cache_open(struct diagsrv_one* ds, int step, float time)
 {
-  struct diagsrv_srv_cache_ctx *srv = (struct diagsrv_srv_cache_ctx *) ds->srv;
+  struct diagsrv_srv_cache_ctx* srv = (struct diagsrv_srv_cache_ctx*)ds->srv;
   srv->nr_flds = 0;
   srv->step = step;
   srv->time = time;
   INIT_LIST_HEAD(&srv->attrs_list);
 }
 
-static void
-ds_srv_cache_destroy(struct diagsrv_one *ds)
+static void ds_srv_cache_destroy(struct diagsrv_one* ds)
 {
-  struct diagsrv_srv_cache_ctx *srv = (struct diagsrv_srv_cache_ctx *) ds->srv;
+  struct diagsrv_srv_cache_ctx* srv = (struct diagsrv_srv_cache_ctx*)ds->srv;
   for (int i = 0; i < MAX_FIELDS; i++) {
     free(srv->obj_names[i]);
     free(srv->fld_names[i]);
@@ -616,38 +621,38 @@ ds_srv_cache_destroy(struct diagsrv_one *ds)
   free(srv);
 }
 
-static struct mrc_fld *
-ds_srv_cache_get_gfld_2d(struct diagsrv_one *ds, int gdims[2])
+static struct mrc_fld* ds_srv_cache_get_gfld_2d(struct diagsrv_one* ds,
+                                                int gdims[2])
 {
-  struct diagsrv_srv_cache_ctx *srv = (struct diagsrv_srv_cache_ctx *) ds->srv;
+  struct diagsrv_srv_cache_ctx* srv = (struct diagsrv_srv_cache_ctx*)ds->srv;
   assert(srv->nr_flds < MAX_FIELDS);
   free(srv->fld_names[srv->nr_flds]);
-  struct mrc_fld *f2 = mrc_fld_create(MPI_COMM_SELF);
-  mrc_fld_set_param_int_array(f2, "dims", 3, (int[3]) { gdims[0], gdims[1], 1 });
+  struct mrc_fld* f2 = mrc_fld_create(MPI_COMM_SELF);
+  mrc_fld_set_param_int_array(f2, "dims", 3, (int[3]){gdims[0], gdims[1], 1});
   mrc_fld_set_array(f2, srv->gflds[srv->nr_flds]);
   mrc_fld_setup(f2);
   f2->_domain = srv->domain; // FIXME, quite a hack
   return f2;
 }
 
-static struct mrc_fld *
-ds_srv_cache_get_gfld_3d(struct diagsrv_one *ds, int gdims[3])
+static struct mrc_fld* ds_srv_cache_get_gfld_3d(struct diagsrv_one* ds,
+                                                int gdims[3])
 {
-  struct diagsrv_srv_cache_ctx *srv = (struct diagsrv_srv_cache_ctx *) ds->srv;
+  struct diagsrv_srv_cache_ctx* srv = (struct diagsrv_srv_cache_ctx*)ds->srv;
   assert(srv->nr_flds < MAX_FIELDS);
   free(srv->obj_names[srv->nr_flds]);
   free(srv->fld_names[srv->nr_flds]);
-  struct mrc_fld *fld = mrc_domain_fld_create(srv->domain, SW_0, NULL);
+  struct mrc_fld* fld = mrc_domain_fld_create(srv->domain, SW_0, NULL);
   mrc_fld_set_array(fld, srv->gflds[srv->nr_flds]);
   mrc_fld_setup(fld);
   return fld;
 }
 
-static void
-ds_srv_cache_put_gfld_2d(struct diagsrv_one *ds, struct mrc_fld *gfld, char *fld_name,
-			 int outtype, float sheet)
+static void ds_srv_cache_put_gfld_2d(struct diagsrv_one* ds,
+                                     struct mrc_fld* gfld, char* fld_name,
+                                     int outtype, float sheet)
 {
-  struct diagsrv_srv_cache_ctx *srv = (struct diagsrv_srv_cache_ctx *) ds->srv;
+  struct diagsrv_srv_cache_ctx* srv = (struct diagsrv_srv_cache_ctx*)ds->srv;
   assert(srv->nr_flds < MAX_FIELDS);
   srv->fld_names[srv->nr_flds] = strdup(fld_name);
   srv->outtypes[srv->nr_flds] = outtype;
@@ -656,10 +661,10 @@ ds_srv_cache_put_gfld_2d(struct diagsrv_one *ds, struct mrc_fld *gfld, char *fld
   mrc_fld_destroy(gfld);
 }
 
-static void
-ds_srv_cache_put_gfld_3d(struct diagsrv_one *ds, struct mrc_fld *fld)
+static void ds_srv_cache_put_gfld_3d(struct diagsrv_one* ds,
+                                     struct mrc_fld* fld)
 {
-  struct diagsrv_srv_cache_ctx *srv = (struct diagsrv_srv_cache_ctx *) ds->srv;
+  struct diagsrv_srv_cache_ctx* srv = (struct diagsrv_srv_cache_ctx*)ds->srv;
   assert(srv->nr_flds < MAX_FIELDS);
   srv->obj_names[srv->nr_flds] = strdup(mrc_fld_name(fld));
   srv->fld_names[srv->nr_flds] = strdup(mrc_fld_comp_name(fld, 0));
@@ -668,14 +673,15 @@ ds_srv_cache_put_gfld_3d(struct diagsrv_one *ds, struct mrc_fld *fld)
   mrc_fld_destroy(fld);
 }
 
-static void
-ds_srv_cache_write_attr(struct diagsrv_one *ds, const char *path, int type,
-			const char *name, union param_u *pv)
+static void ds_srv_cache_write_attr(struct diagsrv_one* ds, const char* path,
+                                    int type, const char* name,
+                                    union param_u* pv)
 {
-  struct diagsrv_srv_cache_ctx *srv = (struct diagsrv_srv_cache_ctx *) ds->srv;
+  struct diagsrv_srv_cache_ctx* srv = (struct diagsrv_srv_cache_ctx*)ds->srv;
 
-  struct mrc_attrs_entry *p;
-  __list_for_each_entry(p, &srv->attrs_list, entry, struct mrc_attrs_entry) {
+  struct mrc_attrs_entry* p;
+  __list_for_each_entry(p, &srv->attrs_list, entry, struct mrc_attrs_entry)
+  {
     if (strcmp(p->path, path) == 0)
       goto found;
   }
@@ -686,14 +692,13 @@ ds_srv_cache_write_attr(struct diagsrv_one *ds, const char *path, int type,
   p->path = strdup(path);
   list_add_tail(&p->entry, &srv->attrs_list);
 
- found:
+found:
   mrc_obj_dict_add(p->attrs, type, name, pv);
 }
 
-static void
-ds_srv_cache_close(struct diagsrv_one *ds)
+static void ds_srv_cache_close(struct diagsrv_one* ds)
 {
-  struct diagsrv_srv_cache_ctx *srv = (struct diagsrv_srv_cache_ctx *) ds->srv;
+  struct diagsrv_srv_cache_ctx* srv = (struct diagsrv_srv_cache_ctx*)ds->srv;
   int gdims[3];
   mrc_domain_get_global_dims(srv->domain, gdims);
 
@@ -701,55 +706,58 @@ ds_srv_cache_close(struct diagsrv_one *ds)
 
   for (int i = 0; i < srv->nr_flds; i++) {
     switch (srv->outtypes[i]) {
-    case DIAG_TYPE_3D: {
-      struct mrc_fld *gfld = mrc_domain_fld_create(srv->domain, SW_0, srv->fld_names[i]);
-      mrc_fld_set_array(gfld, srv->gflds[i]);
-      mrc_fld_set_name(gfld, srv->obj_names[i]);
-      mrc_fld_setup(gfld);
-      mrc_fld_write(gfld, ds->io);
-      mrc_fld_destroy(gfld);
-      break;
-    }
-    case DIAG_TYPE_2D_X: {
-      struct mrc_fld *gfld2 = mrc_fld_create(MPI_COMM_SELF);
-      mrc_fld_set_param_int_array(gfld2, "dims", 3, (int[3]) { gdims[1], gdims[2], 1 });
-      mrc_fld_set_array(gfld2, srv->gflds[i]);
-      mrc_fld_set_comp_name(gfld2, 0, srv->fld_names[i]);
-      mrc_fld_setup(gfld2);
-      gfld2->_domain = srv->domain; // FIXME, quite a hack
-      mrc_io_write_field2d(ds->io, 1., gfld2, DIAG_TYPE_2D_X, srv->sheets[i]);
-      mrc_fld_destroy(gfld2);
-      break;
-    }
-    case DIAG_TYPE_2D_Y: {
-      struct mrc_fld *gfld2 = mrc_fld_create(MPI_COMM_SELF);
-      mrc_fld_set_param_int_array(gfld2, "dims", 3, (int[3]) { gdims[0], gdims[2], 1 });
-      mrc_fld_set_array(gfld2, srv->gflds[i]);
-      mrc_fld_set_comp_name(gfld2, 0, srv->fld_names[i]);
-      mrc_fld_setup(gfld2);
-      gfld2->_domain = srv->domain; // FIXME, quite a hack
-      mrc_io_write_field2d(ds->io, 1., gfld2, DIAG_TYPE_2D_Y, srv->sheets[i]);
-      mrc_fld_destroy(gfld2);
-      break;
-    }
-    case DIAG_TYPE_2D_Z: {
-      struct mrc_fld *gfld2 = mrc_fld_create(MPI_COMM_SELF);
-      mrc_fld_set_param_int_array(gfld2, "dims", 3, (int[3]) { gdims[0], gdims[1], 1 });
-      mrc_fld_set_array(gfld2, srv->gflds[i]);
-      mrc_fld_set_comp_name(gfld2, 0, srv->fld_names[i]);
-      mrc_fld_setup(gfld2);
-      gfld2->_domain = srv->domain; // FIXME, quite a hack
-      mrc_io_write_field2d(ds->io, 1., gfld2, DIAG_TYPE_2D_Z, srv->sheets[i]);
-      mrc_fld_destroy(gfld2);
-      break;
-    }
-    default:
-      assert(0);
+      case DIAG_TYPE_3D: {
+        struct mrc_fld* gfld =
+          mrc_domain_fld_create(srv->domain, SW_0, srv->fld_names[i]);
+        mrc_fld_set_array(gfld, srv->gflds[i]);
+        mrc_fld_set_name(gfld, srv->obj_names[i]);
+        mrc_fld_setup(gfld);
+        mrc_fld_write(gfld, ds->io);
+        mrc_fld_destroy(gfld);
+        break;
+      }
+      case DIAG_TYPE_2D_X: {
+        struct mrc_fld* gfld2 = mrc_fld_create(MPI_COMM_SELF);
+        mrc_fld_set_param_int_array(gfld2, "dims", 3,
+                                    (int[3]){gdims[1], gdims[2], 1});
+        mrc_fld_set_array(gfld2, srv->gflds[i]);
+        mrc_fld_set_comp_name(gfld2, 0, srv->fld_names[i]);
+        mrc_fld_setup(gfld2);
+        gfld2->_domain = srv->domain; // FIXME, quite a hack
+        mrc_io_write_field2d(ds->io, 1., gfld2, DIAG_TYPE_2D_X, srv->sheets[i]);
+        mrc_fld_destroy(gfld2);
+        break;
+      }
+      case DIAG_TYPE_2D_Y: {
+        struct mrc_fld* gfld2 = mrc_fld_create(MPI_COMM_SELF);
+        mrc_fld_set_param_int_array(gfld2, "dims", 3,
+                                    (int[3]){gdims[0], gdims[2], 1});
+        mrc_fld_set_array(gfld2, srv->gflds[i]);
+        mrc_fld_set_comp_name(gfld2, 0, srv->fld_names[i]);
+        mrc_fld_setup(gfld2);
+        gfld2->_domain = srv->domain; // FIXME, quite a hack
+        mrc_io_write_field2d(ds->io, 1., gfld2, DIAG_TYPE_2D_Y, srv->sheets[i]);
+        mrc_fld_destroy(gfld2);
+        break;
+      }
+      case DIAG_TYPE_2D_Z: {
+        struct mrc_fld* gfld2 = mrc_fld_create(MPI_COMM_SELF);
+        mrc_fld_set_param_int_array(gfld2, "dims", 3,
+                                    (int[3]){gdims[0], gdims[1], 1});
+        mrc_fld_set_array(gfld2, srv->gflds[i]);
+        mrc_fld_set_comp_name(gfld2, 0, srv->fld_names[i]);
+        mrc_fld_setup(gfld2);
+        gfld2->_domain = srv->domain; // FIXME, quite a hack
+        mrc_io_write_field2d(ds->io, 1., gfld2, DIAG_TYPE_2D_Z, srv->sheets[i]);
+        mrc_fld_destroy(gfld2);
+        break;
+      }
+      default: assert(0);
     }
   }
 
   while (!list_empty(&srv->attrs_list)) {
-    struct mrc_attrs_entry *p =
+    struct mrc_attrs_entry* p =
       list_entry(srv->attrs_list.next, struct mrc_attrs_entry, entry);
     mrc_obj_write(p->attrs, ds->io);
     mrc_obj_destroy(p->attrs);
@@ -762,44 +770,44 @@ ds_srv_cache_close(struct diagsrv_one *ds)
 }
 
 struct diagsrv_srv_ops ds_srv_cache_ops = {
-  .name        = "cache",
-  .create      = ds_srv_cache_create,
-  .destroy     = ds_srv_cache_destroy,
-  .set_domain  = ds_srv_cache_set_domain,
-  .open        = ds_srv_cache_open,
+  .name = "cache",
+  .create = ds_srv_cache_create,
+  .destroy = ds_srv_cache_destroy,
+  .set_domain = ds_srv_cache_set_domain,
+  .open = ds_srv_cache_open,
   .get_gfld_2d = ds_srv_cache_get_gfld_2d,
   .get_gfld_3d = ds_srv_cache_get_gfld_3d,
   .put_gfld_2d = ds_srv_cache_put_gfld_2d,
   .put_gfld_3d = ds_srv_cache_put_gfld_3d,
-  .write_attr  = ds_srv_cache_write_attr,
-  .close       = ds_srv_cache_close,
+  .write_attr = ds_srv_cache_write_attr,
+  .close = ds_srv_cache_close,
 };
 
 // ----------------------------------------------------------------------
 // diagsrv_one helpers
 
-static void
-add_to_field_2d(struct mrc_fld *g, struct mrc_fld *l, int ib[2])
+static void add_to_field_2d(struct mrc_fld* g, struct mrc_fld* l, int ib[2])
 {
-  struct mrc_fld *_g = mrc_fld_get_as(g, "float");
-  struct mrc_fld *_l = mrc_fld_get_as(l, "float");
+  struct mrc_fld* _g = mrc_fld_get_as(g, "float");
+  struct mrc_fld* _l = mrc_fld_get_as(l, "float");
   for (int iy = 0; iy < l->_dims.vals[1]; iy++) {
     for (int ix = 0; ix < l->_dims.vals[0]; ix++) {
-      MRC_F2(_g,0, ix+ib[0],iy+ib[1]) = MRC_F2(_l,0, ix,iy);
+      MRC_F2(_g, 0, ix + ib[0], iy + ib[1]) = MRC_F2(_l, 0, ix, iy);
     }
   }
   mrc_fld_put_as(_g, g);
   mrc_fld_put_as(_l, l);
 }
 
-static void
-add_to_field_3d(struct mrc_fld *g_, struct mrc_fld *l_, int ib[3])
+static void add_to_field_3d(struct mrc_fld* g_, struct mrc_fld* l_, int ib[3])
 {
-  struct mrc_fld *g = mrc_fld_get_as(g_, "float");
-  struct mrc_fld *l = mrc_fld_get_as(l_, "float");
-  mrc_fld_foreach(l, ix,iy,iz, 0, 0) {
-    MRC_F3(g,0, ix+ib[0],iy+ib[1],iz+ib[2]) = MRC_F3(l,0, ix,iy,iz);
-  } mrc_fld_foreach_end;
+  struct mrc_fld* g = mrc_fld_get_as(g_, "float");
+  struct mrc_fld* l = mrc_fld_get_as(l_, "float");
+  mrc_fld_foreach(l, ix, iy, iz, 0, 0)
+  {
+    MRC_F3(g, 0, ix + ib[0], iy + ib[1], iz + ib[2]) = MRC_F3(l, 0, ix, iy, iz);
+  }
+  mrc_fld_foreach_end;
   mrc_fld_put_as(g, g_);
   mrc_fld_put_as(l, l_);
 }
@@ -807,14 +815,13 @@ add_to_field_3d(struct mrc_fld *g_, struct mrc_fld *l_, int ib[3])
 // ----------------------------------------------------------------------
 // diagsrv_one
 
-static struct diagsrv_srv_ops *ds_srvs[] = {
+static struct diagsrv_srv_ops* ds_srvs[] = {
   &ds_srv_ops,
   &ds_srv_cache_ops,
   NULL,
 };
 
-static struct diagsrv_srv_ops *
-find_ds_srv(const char *ds_srv)
+static struct diagsrv_srv_ops* find_ds_srv(const char* ds_srv)
 {
 #if 0
   fprintf(stderr,"Available ds_srvs:\n");
@@ -832,19 +839,18 @@ find_ds_srv(const char *ds_srv)
   abort();
 }
 
-
-static struct mrc_domain *
-diagsrv_recv_domain_info(int nr_procs, int ldims[3])
+static struct mrc_domain* diagsrv_recv_domain_info(int nr_procs, int ldims[3])
 {
   for (int d = 0; d < 3; d++) {
     ldims[d] = 0;
   }
 
-  struct mrc_domain *domain = NULL;
-  struct mrc_crds *crds = NULL;
+  struct mrc_domain* domain = NULL;
+  struct mrc_crds* crds = NULL;
   int iw[9], *off = iw, *_ldims = iw + 3, *gdims = iw + 6;
   for (int rank = 0; rank < nr_procs; rank++) {
-    MPI_Recv(iw, 9, MPI_INT, rank, ID_DIAGS_CMD_DOMAIN_INFO, MPI_COMM_WORLD, MPI_STATUS_IGNORE);
+    MPI_Recv(iw, 9, MPI_INT, rank, ID_DIAGS_CMD_DOMAIN_INFO, MPI_COMM_WORLD,
+             MPI_STATUS_IGNORE);
     if (rank == 0) {
       domain = mrc_domain_create(MPI_COMM_SELF);
       mrc_domain_set_type(domain, "simple");
@@ -858,12 +864,12 @@ diagsrv_recv_domain_info(int nr_procs, int ldims[3])
       if (ldims[d] < _ldims[d]) {
         ldims[d] = _ldims[d];
       }
-      // FIXME, this is a bit stupid, but by far the easiest way without assuming
-      // internal mpi_domain knowledge -- we repeatedly receive the same pieces
-      // of the global coord array, but it's only done once, anyway
-      float *buf = calloc(_ldims[d], sizeof(*buf));
-      MPI_Recv(buf, _ldims[d], MPI_FLOAT, rank, ID_DIAGS_CMD_CRDX + d, MPI_COMM_WORLD,
-	       MPI_STATUS_IGNORE);
+      // FIXME, this is a bit stupid, but by far the easiest way without
+      // assuming internal mpi_domain knowledge -- we repeatedly receive the
+      // same pieces of the global coord array, but it's only done once, anyway
+      float* buf = calloc(_ldims[d], sizeof(*buf));
+      MPI_Recv(buf, _ldims[d], MPI_FLOAT, rank, ID_DIAGS_CMD_CRDX + d,
+               MPI_COMM_WORLD, MPI_STATUS_IGNORE);
       for (int i = 0; i < _ldims[d]; i++) {
         MRC_CRD(crds, d, i + off[d]) = buf[i];
       }
@@ -873,39 +879,39 @@ diagsrv_recv_domain_info(int nr_procs, int ldims[3])
   return domain;
 }
 
-void
-mrc_io_server(const char *ds_format, const char *ds_srv, int nr_procs)
+void mrc_io_server(const char* ds_format, const char* ds_srv, int nr_procs)
 {
-  struct diagsrv_params {
-    char *format;
-    char *server;
+  struct diagsrv_params
+  {
+    char* format;
+    char* server;
   };
 
-#define VAR(x) (void *)offsetof(struct diagsrv_params, x)
-static struct param diagsrv_params_descr[] = {
-  { "diagsrv_format"     , VAR(format)          , PARAM_STRING(NULL)      },
-  { "diagsrv_server"     , VAR(server)          , PARAM_STRING(NULL)      },
-  {},
-};
+#define VAR(x) (void*)offsetof(struct diagsrv_params, x)
+  static struct param diagsrv_params_descr[] = {
+    {"diagsrv_format", VAR(format), PARAM_STRING(NULL)},
+    {"diagsrv_server", VAR(server), PARAM_STRING(NULL)},
+    {},
+  };
 #undef VAR
 
   struct diagsrv_params par = {
-    .format = (char *) ds_format,
-    .server = (char *) ds_srv,
+    .format = (char*)ds_format,
+    .server = (char*)ds_srv,
   };
   mrc_params_parse_nodefault(&par, diagsrv_params_descr, "diagsrv",
-			     MPI_COMM_SELF);
+                             MPI_COMM_SELF);
   mrc_params_print(&par, diagsrv_params_descr, "diagsrv", MPI_COMM_SELF);
 
-  struct diagsrv_srv_ops *srv_ops = find_ds_srv(par.server);
+  struct diagsrv_srv_ops* srv_ops = find_ds_srv(par.server);
   struct diagsrv_one ds = {
-    .srv_ops    = srv_ops,
+    .srv_ops = srv_ops,
   };
   INIT_LIST_HEAD(&ds.mrc_io_list);
 
   int respond_to_rank = -1;
   int gdims[3];
-  float *w2 = NULL;
+  float* w2 = NULL;
 
   srv_ops->create(&ds);
 
@@ -924,10 +930,12 @@ static struct param diagsrv_params_descr[] = {
 
     if (icmd[0] == DIAG_CMD_CREATE) {
       char s[256] = {};
-      MPI_Recv(s, 255, MPI_CHAR, 0, ID_DIAGS_CREATE_OUTDIR, MPI_COMM_WORLD, MPI_STATUS_IGNORE);
-      char *outdir = strdup(s);
-      MPI_Recv(s, 255, MPI_CHAR, 0, ID_DIAGS_CREATE_BASENAME, MPI_COMM_WORLD, MPI_STATUS_IGNORE);
-      char *basename = strdup(s);
+      MPI_Recv(s, 255, MPI_CHAR, 0, ID_DIAGS_CREATE_OUTDIR, MPI_COMM_WORLD,
+               MPI_STATUS_IGNORE);
+      char* outdir = strdup(s);
+      MPI_Recv(s, 255, MPI_CHAR, 0, ID_DIAGS_CREATE_BASENAME, MPI_COMM_WORLD,
+               MPI_STATUS_IGNORE);
+      char* basename = strdup(s);
 
       assert(!find_diagsrv_io(&ds, basename));
       create_diagsrv_io(&ds, par.format, outdir, basename);
@@ -940,182 +948,194 @@ static struct param diagsrv_params_descr[] = {
     int outtag = stat.MPI_TAG;
 
     char s[256] = {};
-    MPI_Recv(s, 255, MPI_CHAR, 0, ID_DIAGS_BASENAME, MPI_COMM_WORLD, MPI_STATUS_IGNORE);
-    struct mrc_io_entry *io_entry = find_diagsrv_io(&ds, s);
+    MPI_Recv(s, 255, MPI_CHAR, 0, ID_DIAGS_BASENAME, MPI_COMM_WORLD,
+             MPI_STATUS_IGNORE);
+    struct mrc_io_entry* io_entry = find_diagsrv_io(&ds, s);
     assert(io_entry);
     ds.io = io_entry->io;
 
     float time;
     MPI_Recv(&time, 1, MPI_FLOAT, 0, ID_DIAGS_TIME, MPI_COMM_WORLD,
-	     MPI_STATUS_IGNORE);
+             MPI_STATUS_IGNORE);
 
     switch (outtag) {
-    case ID_DIAGS_CMD_OPEN:
-      srv_ops->open(&ds, step, time);
-      break;
-    default:
-      assert(0);
+      case ID_DIAGS_CMD_OPEN: srv_ops->open(&ds, step, time); break;
+      default: assert(0);
     }
 
-    for (;;) { //waiting for field to write.
+    for (;;) { // waiting for field to write.
 
       char fld_name80[80];
       MPI_Recv(fld_name80, 80, MPI_CHAR, 0, MPI_ANY_TAG, MPI_COMM_WORLD,
-	       &status);
+               &status);
       if (status.MPI_TAG == ID_DIAGS_CMD_WRITE_ATTR) {
-	char *path = fld_name80;
-	int type;
-	MPI_Recv(&type, 1, MPI_INT, 0, ID_DIAGS_CMD_WRITE_ATTR, MPI_COMM_WORLD,
-		 MPI_STATUS_IGNORE);
-	char name[80];
-	MPI_Recv(name, 80, MPI_CHAR, 0, ID_DIAGS_CMD_WRITE_ATTR, MPI_COMM_WORLD,
-		 MPI_STATUS_IGNORE);
-	union param_u val;
-	switch (type) {
-	case PT_BOOL:
-	case PT_INT:
-	case PT_SELECT:
-	case MRC_VAR_INT:
-	case MRC_VAR_BOOL:
-	  MPI_Recv(&val.u_int, 1, MPI_INT, 0, ID_DIAGS_CMD_WRITE_ATTR, MPI_COMM_WORLD,
-		   MPI_STATUS_IGNORE);
-	  break;
-	case PT_FLOAT:
-	  MPI_Recv(&val.u_float, 1, MPI_FLOAT, 0, ID_DIAGS_CMD_WRITE_ATTR, MPI_COMM_WORLD,
-		   MPI_STATUS_IGNORE);
-	  break;
-	case PT_DOUBLE:
-	case MRC_VAR_DOUBLE:
-	  MPI_Recv(&val.u_double, 1, MPI_DOUBLE, 0, ID_DIAGS_CMD_WRITE_ATTR, MPI_COMM_WORLD,
-		   MPI_STATUS_IGNORE);
-	  break;
-	case PT_STRING: ;
-	  char str[100];
-	  MPI_Recv(str, 100, MPI_CHAR, 0, ID_DIAGS_CMD_WRITE_ATTR, MPI_COMM_WORLD,
-		   MPI_STATUS_IGNORE);
-	  val.u_string = strdup(str);
-	  break;
-	case PT_INT3:
-	  MPI_Recv(val.u_int3, 3, MPI_INT, 0, ID_DIAGS_CMD_WRITE_ATTR, MPI_COMM_WORLD,
-		   MPI_STATUS_IGNORE);
-	  break;
-	case PT_FLOAT3:
-	  MPI_Recv(val.u_float3, 3, MPI_FLOAT, 0, ID_DIAGS_CMD_WRITE_ATTR, MPI_COMM_WORLD,
-		   MPI_STATUS_IGNORE);
-	  break;
-	case PT_DOUBLE3:
-	case MRC_VAR_DOUBLE3:
-	  MPI_Recv(val.u_double3, 3, MPI_DOUBLE, 0, ID_DIAGS_CMD_WRITE_ATTR, MPI_COMM_WORLD,
-		   MPI_STATUS_IGNORE);
-	  break;
-	case PT_INT_ARRAY:
-	  MPI_Recv(&val.u_int_array.nr_vals, 1, MPI_INT, 0, ID_DIAGS_CMD_WRITE_ATTR, MPI_COMM_WORLD,
-		   MPI_STATUS_IGNORE);
-	  val.u_int_array.vals = calloc(val.u_int_array.nr_vals, sizeof(int));
-	  MPI_Recv(val.u_int_array.vals, val.u_int_array.nr_vals, MPI_INT, 0, ID_DIAGS_CMD_WRITE_ATTR,
-		   MPI_COMM_WORLD, MPI_STATUS_IGNORE);
-	  break;
-	default:
-	  assert(0);
-	}
-	srv_ops->write_attr(&ds, path, type, name, &val);
-	continue;
+        char* path = fld_name80;
+        int type;
+        MPI_Recv(&type, 1, MPI_INT, 0, ID_DIAGS_CMD_WRITE_ATTR, MPI_COMM_WORLD,
+                 MPI_STATUS_IGNORE);
+        char name[80];
+        MPI_Recv(name, 80, MPI_CHAR, 0, ID_DIAGS_CMD_WRITE_ATTR, MPI_COMM_WORLD,
+                 MPI_STATUS_IGNORE);
+        union param_u val;
+        switch (type) {
+          case PT_BOOL:
+          case PT_INT:
+          case PT_SELECT:
+          case MRC_VAR_INT:
+          case MRC_VAR_BOOL:
+            MPI_Recv(&val.u_int, 1, MPI_INT, 0, ID_DIAGS_CMD_WRITE_ATTR,
+                     MPI_COMM_WORLD, MPI_STATUS_IGNORE);
+            break;
+          case PT_FLOAT:
+            MPI_Recv(&val.u_float, 1, MPI_FLOAT, 0, ID_DIAGS_CMD_WRITE_ATTR,
+                     MPI_COMM_WORLD, MPI_STATUS_IGNORE);
+            break;
+          case PT_DOUBLE:
+          case MRC_VAR_DOUBLE:
+            MPI_Recv(&val.u_double, 1, MPI_DOUBLE, 0, ID_DIAGS_CMD_WRITE_ATTR,
+                     MPI_COMM_WORLD, MPI_STATUS_IGNORE);
+            break;
+          case PT_STRING:;
+            char str[100];
+            MPI_Recv(str, 100, MPI_CHAR, 0, ID_DIAGS_CMD_WRITE_ATTR,
+                     MPI_COMM_WORLD, MPI_STATUS_IGNORE);
+            val.u_string = strdup(str);
+            break;
+          case PT_INT3:
+            MPI_Recv(val.u_int3, 3, MPI_INT, 0, ID_DIAGS_CMD_WRITE_ATTR,
+                     MPI_COMM_WORLD, MPI_STATUS_IGNORE);
+            break;
+          case PT_FLOAT3:
+            MPI_Recv(val.u_float3, 3, MPI_FLOAT, 0, ID_DIAGS_CMD_WRITE_ATTR,
+                     MPI_COMM_WORLD, MPI_STATUS_IGNORE);
+            break;
+          case PT_DOUBLE3:
+          case MRC_VAR_DOUBLE3:
+            MPI_Recv(val.u_double3, 3, MPI_DOUBLE, 0, ID_DIAGS_CMD_WRITE_ATTR,
+                     MPI_COMM_WORLD, MPI_STATUS_IGNORE);
+            break;
+          case PT_INT_ARRAY:
+            MPI_Recv(&val.u_int_array.nr_vals, 1, MPI_INT, 0,
+                     ID_DIAGS_CMD_WRITE_ATTR, MPI_COMM_WORLD,
+                     MPI_STATUS_IGNORE);
+            val.u_int_array.vals = calloc(val.u_int_array.nr_vals, sizeof(int));
+            MPI_Recv(val.u_int_array.vals, val.u_int_array.nr_vals, MPI_INT, 0,
+                     ID_DIAGS_CMD_WRITE_ATTR, MPI_COMM_WORLD,
+                     MPI_STATUS_IGNORE);
+            break;
+          default: assert(0);
+        }
+        srv_ops->write_attr(&ds, path, type, name, &val);
+        continue;
       } else if (status.MPI_TAG == ID_DIAGS_CMD_CREATE) {
-	assert (!io_entry->domain);
-	io_entry->domain = diagsrv_recv_domain_info(nr_procs, io_entry->ldims);
-	srv_ops->set_domain(&ds, io_entry->domain);
-	mrc_domain_get_global_dims(io_entry->domain, gdims);
-	int *ldims = io_entry->ldims;
-	w2 = malloc(ldims[0] * ldims[1] * ldims[2] * sizeof(float));
-	continue;
+        assert(!io_entry->domain);
+        io_entry->domain = diagsrv_recv_domain_info(nr_procs, io_entry->ldims);
+        srv_ops->set_domain(&ds, io_entry->domain);
+        mrc_domain_get_global_dims(io_entry->domain, gdims);
+        int* ldims = io_entry->ldims;
+        w2 = malloc(ldims[0] * ldims[1] * ldims[2] * sizeof(float));
+        continue;
       };
       assert(status.MPI_TAG == ID_DIAGS_FLDNAME);
       assert(io_entry->domain);
 
       if (!fld_name80[0])
-	break;
+        break;
 
       char obj_name80[80];
       strcpy(obj_name80, fld_name80);
 
       MPI_Recv(fld_name80, 80, MPI_CHAR, 0, ID_DIAGS_FLDNAME, MPI_COMM_WORLD,
-	       MPI_STATUS_IGNORE);
+               MPI_STATUS_IGNORE);
 
       int outtype;
       MPI_Recv(&outtype, 1, MPI_INT, 0, ID_DIAGS_CMD_WRITE, MPI_COMM_WORLD,
-	       MPI_STATUS_IGNORE);
+               MPI_STATUS_IGNORE);
 
       if (outtype != DIAG_TYPE_3D) {
-	float sheet;
-	MPI_Recv(&sheet, 1, MPI_FLOAT, 0, ID_DIAGS_CMD_WRITE, MPI_COMM_WORLD,
-		 MPI_STATUS_IGNORE);
+        float sheet;
+        MPI_Recv(&sheet, 1, MPI_FLOAT, 0, ID_DIAGS_CMD_WRITE, MPI_COMM_WORLD,
+                 MPI_STATUS_IGNORE);
 
-	int i0 = -1, i1 = -1;
-	switch (outtype) {
-	case DIAG_TYPE_2D_X: i0 = 1; i1 = 2; break;
-	case DIAG_TYPE_2D_Y: i0 = 0; i1 = 2; break;
-	case DIAG_TYPE_2D_Z: i0 = 0; i1 = 1; break;
-	default:
-	  assert(0);
-	}
+        int i0 = -1, i1 = -1;
+        switch (outtype) {
+          case DIAG_TYPE_2D_X:
+            i0 = 1;
+            i1 = 2;
+            break;
+          case DIAG_TYPE_2D_Y:
+            i0 = 0;
+            i1 = 2;
+            break;
+          case DIAG_TYPE_2D_Z:
+            i0 = 0;
+            i1 = 1;
+            break;
+          default: assert(0);
+        }
 
-	struct mrc_fld *gfld2 = srv_ops->get_gfld_2d(&ds, (int [2]) { gdims[i0], gdims[i1] });
+        struct mrc_fld* gfld2 =
+          srv_ops->get_gfld_2d(&ds, (int[2]){gdims[i0], gdims[i1]});
 
-	for (int k = 0; k < nr_procs; k++) {
-	  int iw[6], *off = iw, *dims = iw + 3; // off, then dims
-	  MPI_Recv(iw, 6, MPI_INT, k, ID_DIAGS_SUBDOMAIN, MPI_COMM_WORLD, MPI_STATUS_IGNORE);
+        for (int k = 0; k < nr_procs; k++) {
+          int iw[6], *off = iw, *dims = iw + 3; // off, then dims
+          MPI_Recv(iw, 6, MPI_INT, k, ID_DIAGS_SUBDOMAIN, MPI_COMM_WORLD,
+                   MPI_STATUS_IGNORE);
 
-	  // receive data and add to field
-	  if (iw[0] > -1) {
-	    struct mrc_fld *lfld2 = mrc_fld_create(MPI_COMM_SELF);
-	    mrc_fld_set_param_int_array(lfld2, "dims", 3, (int[3]) { dims[i0], dims[i1], 1 });
-	    mrc_fld_set_array(lfld2, w2);
-	    mrc_fld_setup(lfld2);
-	    struct mrc_fld *_lfld2 = mrc_fld_get_as(lfld2, "float");
-	    MPI_Recv(_lfld2->_nd->arr, mrc_fld_len(lfld2), MPI_FLOAT, k, ID_DIAGS_2DDATA, MPI_COMM_WORLD,
-		     MPI_STATUS_IGNORE);
-	    mrc_fld_put_as(_lfld2, lfld2);
-	    add_to_field_2d(gfld2, lfld2, (int [2]) { off[i0], off[i1] });
-	    mrc_fld_destroy(lfld2);
-	  }
-	}
+          // receive data and add to field
+          if (iw[0] > -1) {
+            struct mrc_fld* lfld2 = mrc_fld_create(MPI_COMM_SELF);
+            mrc_fld_set_param_int_array(lfld2, "dims", 3,
+                                        (int[3]){dims[i0], dims[i1], 1});
+            mrc_fld_set_array(lfld2, w2);
+            mrc_fld_setup(lfld2);
+            struct mrc_fld* _lfld2 = mrc_fld_get_as(lfld2, "float");
+            MPI_Recv(_lfld2->_nd->arr, mrc_fld_len(lfld2), MPI_FLOAT, k,
+                     ID_DIAGS_2DDATA, MPI_COMM_WORLD, MPI_STATUS_IGNORE);
+            mrc_fld_put_as(_lfld2, lfld2);
+            add_to_field_2d(gfld2, lfld2, (int[2]){off[i0], off[i1]});
+            mrc_fld_destroy(lfld2);
+          }
+        }
 
-	srv_ops->put_gfld_2d(&ds, gfld2, fld_name80, outtype, sheet);
+        srv_ops->put_gfld_2d(&ds, gfld2, fld_name80, outtype, sheet);
       } else {
-	struct mrc_fld *gfld3 = srv_ops->get_gfld_3d(&ds, gdims);
+        struct mrc_fld* gfld3 = srv_ops->get_gfld_3d(&ds, gdims);
 
-	for (int k = 0; k < nr_procs; k++) {
-	  int iw[6], *off = iw, *dims = iw + 3; // off, then dims
-	  MPI_Recv(iw, 6, MPI_INT, k, ID_DIAGS_SUBDOMAIN, MPI_COMM_WORLD, MPI_STATUS_IGNORE);
+        for (int k = 0; k < nr_procs; k++) {
+          int iw[6], *off = iw, *dims = iw + 3; // off, then dims
+          MPI_Recv(iw, 6, MPI_INT, k, ID_DIAGS_SUBDOMAIN, MPI_COMM_WORLD,
+                   MPI_STATUS_IGNORE);
 
-	  // receive data and add to field
-	  if (iw[0] > -1) {
-	    struct mrc_fld *lfld3 = mrc_fld_create(MPI_COMM_SELF);
-	    mrc_fld_set_param_int_array(lfld3, "dims", 4,
-				       (int[4]) { dims[0], dims[1], dims[2], 1 });
-	    mrc_fld_set_array(lfld3, w2);
-	    mrc_fld_setup(lfld3);
-	    struct mrc_fld *_lfld3 = mrc_fld_get_as(lfld3, "float");
-	    MPI_Recv(lfld3->_nd->arr, mrc_fld_len(lfld3), MPI_FLOAT, k, ID_DIAGS_DATA, MPI_COMM_WORLD,
-		     MPI_STATUS_IGNORE);
-	    mrc_fld_put_as(_lfld3, lfld3);
-	    add_to_field_3d(gfld3, lfld3, off);
-	    mrc_fld_destroy(lfld3);
-	  }
-	}
+          // receive data and add to field
+          if (iw[0] > -1) {
+            struct mrc_fld* lfld3 = mrc_fld_create(MPI_COMM_SELF);
+            mrc_fld_set_param_int_array(lfld3, "dims", 4,
+                                        (int[4]){dims[0], dims[1], dims[2], 1});
+            mrc_fld_set_array(lfld3, w2);
+            mrc_fld_setup(lfld3);
+            struct mrc_fld* _lfld3 = mrc_fld_get_as(lfld3, "float");
+            MPI_Recv(lfld3->_nd->arr, mrc_fld_len(lfld3), MPI_FLOAT, k,
+                     ID_DIAGS_DATA, MPI_COMM_WORLD, MPI_STATUS_IGNORE);
+            mrc_fld_put_as(_lfld3, lfld3);
+            add_to_field_3d(gfld3, lfld3, off);
+            mrc_fld_destroy(lfld3);
+          }
+        }
 
-	mrc_fld_set_name(gfld3, obj_name80);
-	mrc_fld_set_comp_name(gfld3, 0, fld_name80);
-	srv_ops->put_gfld_3d(&ds, gfld3);
+        mrc_fld_set_name(gfld3, obj_name80);
+        mrc_fld_set_comp_name(gfld3, 0, fld_name80);
+        srv_ops->put_gfld_3d(&ds, gfld3);
       }
     }
     srv_ops->close(&ds);
     ds.io = NULL;
-  }  //for (;;) //loop waiting for data to write...
+  } // for (;;) //loop waiting for data to write...
   free(w2);
 
   while (!list_empty(&ds.mrc_io_list)) {
-    struct mrc_io_entry *p = list_entry(ds.mrc_io_list.next, struct mrc_io_entry, entry);
+    struct mrc_io_entry* p =
+      list_entry(ds.mrc_io_list.next, struct mrc_io_entry, entry);
     mrc_io_destroy(p->io);
     mrc_domain_destroy(p->domain);
     list_del(&p->entry);
@@ -1128,6 +1148,6 @@ static struct param diagsrv_params_descr[] = {
     int response = DIAG_RESPONSE_SHUTDOWN_COMPLETE;
     assert(respond_to_rank == 0);
     MPI_Send(&response, 1, MPI_INT, respond_to_rank, ID_DIAGS_CMD_RESPONSE,
-	     MPI_COMM_WORLD);
+             MPI_COMM_WORLD);
   }
 }

--- a/src/libmrc/src/mrc_io_util.c
+++ b/src/libmrc/src/mrc_io_util.c
@@ -9,13 +9,11 @@
 // ======================================================================
 // diagc_make_filename
 
-char *
-diagc_make_filename(struct mrc_io *io, const char *ext)
+char* diagc_make_filename(struct mrc_io* io, const char* ext)
 {
-  struct mrc_io_params *par = &io->par;
+  struct mrc_io_params* par = &io->par;
 
-  char *filename = malloc(strlen(par->outdir) + strlen(par->basename) + 30);
+  char* filename = malloc(strlen(par->outdir) + strlen(par->basename) + 30);
   sprintf(filename, "%s/%s.%06d%s", par->outdir, par->basename, io->step, ext);
   return filename;
 }
-

--- a/src/libmrc/src/mrc_io_xdmf.c
+++ b/src/libmrc/src/mrc_io_xdmf.c
@@ -131,7 +131,7 @@ static void make_sfx(char* sfx, int outtype, float sheet)
 static void hdf5_open(struct mrc_io* io, const char* mode)
 {
   struct diag_hdf5* hdf5 = diag_hdf5(io);
-  char filename[strlen(io->par.outdir) + strlen(io->par.basename) + 20];
+  char filename[strlen(io->par.outdir) + strlen(io->par.basename) + 30];
   sprintf(filename, "%s/%s.%06d_p%06d.h5", io->par.outdir, io->par.basename,
           io->step, io->rank);
   if (strcmp(mode, "w") == 0) {
@@ -541,7 +541,7 @@ static void xdmf_write_spatial_collection(struct mrc_io* io,
     fprintf(f, "   <Grid Name=\"mesh-%s-%d\" GridType=\"Uniform\">\n", xs->sfx,
             s);
 
-    char fname[strlen(io->par.outdir) + strlen(io->par.basename) + 20];
+    char fname[strlen(io->par.outdir) + strlen(io->par.basename) + 30];
     sprintf(fname, "%s/%s.%06d_p%06d.h5", io->par.outdir, io->par.basename,
             io->step, s);
     int* im = xs->subdomains[s].im;
@@ -1978,7 +1978,7 @@ static void ds_xdmf_parallel_open(struct mrc_io* io, const char* mode)
   hdf5->mode = strdup(mode);
   hdf5->crds_done = false;
 
-  char filename[strlen(io->par.outdir) + strlen(io->par.basename) + 20];
+  char filename[strlen(io->par.outdir) + strlen(io->par.basename) + 30];
   sprintf(filename, "%s/%s.%06d_p%06d.h5", io->par.outdir, io->par.basename,
           io->step, 0);
 

--- a/src/libmrc/src/mrc_io_xdmf.c
+++ b/src/libmrc/src/mrc_io_xdmf.c
@@ -26,80 +26,89 @@
 
 #define MAX_FLD_INFO (100)
 
-struct fld_info {
-  char *name;
-  char *path;
+struct fld_info
+{
+  char* name;
+  char* path;
   bool is_vec;
   int dim;
 };
 
-struct xdmf_temporal_step {
+struct xdmf_temporal_step
+{
   list_t entry;
   char filename[0];
 };
 
-struct xdmf_temporal {
-  char *filename;
+struct xdmf_temporal
+{
+  char* filename;
   list_t timesteps;
 };
 
-struct xdmf_subdomain {
+struct xdmf_subdomain
+{
   int im[3];
 };
 
-struct xdmf_spatial {
-  char *sfx;
+struct xdmf_spatial
+{
+  char* sfx;
   float sheet;
   int p;
   int nr_subdomains;
-  struct xdmf_subdomain *subdomains;
+  struct xdmf_subdomain* subdomains;
   int nr_fld_info;
   struct fld_info fld_info[MAX_FLD_INFO];
-  void (*write_topology)(FILE *f, int im[3], const char *filename, float sheet, int p);
-  void (*write_fld)(FILE *f, struct fld_info *fld_info, int im[3], const char *filename);
+  void (*write_topology)(FILE* f, int im[3], const char* filename, float sheet,
+                         int p);
+  void (*write_fld)(FILE* f, struct fld_info* fld_info, int im[3],
+                    const char* filename);
   list_t entry;
 };
 
-struct diag_hdf5_params {
+struct diag_hdf5_params
+{
   bool use_independent_io;
 };
 
-#define VAR(x) (void *)offsetof(struct diag_hdf5_params, x)
+#define VAR(x) (void*)offsetof(struct diag_hdf5_params, x)
 
 static struct param diag_hdf5_params_descr[] = {
-  { "use_independent_io"     , VAR(use_independent_io)      , PARAM_BOOL(false)      },
+  {"use_independent_io", VAR(use_independent_io), PARAM_BOOL(false)},
   {},
 };
 
 #undef VAR
 
-struct diag_hdf5 {
+struct diag_hdf5
+{
   struct diag_hdf5_params par;
-  char *mode;
+  char* mode;
   hid_t file;
-  bool crd_written[3]; // this should be per mrc_domain, but this will do for crds
+  bool
+    crd_written[3]; // this should be per mrc_domain, but this will do for crds
   bool crds_done;
   int gdims[3], nr_procs[3];
   int off[3], ldims[3];
-  struct mrc_fld *vfld;
-  struct xdmf_temporal *xdmf_temporal; // lives from create() to destroy()
-  list_t xdmf_spatial_list;  // lives from open to close
+  struct mrc_fld* vfld;
+  struct xdmf_temporal* xdmf_temporal; // lives from create() to destroy()
+  list_t xdmf_spatial_list;            // lives from open to close
   hid_t group_crd;
 };
 
 // ======================================================================
 // filename helpers
 
-static void
-make_path(char *path, const char *sfx)
+static void make_path(char* path, const char* sfx)
 {
   sprintf(path, "%s", sfx);
 }
 
-static void
-make_sfx(char *sfx, int outtype, float sheet)
+static void make_sfx(char* sfx, int outtype, float sheet)
 {
-  int out_sheet = (sheet>=0.0) ? (int)(sheet*10.0001): -(int)(-sheet*10.0001);
+  int out_sheet =
+    (sheet >= 0.0) ? (int)(sheet * 10.0001) : -(int)(-sheet * 10.0001);
   if (outtype == DIAG_TYPE_2D_X) {
     sprintf(sfx, "px_%d", out_sheet);
   } else if (outtype == DIAG_TYPE_2D_Y) {
@@ -117,15 +126,14 @@ make_sfx(char *sfx, int outtype, float sheet)
 // ======================================================================
 // generic hdf5
 
-#define diag_hdf5(io) ((struct diag_hdf5 *)io->obj.subctx)
+#define diag_hdf5(io) ((struct diag_hdf5*)io->obj.subctx)
 
-static void
-hdf5_open(struct mrc_io *io, const char *mode) 
+static void hdf5_open(struct mrc_io* io, const char* mode)
 {
-  struct diag_hdf5 *hdf5 = diag_hdf5(io);
+  struct diag_hdf5* hdf5 = diag_hdf5(io);
   char filename[strlen(io->par.outdir) + strlen(io->par.basename) + 20];
   sprintf(filename, "%s/%s.%06d_p%06d.h5", io->par.outdir, io->par.basename,
-	  io->step, io->rank);
+          io->step, io->rank);
   if (strcmp(mode, "w") == 0) {
     hdf5->file = H5Fcreate(filename, H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT);
   } else if (strcmp(mode, "r") == 0) {
@@ -135,68 +143,88 @@ hdf5_open(struct mrc_io *io, const char *mode)
   }
 }
 
-static void
-hdf5_close(struct mrc_io *io) 
+static void hdf5_close(struct mrc_io* io)
 {
   herr_t ierr;
-  struct diag_hdf5 *hdf5 = diag_hdf5(io);
+  struct diag_hdf5* hdf5 = diag_hdf5(io);
 
   if (strcmp(hdf5->mode, "w") == 0) {
-    hid_t group = H5Gcreate(hdf5->file, "mrc_io", H5P_DEFAULT, H5P_DEFAULT,
-			    H5P_DEFAULT); H5_CHK(group);
-    ierr = H5LTset_attribute_int(group, ".", "step", &io->step, 1); CE;
-    ierr = H5LTset_attribute_float(group, ".", "time", &io->time, 1); CE;
-    ierr = H5Gclose(group); CE;
-  
-    group = H5Gcreate(hdf5->file, "mrc_info", H5P_DEFAULT, H5P_DEFAULT,
-		      H5P_DEFAULT); H5_CHK(group);
-    ierr = H5LTset_attribute_int(group, ".", "global_dims", hdf5->gdims, 3); CE;
-    
-    ierr = H5LTset_attribute_int(group, ".", "proc_rank", &io->rank, 1); CE;
+    hid_t group =
+      H5Gcreate(hdf5->file, "mrc_io", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
+    H5_CHK(group);
+    ierr = H5LTset_attribute_int(group, ".", "step", &io->step, 1);
+    CE;
+    ierr = H5LTset_attribute_float(group, ".", "time", &io->time, 1);
+    CE;
+    ierr = H5Gclose(group);
+    CE;
+
+    group =
+      H5Gcreate(hdf5->file, "mrc_info", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
+    H5_CHK(group);
+    ierr = H5LTset_attribute_int(group, ".", "global_dims", hdf5->gdims, 3);
+    CE;
+
+    ierr = H5LTset_attribute_int(group, ".", "proc_rank", &io->rank, 1);
+    CE;
     // put in the number of procs and global indices
     // Note that the nproc variables are the number of procs writing output,
-    // not the number of procs for the simulation.  
-    // Simlarly for the global_?_idx+{min,max}! 
-    
+    // not the number of procs for the simulation.
+    // Simlarly for the global_?_idx+{min,max}!
+
     int g_high[3];
     for (int d = 0; d < 3; d++) {
       g_high[d] = hdf5->off[d] + hdf5->ldims[d];
     }
-    ierr = H5LTset_attribute_int(group, ".", "nproc", hdf5->nr_procs, 3); CE;
-    ierr = H5LTset_attribute_int(group, ".", "global_idx_low", hdf5->off, 3); CE;
-    ierr = H5LTset_attribute_int(group, ".", "global_idx_high", g_high, 3); CE;
-    
-    ierr = H5Gclose(group); CE;
+    ierr = H5LTset_attribute_int(group, ".", "nproc", hdf5->nr_procs, 3);
+    CE;
+    ierr = H5LTset_attribute_int(group, ".", "global_idx_low", hdf5->off, 3);
+    CE;
+    ierr = H5LTset_attribute_int(group, ".", "global_idx_high", g_high, 3);
+    CE;
+
+    ierr = H5Gclose(group);
+    CE;
   }
-  ierr = H5Fclose(hdf5->file); CE;
+  ierr = H5Fclose(hdf5->file);
+  CE;
 }
 
-static void
-hdf5_write_field2d_serial(struct mrc_io *io, float scale, struct mrc_fld *fld,
-			  const char *path)
+static void hdf5_write_field2d_serial(struct mrc_io* io, float scale,
+                                      struct mrc_fld* fld, const char* path)
 {
   herr_t ierr;
-  struct diag_hdf5 *hdf5 = diag_hdf5(io);
+  struct diag_hdf5* hdf5 = diag_hdf5(io);
 
-  hsize_t fdims[2] = { fld->_dims.vals[1], fld->_dims.vals[0] };
+  hsize_t fdims[2] = {fld->_dims.vals[1], fld->_dims.vals[0]};
   //  printf("[%d] diagsrv: write '%s'\n", info->rank, fld_name);
 
-  hid_t group0 = H5Gopen(hdf5->file, path, H5P_DEFAULT); H5_CHK(group0);
-  hid_t group = H5Gcreate(group0, mrc_fld_comp_name(fld, 0), H5P_DEFAULT, H5P_DEFAULT,
-			  H5P_DEFAULT); H5_CHK(group);
+  hid_t group0 = H5Gopen(hdf5->file, path, H5P_DEFAULT);
+  H5_CHK(group0);
+  hid_t group = H5Gcreate(group0, mrc_fld_comp_name(fld, 0), H5P_DEFAULT,
+                          H5P_DEFAULT, H5P_DEFAULT);
+  H5_CHK(group);
   // FIXME H5lt
-  hid_t filespace = H5Screate_simple(2, fdims, NULL); H5_CHK(filespace);
+  hid_t filespace = H5Screate_simple(2, fdims, NULL);
+  H5_CHK(filespace);
   hid_t dataset = H5Dcreate(group, "2d", H5T_NATIVE_FLOAT, filespace,
-			    H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT); H5_CHK(dataset);
+                            H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
+  H5_CHK(dataset);
 
-  struct mrc_fld *f = mrc_fld_get_as(fld, "float");
-  ierr = H5Dwrite(dataset, H5T_NATIVE_FLOAT, H5S_ALL, H5S_ALL, H5P_DEFAULT, f->_nd->arr); CE;
+  struct mrc_fld* f = mrc_fld_get_as(fld, "float");
+  ierr = H5Dwrite(dataset, H5T_NATIVE_FLOAT, H5S_ALL, H5S_ALL, H5P_DEFAULT,
+                  f->_nd->arr);
+  CE;
   mrc_fld_put_as(f, fld);
 
-  ierr = H5Dclose(dataset); CE;
-  ierr = H5Sclose(filespace); CE;
-  ierr = H5Gclose(group); CE;
-  ierr = H5Gclose(group0); CE;
+  ierr = H5Dclose(dataset);
+  CE;
+  ierr = H5Sclose(filespace);
+  CE;
+  ierr = H5Gclose(group);
+  CE;
+  ierr = H5Gclose(group0);
+  CE;
 }
 
 // ======================================================================
@@ -207,34 +235,44 @@ hdf5_write_field2d_serial(struct mrc_io *io, float scale, struct mrc_fld *fld,
 //    description file describing the global topology
 // -- use diagsrv, so only one proc writes, but still create XDMF description
 
-static void
-xdmf_write_header(FILE *f)
+static void xdmf_write_header(FILE* f)
 {
   fprintf(f, "<?xml version='1.0' ?>\n");
-  fprintf(f, "<Xdmf xmlns:xi='http://www.w3.org/2001/XInclude' Version='2.0'>\n");
+  fprintf(f,
+          "<Xdmf xmlns:xi='http://www.w3.org/2001/XInclude' Version='2.0'>\n");
 }
 
-static void
-xdmf_write_topology_3d(FILE *f, int im[3], const char *filename, float sheet, int p)
+static void xdmf_write_topology_3d(FILE* f, int im[3], const char* filename,
+                                   float sheet, int p)
 {
-  fprintf(f, "     <Topology TopologyType=\"3DRectMesh\" Dimensions=\"%d %d %d\"/>\n",
-	  im[2] + 1, im[1] + 1, im[0] + 1);
+  fprintf(
+    f, "     <Topology TopologyType=\"3DRectMesh\" Dimensions=\"%d %d %d\"/>\n",
+    im[2] + 1, im[1] + 1, im[0] + 1);
   fprintf(f, "     <Geometry GeometryType=\"VXVYVZ\">\n");
-  fprintf(f, "     <DataItem Name=\"VX\" DataType=\"Float\" Dimensions=\"%d\" Format=\"HDF\">\n", im[0] + 1);
+  fprintf(f,
+          "     <DataItem Name=\"VX\" DataType=\"Float\" Dimensions=\"%d\" "
+          "Format=\"HDF\">\n",
+          im[0] + 1);
   if (p >= 0) {
     fprintf(f, "        ./%s:/crd/x-%d\n", filename, p);
   } else {
     fprintf(f, "        ./%s:/crd/x\n", filename);
   }
   fprintf(f, "     </DataItem>\n");
-  fprintf(f, "     <DataItem Name=\"VY\" DataType=\"Float\" Dimensions=\"%d\" Format=\"HDF\">\n", im[1] + 1);
+  fprintf(f,
+          "     <DataItem Name=\"VY\" DataType=\"Float\" Dimensions=\"%d\" "
+          "Format=\"HDF\">\n",
+          im[1] + 1);
   if (p >= 0) {
     fprintf(f, "        ./%s:/crd/y-%d\n", filename, p);
   } else {
     fprintf(f, "        ./%s:/crd/y\n", filename);
   }
   fprintf(f, "     </DataItem>\n");
-  fprintf(f, "     <DataItem Name=\"VZ\" DataType=\"Float\" Dimensions=\"%d\" Format=\"HDF\">\n", im[2] + 1);
+  fprintf(f,
+          "     <DataItem Name=\"VZ\" DataType=\"Float\" Dimensions=\"%d\" "
+          "Format=\"HDF\">\n",
+          im[2] + 1);
   if (p >= 0) {
     fprintf(f, "        ./%s:/crd/z-%d\n", filename, p);
   } else {
@@ -245,77 +283,103 @@ xdmf_write_topology_3d(FILE *f, int im[3], const char *filename, float sheet, in
   fprintf(f, "\n");
 }
 
-static void
-xdmf_write_topology_2d_x(FILE *f, int im[2], const char *filename, float sheet, int p)
+static void xdmf_write_topology_2d_x(FILE* f, int im[2], const char* filename,
+                                     float sheet, int p)
 {
-  fprintf(f, "     <Topology TopologyType=\"3DRectMesh\" Dimensions=\"%d %d %d\"/>\n",
-	  im[1] + 1, im[0] + 1, 2);
+  fprintf(
+    f, "     <Topology TopologyType=\"3DRectMesh\" Dimensions=\"%d %d %d\"/>\n",
+    im[1] + 1, im[0] + 1, 2);
   fprintf(f, "     <Geometry GeometryType=\"VXVYVZ\">\n");
-  fprintf(f, "     <DataItem Name=\"VX\" DataType=\"Float\" Dimensions=\"%d\">\n", 2);
+  fprintf(
+    f, "     <DataItem Name=\"VX\" DataType=\"Float\" Dimensions=\"%d\">\n", 2);
   fprintf(f, "        %g %g\n", sheet - .01, sheet + .01);
   fprintf(f, "     </DataItem>\n");
-  fprintf(f, "     <DataItem Name=\"VY\" DataType=\"Float\" Dimensions=\"%d\" Format=\"HDF\">\n", im[0] + 1);
+  fprintf(f,
+          "     <DataItem Name=\"VY\" DataType=\"Float\" Dimensions=\"%d\" "
+          "Format=\"HDF\">\n",
+          im[0] + 1);
   fprintf(f, "        ./%s:/crd/y\n", filename);
   fprintf(f, "     </DataItem>\n");
-  fprintf(f, "     <DataItem Name=\"VZ\" DataType=\"Float\" Dimensions=\"%d\" Format=\"HDF\">\n", im[1] + 1);
+  fprintf(f,
+          "     <DataItem Name=\"VZ\" DataType=\"Float\" Dimensions=\"%d\" "
+          "Format=\"HDF\">\n",
+          im[1] + 1);
   fprintf(f, "        ./%s:/crd/z\n", filename);
   fprintf(f, "     </DataItem>\n");
   fprintf(f, "     </Geometry>\n");
   fprintf(f, "\n");
 }
 
-static void
-xdmf_write_topology_2d_y(FILE *f, int im[2], const char *filename, float sheet, int p)
+static void xdmf_write_topology_2d_y(FILE* f, int im[2], const char* filename,
+                                     float sheet, int p)
 {
-  fprintf(f, "     <Topology TopologyType=\"3DRectMesh\" Dimensions=\"%d %d %d\"/>\n",
-	  im[1] + 1, 2, im[0] + 1);
+  fprintf(
+    f, "     <Topology TopologyType=\"3DRectMesh\" Dimensions=\"%d %d %d\"/>\n",
+    im[1] + 1, 2, im[0] + 1);
   fprintf(f, "     <Geometry GeometryType=\"VXVYVZ\">\n");
-  fprintf(f, "     <DataItem Name=\"VX\" DataType=\"Float\" Dimensions=\"%d\" Format=\"HDF\">\n", im[0] + 1);
+  fprintf(f,
+          "     <DataItem Name=\"VX\" DataType=\"Float\" Dimensions=\"%d\" "
+          "Format=\"HDF\">\n",
+          im[0] + 1);
   fprintf(f, "        ./%s:/crd/x\n", filename);
   fprintf(f, "     </DataItem>\n");
-  fprintf(f, "     <DataItem Name=\"VY\" DataType=\"Float\" Dimensions=\"%d\">\n", 2);
+  fprintf(
+    f, "     <DataItem Name=\"VY\" DataType=\"Float\" Dimensions=\"%d\">\n", 2);
   fprintf(f, "        %g %g\n", sheet - .01, sheet + .01);
   fprintf(f, "     </DataItem>\n");
-  fprintf(f, "     <DataItem Name=\"VZ\" DataType=\"Float\" Dimensions=\"%d\" Format=\"HDF\">\n", im[1] + 1);
+  fprintf(f,
+          "     <DataItem Name=\"VZ\" DataType=\"Float\" Dimensions=\"%d\" "
+          "Format=\"HDF\">\n",
+          im[1] + 1);
   fprintf(f, "        ./%s:/crd/z\n", filename);
   fprintf(f, "     </DataItem>\n");
   fprintf(f, "     </Geometry>\n");
   fprintf(f, "\n");
 }
 
-static void
-xdmf_write_topology_2d_z(FILE *f, int im[2], const char *filename, float sheet, int p)
+static void xdmf_write_topology_2d_z(FILE* f, int im[2], const char* filename,
+                                     float sheet, int p)
 {
-  fprintf(f, "     <Topology TopologyType=\"3DRectMesh\" Dimensions=\"%d %d %d\"/>\n",
-	  2, im[1] + 1, im[0] + 1);
+  fprintf(
+    f, "     <Topology TopologyType=\"3DRectMesh\" Dimensions=\"%d %d %d\"/>\n",
+    2, im[1] + 1, im[0] + 1);
   fprintf(f, "     <Geometry GeometryType=\"VXVYVZ\">\n");
-  fprintf(f, "     <DataItem Name=\"VX\" DataType=\"Float\" Dimensions=\"%d\" Format=\"HDF\">\n", im[0] + 1);
+  fprintf(f,
+          "     <DataItem Name=\"VX\" DataType=\"Float\" Dimensions=\"%d\" "
+          "Format=\"HDF\">\n",
+          im[0] + 1);
   fprintf(f, "        ./%s:/crd/x\n", filename);
   fprintf(f, "     </DataItem>\n");
-  fprintf(f, "     <DataItem Name=\"VY\" DataType=\"Float\" Dimensions=\"%d\" Format=\"HDF\">\n", im[1] + 1);
+  fprintf(f,
+          "     <DataItem Name=\"VY\" DataType=\"Float\" Dimensions=\"%d\" "
+          "Format=\"HDF\">\n",
+          im[1] + 1);
   fprintf(f, "        ./%s:/crd/y\n", filename);
   fprintf(f, "     </DataItem>\n");
-  fprintf(f, "     <DataItem Name=\"VZ\" DataType=\"Float\" Dimensions=\"%d\">\n", 2);
+  fprintf(
+    f, "     <DataItem Name=\"VZ\" DataType=\"Float\" Dimensions=\"%d\">\n", 2);
   fprintf(f, "        %g %g\n", sheet - .01, sheet + .01);
   fprintf(f, "     </DataItem>\n");
   fprintf(f, "     </Geometry>\n");
   fprintf(f, "\n");
 }
 
-static void
-xdmf_write_topology_iono(FILE *f, int im[2], const char *filename, float sheet, int p)
+static void xdmf_write_topology_iono(FILE* f, int im[2], const char* filename,
+                                     float sheet, int p)
 {
-  fprintf(f, "     <Topology TopologyType=\"2DSMesh\" Dimensions=\"%d %d\"/>\n", im[1], im[0]);
+  fprintf(f, "     <Topology TopologyType=\"2DSMesh\" Dimensions=\"%d %d\"/>\n",
+          im[1], im[0]);
   fprintf(f, "     <Geometry GeometryType=\"XYZ\">\n");
-  fprintf(f, "       <DataItem Format=\"XML\" Dimensions=\"%d %d 3\">\n", im[1], im[0]);
+  fprintf(f, "       <DataItem Format=\"XML\" Dimensions=\"%d %d 3\">\n", im[1],
+          im[0]);
   // FIXME, write to HDF5
-  float dphi = 2.*M_PI / (im[0] - 1);
+  float dphi = 2. * M_PI / (im[0] - 1);
   float dtheta = M_PI / (im[1] - 1);
   for (int itheta = 0; itheta < im[1]; itheta++) {
     for (int iphi = 0; iphi < im[0]; iphi++) {
       double phi = iphi * dphi, theta = itheta * dtheta;
-      fprintf(f, "        %g %g %g\n", cos(phi)*sin(theta), sin(phi)*sin(theta),cos(theta)
-);
+      fprintf(f, "        %g %g %g\n", cos(phi) * sin(theta),
+              sin(phi) * sin(theta), cos(theta));
     }
   }
   fprintf(f, "       </DataItem>\n");
@@ -323,95 +387,122 @@ xdmf_write_topology_iono(FILE *f, int im[2], const char *filename, float sheet, 
   fprintf(f, "\n");
 }
 
-static void
-xdmf_write_fld_2d_iono(FILE *f, struct fld_info *fld_info, int im[2], const char *filename)
+static void xdmf_write_fld_2d_iono(FILE* f, struct fld_info* fld_info,
+                                   int im[2], const char* filename)
 {
-  fprintf(f, "     <Attribute Name=\"%s\" AttributeType=\"Scalar\" Center=\"Node\">\n",
-	  fld_info->name);
-  fprintf(f, "       <DataItem Dimensions=\"%d %d\" NumberType=\"Float\" Precision=\"4\" Format=\"HDF\">\n",
-	  im[1], im[0]);
-  fprintf(f, "        %s:/%s/%s/2d\n", filename, fld_info->path, fld_info->name);
+  fprintf(
+    f,
+    "     <Attribute Name=\"%s\" AttributeType=\"Scalar\" Center=\"Node\">\n",
+    fld_info->name);
+  fprintf(f,
+          "       <DataItem Dimensions=\"%d %d\" NumberType=\"Float\" "
+          "Precision=\"4\" Format=\"HDF\">\n",
+          im[1], im[0]);
+  fprintf(f, "        %s:/%s/%s/2d\n", filename, fld_info->path,
+          fld_info->name);
   fprintf(f, "       </DataItem>\n");
   fprintf(f, "     </Attribute>\n");
 }
 
-static void
-xdmf_write_fld_2d_x(FILE *f, struct fld_info *fld_info, int im[2], const char *filename)
+static void xdmf_write_fld_2d_x(FILE* f, struct fld_info* fld_info, int im[2],
+                                const char* filename)
 {
-  fprintf(f, "     <Attribute Name=\"%s\" AttributeType=\"Scalar\" Center=\"Cell\">\n",
-	  fld_info->name);
-  fprintf(f, "       <DataItem Dimensions=\"1 %d %d\" NumberType=\"Float\" Precision=\"4\" Format=\"HDF\">\n",
-	  im[1], im[0]);
-  fprintf(f, "        %s:/%s/%s/2d\n", filename, fld_info->path, fld_info->name);
+  fprintf(
+    f,
+    "     <Attribute Name=\"%s\" AttributeType=\"Scalar\" Center=\"Cell\">\n",
+    fld_info->name);
+  fprintf(f,
+          "       <DataItem Dimensions=\"1 %d %d\" NumberType=\"Float\" "
+          "Precision=\"4\" Format=\"HDF\">\n",
+          im[1], im[0]);
+  fprintf(f, "        %s:/%s/%s/2d\n", filename, fld_info->path,
+          fld_info->name);
   fprintf(f, "       </DataItem>\n");
   fprintf(f, "     </Attribute>\n");
 }
 
-static void
-xdmf_write_fld_2d_y(FILE *f, struct fld_info *fld_info, int im[2], const char *filename)
+static void xdmf_write_fld_2d_y(FILE* f, struct fld_info* fld_info, int im[2],
+                                const char* filename)
 {
-  fprintf(f, "     <Attribute Name=\"%s\" AttributeType=\"Scalar\" Center=\"Cell\">\n",
-	  fld_info->name);
-  fprintf(f, "       <DataItem Dimensions=\"%d 1 %d\" NumberType=\"Float\" Precision=\"4\" Format=\"HDF\">\n",
-	  im[1], im[0]);
-  fprintf(f, "        %s:/%s/%s/2d\n", filename, fld_info->path, fld_info->name);
+  fprintf(
+    f,
+    "     <Attribute Name=\"%s\" AttributeType=\"Scalar\" Center=\"Cell\">\n",
+    fld_info->name);
+  fprintf(f,
+          "       <DataItem Dimensions=\"%d 1 %d\" NumberType=\"Float\" "
+          "Precision=\"4\" Format=\"HDF\">\n",
+          im[1], im[0]);
+  fprintf(f, "        %s:/%s/%s/2d\n", filename, fld_info->path,
+          fld_info->name);
   fprintf(f, "       </DataItem>\n");
   fprintf(f, "     </Attribute>\n");
 }
 
-static void
-xdmf_write_fld_2d_z(FILE *f, struct fld_info *fld_info, int im[2], const char *filename)
+static void xdmf_write_fld_2d_z(FILE* f, struct fld_info* fld_info, int im[2],
+                                const char* filename)
 {
-  fprintf(f, "     <Attribute Name=\"%s\" AttributeType=\"Scalar\" Center=\"Cell\">\n",
-	  fld_info->name);
-  fprintf(f, "       <DataItem Dimensions=\"%d %d 1\" NumberType=\"Float\" Precision=\"4\" Format=\"HDF\">\n",
-	  im[1], im[0]);
-  fprintf(f, "        %s:/%s/%s/2d\n", filename, fld_info->path, fld_info->name);
+  fprintf(
+    f,
+    "     <Attribute Name=\"%s\" AttributeType=\"Scalar\" Center=\"Cell\">\n",
+    fld_info->name);
+  fprintf(f,
+          "       <DataItem Dimensions=\"%d %d 1\" NumberType=\"Float\" "
+          "Precision=\"4\" Format=\"HDF\">\n",
+          im[1], im[0]);
+  fprintf(f, "        %s:/%s/%s/2d\n", filename, fld_info->path,
+          fld_info->name);
   fprintf(f, "       </DataItem>\n");
   fprintf(f, "     </Attribute>\n");
 }
 
-static void
-xdmf_write_fld_3d(FILE *f, struct fld_info *fld_info, int im[3], const char *filename)
+static void xdmf_write_fld_3d(FILE* f, struct fld_info* fld_info, int im[3],
+                              const char* filename)
 {
-  fprintf(f, "     <Attribute Name=\"%s\" AttributeType=\"%s\" Center=\"Cell\">\n",
-	  fld_info->name, fld_info->is_vec ? "Vector" : "Scalar");
-  fprintf(f, "       <DataItem Dimensions=\"%d %d %d%s\" NumberType=\"Float\" Precision=\"4\" Format=\"HDF\">\n",
-	  im[2], im[1], im[0], fld_info->is_vec ? " 3" : "");
-  fprintf(f, "        %s:/%s/%s/3d\n", filename, fld_info->path, fld_info->name);
+  fprintf(f,
+          "     <Attribute Name=\"%s\" AttributeType=\"%s\" Center=\"Cell\">\n",
+          fld_info->name, fld_info->is_vec ? "Vector" : "Scalar");
+  fprintf(f,
+          "       <DataItem Dimensions=\"%d %d %d%s\" NumberType=\"Float\" "
+          "Precision=\"4\" Format=\"HDF\">\n",
+          im[2], im[1], im[0], fld_info->is_vec ? " 3" : "");
+  fprintf(f, "        %s:/%s/%s/3d\n", filename, fld_info->path,
+          fld_info->name);
   fprintf(f, "       </DataItem>\n");
   fprintf(f, "     </Attribute>\n");
 }
 
-static struct xdmf_spatial *
-xdmf_spatial_create(struct mrc_io *io, const char *sfx, float sheet, int p, int nr_subdomains,
-		    struct xdmf_subdomain *subdomains, int size,
-		    void (*write_topology)(FILE *f, int im[3], const char *filename, float sheet, int p),
-		    void (*write_fld)(FILE *f, struct fld_info *fld_info, int im[3],
-				      const char *filename))
+static struct xdmf_spatial* xdmf_spatial_create(
+  struct mrc_io* io, const char* sfx, float sheet, int p, int nr_subdomains,
+  struct xdmf_subdomain* subdomains, int size,
+  void (*write_topology)(FILE* f, int im[3], const char* filename, float sheet,
+                         int p),
+  void (*write_fld)(FILE* f, struct fld_info* fld_info, int im[3],
+                    const char* filename))
 {
-  struct diag_hdf5 *hdf5 = diag_hdf5(io);
-  struct xdmf_spatial *xs = malloc(sizeof(*xs));
+  struct diag_hdf5* hdf5 = diag_hdf5(io);
+  struct xdmf_spatial* xs = malloc(sizeof(*xs));
   memset(xs, 0, sizeof(*xs));
-  xs->sfx            = strdup(sfx);
-  xs->sheet          = sheet;
-  xs->p              = p;
-  xs->nr_subdomains  = nr_subdomains;
-  xs->subdomains     = subdomains;
+  xs->sfx = strdup(sfx);
+  xs->sheet = sheet;
+  xs->p = p;
+  xs->nr_subdomains = nr_subdomains;
+  xs->subdomains = subdomains;
   xs->write_topology = write_topology;
-  xs->write_fld      = write_fld;
-  
+  xs->write_fld = write_fld;
+
   list_add_tail(&xs->entry, &hdf5->xdmf_spatial_list);
 
   return xs;
 }
 
-static struct xdmf_spatial *
-xdmf_spatial_find(struct mrc_io *io, const char *sfx, float sheet)
+static struct xdmf_spatial* xdmf_spatial_find(struct mrc_io* io,
+                                              const char* sfx, float sheet)
 {
-  struct diag_hdf5 *hdf5 = diag_hdf5(io);
-  struct xdmf_spatial *xs;
-  __list_for_each_entry(xs, &hdf5->xdmf_spatial_list, entry, struct xdmf_spatial) {
+  struct diag_hdf5* hdf5 = diag_hdf5(io);
+  struct xdmf_spatial* xs;
+  __list_for_each_entry(xs, &hdf5->xdmf_spatial_list, entry,
+                        struct xdmf_spatial)
+  {
     if (xs->sheet == sheet && strcmp(xs->sfx, sfx) == 0) {
       return xs;
     }
@@ -419,8 +510,7 @@ xdmf_spatial_find(struct mrc_io *io, const char *sfx, float sheet)
   return NULL;
 }
 
-static void
-xdmf_spatial_destroy(struct xdmf_spatial *xs)
+static void xdmf_spatial_destroy(struct xdmf_spatial* xs)
 {
   list_del(&xs->entry);
 
@@ -433,27 +523,30 @@ xdmf_spatial_destroy(struct xdmf_spatial *xs)
   free(xs);
 }
 
-static void
-xdmf_write_spatial_collection(struct mrc_io *io, struct xdmf_spatial *xs, const char *filename)
+static void xdmf_write_spatial_collection(struct mrc_io* io,
+                                          struct xdmf_spatial* xs,
+                                          const char* filename)
 {
   if (io->rank > 0)
     return;
 
   mprintf("diag: writing '%s'\n", filename);
 
-  FILE *f = fopen(filename, "w");
+  FILE* f = fopen(filename, "w");
   xdmf_write_header(f);
   fprintf(f, "<Domain>\n");
   fprintf(f, "<Grid GridType=\"Collection\" CollectionType=\"Spatial\">\n");
   fprintf(f, "   <Time Type=\"Single\" Value=\"%g\" />\n", io->time);
   for (int s = 0; s < xs->nr_subdomains; s++) {
-    fprintf(f, "   <Grid Name=\"mesh-%s-%d\" GridType=\"Uniform\">\n", xs->sfx, s);
-    
+    fprintf(f, "   <Grid Name=\"mesh-%s-%d\" GridType=\"Uniform\">\n", xs->sfx,
+            s);
+
     char fname[strlen(io->par.outdir) + strlen(io->par.basename) + 20];
-    sprintf(fname, "%s/%s.%06d_p%06d.h5", io->par.outdir, io->par.basename, io->step, s);
-    int *im = xs->subdomains[s].im;
+    sprintf(fname, "%s/%s.%06d_p%06d.h5", io->par.outdir, io->par.basename,
+            io->step, s);
+    int* im = xs->subdomains[s].im;
     xs->write_topology(f, im, fname, xs->sheet, xs->p);
-    
+
     for (int m = 0; m < xs->nr_fld_info; m++) {
       xs->write_fld(f, &xs->fld_info[m], im, fname);
     }
@@ -465,20 +558,18 @@ xdmf_write_spatial_collection(struct mrc_io *io, struct xdmf_spatial *xs, const 
   fclose(f);
 }
 
-static struct xdmf_temporal *
-xdmf_temporal_create(const char *filename)
+static struct xdmf_temporal* xdmf_temporal_create(const char* filename)
 {
-  struct xdmf_temporal *xt = calloc(1, sizeof(*xt));
+  struct xdmf_temporal* xt = calloc(1, sizeof(*xt));
   INIT_LIST_HEAD(&xt->timesteps);
   xt->filename = strdup(filename);
   return xt;
 }
 
-static void
-xdmf_temporal_destroy(struct xdmf_temporal *xt)
+static void xdmf_temporal_destroy(struct xdmf_temporal* xt)
 {
   while (!list_empty(&xt->timesteps)) {
-    struct xdmf_temporal_step *xt_step =
+    struct xdmf_temporal_step* xt_step =
       list_entry(xt->timesteps.next, struct xdmf_temporal_step, entry);
     list_del(&xt_step->entry);
     free(xt_step);
@@ -487,17 +578,16 @@ xdmf_temporal_destroy(struct xdmf_temporal *xt)
   free(xt);
 }
 
-static void
-xdmf_temporal_append(struct xdmf_temporal *xt, const char *fname_spatial)
+static void xdmf_temporal_append(struct xdmf_temporal* xt,
+                                 const char* fname_spatial)
 {
-  struct xdmf_temporal_step *xt_step =
+  struct xdmf_temporal_step* xt_step =
     malloc(sizeof(*xt_step) + strlen(fname_spatial) + 1);
   strcpy(xt_step->filename, fname_spatial);
   list_add_tail(&xt_step->entry, &xt->timesteps);
 }
 
-static void
-xdmf_temporal_write(struct xdmf_temporal *xt)
+static void xdmf_temporal_write(struct xdmf_temporal* xt)
 {
   // It'd be easier to create those files line by line as time goes by.
   // However, then we won't be able to get the timeseries into Paraview
@@ -506,15 +596,18 @@ xdmf_temporal_write(struct xdmf_temporal *xt)
   // which needs however some way to figure out what times we've written
   // before.
 
-  FILE *f = fopen(xt->filename, "w");
+  FILE* f = fopen(xt->filename, "w");
 
   xdmf_write_header(f);
   fprintf(f, "<Domain>\n");
   fprintf(f, "  <Grid GridType='Collection' CollectionType='Temporal'>\n");
-  struct xdmf_temporal_step *xt_step;
-  __list_for_each_entry(xt_step, &xt->timesteps, entry, struct xdmf_temporal_step) {
-    fprintf(f, "  <xi:include href='%s' xpointer='xpointer(//Xdmf/Domain/Grid)'/>\n",
-	    xt_step->filename);
+  struct xdmf_temporal_step* xt_step;
+  __list_for_each_entry(xt_step, &xt->timesteps, entry,
+                        struct xdmf_temporal_step)
+  {
+    fprintf(
+      f, "  <xi:include href='%s' xpointer='xpointer(//Xdmf/Domain/Grid)'/>\n",
+      xt_step->filename);
   }
   fprintf(f, "  </Grid>\n");
   fprintf(f, "  </Domain>\n");
@@ -522,17 +615,17 @@ xdmf_temporal_write(struct xdmf_temporal *xt)
   fclose(f);
 }
 
-static void
-xdmf_open(struct mrc_io *io, const char *mode) 
+static void xdmf_open(struct mrc_io* io, const char* mode)
 {
-  struct diag_hdf5 *hdf5 = diag_hdf5(io);
+  struct diag_hdf5* hdf5 = diag_hdf5(io);
 
   hdf5->mode = strdup(mode);
   hdf5_open(io, mode);
 
   if (strcmp(mode, "w") == 0) {
-    hdf5->group_crd = H5Gcreate(hdf5->file, "crd", H5P_DEFAULT, H5P_DEFAULT,
-				H5P_DEFAULT); H5_CHK(hdf5->group_crd);
+    hdf5->group_crd =
+      H5Gcreate(hdf5->file, "crd", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
+    H5_CHK(hdf5->group_crd);
   }
   for (int d = 0; d < 3; d++) {
     hdf5->crd_written[d] = false;
@@ -541,20 +634,21 @@ xdmf_open(struct mrc_io *io, const char *mode)
   INIT_LIST_HEAD(&hdf5->xdmf_spatial_list);
 }
 
-static void
-xdmf_close(struct mrc_io *io)
+static void xdmf_close(struct mrc_io* io)
 {
-  struct diag_hdf5 *hdf5 = diag_hdf5(io);
+  struct diag_hdf5* hdf5 = diag_hdf5(io);
   while (!list_empty(&hdf5->xdmf_spatial_list)) {
-    struct xdmf_spatial *xs = list_entry(hdf5->xdmf_spatial_list.next, struct xdmf_spatial, entry);
-    
+    struct xdmf_spatial* xs =
+      list_entry(hdf5->xdmf_spatial_list.next, struct xdmf_spatial, entry);
+
     char fname_spatial[strlen(io->par.outdir) + strlen(io->par.basename) + 20];
-    sprintf(fname_spatial, "%s/%s.%06d.xdmf", io->par.outdir, io->par.basename, io->step);
+    sprintf(fname_spatial, "%s/%s.%06d.xdmf", io->par.outdir, io->par.basename,
+            io->step);
     xdmf_write_spatial_collection(io, xs, fname_spatial); // FIXME, rm dir part
     xdmf_spatial_destroy(xs);
 
     if (io->rank == 0) {
-      struct xdmf_temporal *xt = hdf5->xdmf_temporal;
+      struct xdmf_temporal* xt = hdf5->xdmf_temporal;
       xdmf_temporal_append(xt, fname_spatial);
       xdmf_temporal_write(xt);
     }
@@ -562,43 +656,40 @@ xdmf_close(struct mrc_io *io)
   free(hdf5->mode);
 }
 
-static void
-ds_xdmf_setup(struct mrc_io *io)
+static void ds_xdmf_setup(struct mrc_io* io)
 {
   mrc_io_setup_super(io);
 
-  struct diag_hdf5 *hdf5 = diag_hdf5(io);
+  struct diag_hdf5* hdf5 = diag_hdf5(io);
   char filename[strlen(io->par.outdir) + strlen(io->par.basename) + 7];
   sprintf(filename, "%s/%s.xdmf", io->par.outdir, io->par.basename);
   hdf5->xdmf_temporal = xdmf_temporal_create(filename);
 }
 
-static void
-ds_xdmf_destroy(struct mrc_io *io)
+static void ds_xdmf_destroy(struct mrc_io* io)
 {
-  struct diag_hdf5 *hdf5 = diag_hdf5(io);
+  struct diag_hdf5* hdf5 = diag_hdf5(io);
 
   if (hdf5->xdmf_temporal) {
     xdmf_temporal_destroy(hdf5->xdmf_temporal);
   }
 }
 
-static void
-ds_xdmf_open(struct mrc_io *io, const char *mode) 
+static void ds_xdmf_open(struct mrc_io* io, const char* mode)
 {
   xdmf_open(io, mode);
 }
 
-static void
-hdf5_write_crds(struct mrc_io *io, const int im[3], struct mrc_domain *domain, int sw)
+static void hdf5_write_crds(struct mrc_io* io, const int im[3],
+                            struct mrc_domain* domain, int sw)
 {
-  struct diag_hdf5 *hdf5 = diag_hdf5(io);
+  struct diag_hdf5* hdf5 = diag_hdf5(io);
 
   if (!hdf5->gdims[0]) {
     mrc_domain_get_global_dims(domain, hdf5->gdims);
     mrc_domain_get_nr_procs(domain, hdf5->nr_procs);
     int nr_patches;
-    struct mrc_patch *patches = mrc_domain_get_patches(domain, &nr_patches);
+    struct mrc_patch* patches = mrc_domain_get_patches(domain, &nr_patches);
     assert(nr_patches == 1);
     for (int d = 0; d < 3; d++) {
       hdf5->off[d] = patches[0].off[d];
@@ -606,26 +697,26 @@ hdf5_write_crds(struct mrc_io *io, const int im[3], struct mrc_domain *domain, i
     }
   }
 
-  const char *xyz[3] = { "x", "y", "z" };
-  
-  struct mrc_crds *crds = mrc_domain_get_crds(domain);
+  const char* xyz[3] = {"x", "y", "z"};
+
+  struct mrc_crds* crds = mrc_domain_get_crds(domain);
   for (int d = 0; d < 3; d++) {
     if (im[d] == 0 || hdf5->crd_written[d])
       continue;
 
-    float *crd = &MRC_CRD(crds, d, 0);
-    float *crd_nc = calloc(im[d] + 1, sizeof(*crd_nc));
+    float* crd = &MRC_CRD(crds, d, 0);
+    float* crd_nc = calloc(im[d] + 1, sizeof(*crd_nc));
     if (sw > 0) {
       for (int i = 0; i <= im[d]; i++) {
-	crd_nc[i] = .5 * (crd[i-1] + crd[i]);
+        crd_nc[i] = .5 * (crd[i - 1] + crd[i]);
       }
     } else {
       for (int i = 1; i < im[d]; i++) {
-	crd_nc[i] = .5 * (crd[i-1] + crd[i]);
+        crd_nc[i] = .5 * (crd[i - 1] + crd[i]);
       }
       // extrapolate
-      crd_nc[0]  = crd[0] - .5 * (crd[1] - crd[0]);
-      crd_nc[im[d]] = crd[im[d]-1] + .5 * (crd[im[d]-1] - crd[im[d]-2]);
+      crd_nc[0] = crd[0] - .5 * (crd[1] - crd[0]);
+      crd_nc[im[d]] = crd[im[d] - 1] + .5 * (crd[im[d] - 1] - crd[im[d] - 2]);
     }
     hsize_t im1 = im[d] + 1;
     H5LTmake_dataset_float(hdf5->group_crd, xyz[d], 1, &im1, crd_nc);
@@ -634,15 +725,15 @@ hdf5_write_crds(struct mrc_io *io, const int im[3], struct mrc_domain *domain, i
   }
 }
 
-static void
-hdf5_write_mcrds(struct mrc_io *io, struct mrc_domain *domain, int bnd)
+static void hdf5_write_mcrds(struct mrc_io* io, struct mrc_domain* domain,
+                             int bnd)
 {
-  struct diag_hdf5 *hdf5 = diag_hdf5(io);
+  struct diag_hdf5* hdf5 = diag_hdf5(io);
 
   if (!hdf5->gdims[0]) {
     mrc_domain_get_global_dims(domain, hdf5->gdims);
     int nr_patches;
-    struct mrc_patch *patches = mrc_domain_get_patches(domain, &nr_patches);
+    struct mrc_patch* patches = mrc_domain_get_patches(domain, &nr_patches);
     assert(nr_patches == 1);
     for (int d = 0; d < 3; d++) {
       hdf5->off[d] = patches[0].off[d];
@@ -650,32 +741,36 @@ hdf5_write_mcrds(struct mrc_io *io, struct mrc_domain *domain, int bnd)
     }
   }
 
-  
-  struct mrc_crds *crds = mrc_domain_get_crds(domain);
+  struct mrc_crds* crds = mrc_domain_get_crds(domain);
   for (int d = 0; d < 3; d++) {
     if (hdf5->crd_written[d])
       continue;
 
-    struct mrc_fld *mcrd = crds->crd[d];
-    mrc_m1_foreach_patch(mcrd, p) {
+    struct mrc_fld* mcrd = crds->crd[d];
+    mrc_m1_foreach_patch(mcrd, p)
+    {
       int im = mrc_fld_dims(mcrd)[0];
       int is = mrc_fld_ghost_offs(mcrd)[0];
-      float *crd_nc = calloc(im + 2*bnd + 1, sizeof(*crd_nc));
+      float* crd_nc = calloc(im + 2 * bnd + 1, sizeof(*crd_nc));
       crd_nc += bnd;
       if (-is > bnd) {
-	for (int i = -bnd; i <= bnd + im; i++) {
-	  crd_nc[i] = .5 * (MRC_M1(mcrd,0, i -1, p) + MRC_M1(mcrd,0, i, p));
-	}
+        for (int i = -bnd; i <= bnd + im; i++) {
+          crd_nc[i] = .5 * (MRC_M1(mcrd, 0, i - 1, p) + MRC_M1(mcrd, 0, i, p));
+        }
       } else {
-	for (int i = -bnd + 1; i < bnd + im; i++) {
-	  crd_nc[i] = .5 * (MRC_M1(mcrd,0, i-1, p) + MRC_M1(mcrd,0, i, p));
-	}
-	// extrapolate
-	crd_nc[-bnd]   = MRC_M1(mcrd,0, -bnd    , p) - .5 * (MRC_M1(mcrd,0, -bnd+1  , p) - MRC_M1(mcrd,0, -bnd    , p));
-	crd_nc[im+bnd] = MRC_M1(mcrd,0, im+bnd-1, p) + .5 * (MRC_M1(mcrd,0, im+bnd-1, p) - MRC_M1(mcrd,0, im+bnd-2, p));
+        for (int i = -bnd + 1; i < bnd + im; i++) {
+          crd_nc[i] = .5 * (MRC_M1(mcrd, 0, i - 1, p) + MRC_M1(mcrd, 0, i, p));
+        }
+        // extrapolate
+        crd_nc[-bnd] =
+          MRC_M1(mcrd, 0, -bnd, p) -
+          .5 * (MRC_M1(mcrd, 0, -bnd + 1, p) - MRC_M1(mcrd, 0, -bnd, p));
+        crd_nc[im + bnd] = MRC_M1(mcrd, 0, im + bnd - 1, p) +
+                           .5 * (MRC_M1(mcrd, 0, im + bnd - 1, p) -
+                                 MRC_M1(mcrd, 0, im + bnd - 2, p));
       }
       crd_nc -= bnd;
-      hsize_t im1 = im + 2*bnd + 1;
+      hsize_t im1 = im + 2 * bnd + 1;
       char name[20];
       sprintf(name, "%c-%d", 'x' + d, p);
       H5LTmake_dataset_float(hdf5->group_crd, name, 1, &im1, crd_nc);
@@ -686,338 +781,398 @@ hdf5_write_mcrds(struct mrc_io *io, struct mrc_domain *domain, int bnd)
   }
 }
 
-static void
-ds_xdmf_close(struct mrc_io *io)
+static void ds_xdmf_close(struct mrc_io* io)
 {
-  struct diag_hdf5 *hdf5 = diag_hdf5(io);
+  struct diag_hdf5* hdf5 = diag_hdf5(io);
   herr_t ierr;
 
   if (strcmp(hdf5->mode, "w") == 0) {
-    ierr = H5Gclose(hdf5->group_crd); CE;
+    ierr = H5Gclose(hdf5->group_crd);
+    CE;
   }
   hdf5_close(io);
   xdmf_close(io);
 }
 
-static void
-ds_xdmf_read_attr(struct mrc_io *io, const char *path, int type,
-		  const char *name, union param_u *pv)
+static void ds_xdmf_read_attr(struct mrc_io* io, const char* path, int type,
+                              const char* name, union param_u* pv)
 {
-  struct diag_hdf5 *hdf5 = diag_hdf5(io);
+  struct diag_hdf5* hdf5 = diag_hdf5(io);
   herr_t ierr;
 
-  hid_t group = H5Gopen(hdf5->file, path, H5P_DEFAULT); H5_CHK(group);
+  hid_t group = H5Gopen(hdf5->file, path, H5P_DEFAULT);
+  H5_CHK(group);
   switch (type) {
-  case PT_SELECT:
-  case PT_INT:
-  case MRC_VAR_INT:
-    ierr = H5LTget_attribute_int(group, ".", name, &pv->u_int); CE;
-    break;
-  case PT_BOOL:
-  case MRC_VAR_BOOL: {
-    int val;
-    ierr = H5LTget_attribute_int(group, ".", name, &val); CE;
-    pv->u_bool = val;
-    break;
-  }
-  case PT_FLOAT:
-  case MRC_VAR_FLOAT:
-    ierr = H5LTget_attribute_float(group, ".", name, &pv->u_float); CE;
-    break;
-  case PT_DOUBLE:
-  case MRC_VAR_DOUBLE:
-    ierr = H5LTget_attribute_double(group, ".", name, &pv->u_double); CE;
-    break;
-  case PT_STRING: ;
-    hsize_t dims;
-    H5T_class_t class;
-    size_t sz;
-    ierr = H5LTget_attribute_info(group, ".", name, &dims, &class, &sz); CE;
-    char *s = malloc(sz);
-    ierr = H5LTget_attribute_string(group, ".", name, s); CE;
-    if (strcmp(s, "(NULL)") == 0) {
-      free(s);
-      s = NULL;
+    case PT_SELECT:
+    case PT_INT:
+    case MRC_VAR_INT:
+      ierr = H5LTget_attribute_int(group, ".", name, &pv->u_int);
+      CE;
+      break;
+    case PT_BOOL:
+    case MRC_VAR_BOOL: {
+      int val;
+      ierr = H5LTget_attribute_int(group, ".", name, &val);
+      CE;
+      pv->u_bool = val;
+      break;
     }
-    pv->u_string = s;
-    break;
-  case PT_INT3:
-    ierr = H5LTget_attribute_int(group, ".", name, pv->u_int3); CE;
-    break;
-  case PT_FLOAT3:
-    ierr = H5LTget_attribute_float(group, ".", name, pv->u_float3); CE;
-    break;
-  case PT_DOUBLE3:
-  case MRC_VAR_DOUBLE3:
-    ierr = H5LTget_attribute_double(group, ".", name, pv->u_double3); CE;
-    break;
-  case PT_INT_ARRAY: {
-    hid_t attr = H5Aopen(group, name, H5P_DEFAULT); H5_CHK(attr);
-    H5A_info_t ainfo;
-    ierr = H5Aget_info(attr, &ainfo); CE;
-    ierr = H5Aclose(attr); CE;
-    pv->u_int_array.nr_vals = ainfo.data_size / sizeof(int);
-    pv->u_int_array.vals = calloc(pv->u_int_array.nr_vals, sizeof(int));
-    ierr = H5LTget_attribute_int(group, ".", name, pv->u_int_array.vals); CE;
-    break;
+    case PT_FLOAT:
+    case MRC_VAR_FLOAT:
+      ierr = H5LTget_attribute_float(group, ".", name, &pv->u_float);
+      CE;
+      break;
+    case PT_DOUBLE:
+    case MRC_VAR_DOUBLE:
+      ierr = H5LTget_attribute_double(group, ".", name, &pv->u_double);
+      CE;
+      break;
+    case PT_STRING:;
+      hsize_t dims;
+      H5T_class_t class;
+      size_t sz;
+      ierr = H5LTget_attribute_info(group, ".", name, &dims, &class, &sz);
+      CE;
+      char* s = malloc(sz);
+      ierr = H5LTget_attribute_string(group, ".", name, s);
+      CE;
+      if (strcmp(s, "(NULL)") == 0) {
+        free(s);
+        s = NULL;
+      }
+      pv->u_string = s;
+      break;
+    case PT_INT3:
+      ierr = H5LTget_attribute_int(group, ".", name, pv->u_int3);
+      CE;
+      break;
+    case PT_FLOAT3:
+      ierr = H5LTget_attribute_float(group, ".", name, pv->u_float3);
+      CE;
+      break;
+    case PT_DOUBLE3:
+    case MRC_VAR_DOUBLE3:
+      ierr = H5LTget_attribute_double(group, ".", name, pv->u_double3);
+      CE;
+      break;
+    case PT_INT_ARRAY: {
+      hid_t attr = H5Aopen(group, name, H5P_DEFAULT);
+      H5_CHK(attr);
+      H5A_info_t ainfo;
+      ierr = H5Aget_info(attr, &ainfo);
+      CE;
+      ierr = H5Aclose(attr);
+      CE;
+      pv->u_int_array.nr_vals = ainfo.data_size / sizeof(int);
+      pv->u_int_array.vals = calloc(pv->u_int_array.nr_vals, sizeof(int));
+      ierr = H5LTget_attribute_int(group, ".", name, pv->u_int_array.vals);
+      CE;
+      break;
+    }
+    case PT_FLOAT_ARRAY: {
+      hid_t attr = H5Aopen(group, name, H5P_DEFAULT);
+      H5_CHK(attr);
+      H5A_info_t ainfo;
+      ierr = H5Aget_info(attr, &ainfo);
+      CE;
+      ierr = H5Aclose(attr);
+      CE;
+      pv->u_float_array.nr_vals = ainfo.data_size / sizeof(float);
+      pv->u_float_array.vals = calloc(pv->u_float_array.nr_vals, sizeof(float));
+      ierr = H5LTget_attribute_float(group, ".", name, pv->u_float_array.vals);
+      CE;
+      break;
+    }
+    case PT_PTR:
+      mpi_printf(mrc_io_comm(io),
+                 "WARNING: not reading back pointer attribute\n");
+      break;
+    default:
+      mpi_printf(mrc_io_comm(io), "unhandled type %d\n", type);
+      assert(0);
   }
-  case PT_FLOAT_ARRAY: {
-    hid_t attr = H5Aopen(group, name, H5P_DEFAULT); H5_CHK(attr);
-    H5A_info_t ainfo;
-    ierr = H5Aget_info(attr, &ainfo); CE;
-    ierr = H5Aclose(attr); CE;
-    pv->u_float_array.nr_vals = ainfo.data_size / sizeof(float);
-    pv->u_float_array.vals = calloc(pv->u_float_array.nr_vals, sizeof(float));
-    ierr = H5LTget_attribute_float(group, ".", name, pv->u_float_array.vals); CE;
-    break;
-  }
-  case PT_PTR:
-    mpi_printf(mrc_io_comm(io), "WARNING: not reading back pointer attribute\n");
-    break;
-  default:
-    mpi_printf(mrc_io_comm(io), "unhandled type %d\n", type);
-    assert(0);
-  }
-  ierr = H5Gclose(group); CE;
+  ierr = H5Gclose(group);
+  CE;
 }
 
-static void
-ds_xdmf_write_attr(struct mrc_io *io, const char *path, int type,
-		   const char *name, union param_u *pv)
+static void ds_xdmf_write_attr(struct mrc_io* io, const char* path, int type,
+                               const char* name, union param_u* pv)
 {
-  struct diag_hdf5 *hdf5 = diag_hdf5(io);
+  struct diag_hdf5* hdf5 = diag_hdf5(io);
   herr_t ierr;
 
   hid_t group;
   if (H5Lexists(hdf5->file, path, H5P_DEFAULT) > 0) {
-    group = H5Gopen(hdf5->file, path, H5P_DEFAULT); H5_CHK(group);
+    group = H5Gopen(hdf5->file, path, H5P_DEFAULT);
+    H5_CHK(group);
   } else {
-    group = H5Gcreate(hdf5->file, path, H5P_DEFAULT, H5P_DEFAULT,
-		      H5P_DEFAULT); H5_CHK(group);
+    group = H5Gcreate(hdf5->file, path, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
+    H5_CHK(group);
   }
   switch (type) {
-  case PT_SELECT:
-  case PT_INT:
-  case MRC_VAR_INT:
-    ierr = H5LTset_attribute_int(group, ".", name, &pv->u_int, 1); CE;
-    break;
-  case PT_BOOL:
-  case MRC_VAR_BOOL: {
-    int val = pv->u_bool;
-    ierr = H5LTset_attribute_int(group, ".", name, &val, 1); CE;
-    break;
-  }
-  case PT_FLOAT:
-  case MRC_VAR_FLOAT:
-    ierr = H5LTset_attribute_float(group, ".", name, &pv->u_float, 1); CE;
-    break;
-  case PT_DOUBLE:
-  case MRC_VAR_DOUBLE:
-    ierr = H5LTset_attribute_double(group, ".", name, &pv->u_double, 1); CE;
-    break;
-  case PT_STRING:
-    if (pv->u_string) {
-      ierr = H5LTset_attribute_string(group, ".", name, pv->u_string); CE;
-    } else {
-      ierr = H5LTset_attribute_string(group, ".", name, "(NULL)"); CE;
+    case PT_SELECT:
+    case PT_INT:
+    case MRC_VAR_INT:
+      ierr = H5LTset_attribute_int(group, ".", name, &pv->u_int, 1);
+      CE;
+      break;
+    case PT_BOOL:
+    case MRC_VAR_BOOL: {
+      int val = pv->u_bool;
+      ierr = H5LTset_attribute_int(group, ".", name, &val, 1);
+      CE;
+      break;
     }
-    break;
-  case PT_INT3:
-    ierr = H5LTset_attribute_int(group, ".", name, pv->u_int3, 3); CE;
-    break;
-  case PT_FLOAT3:
-    ierr = H5LTset_attribute_float(group, ".", name, pv->u_float3, 3); CE;
-    break;
-  case PT_DOUBLE3:
-  case MRC_VAR_DOUBLE3:
-    ierr = H5LTset_attribute_double(group, ".", name, pv->u_double3, 3); CE;
-    break;
-  case PT_INT_ARRAY: {
-    hsize_t dims = pv->u_int_array.nr_vals;
-    hid_t dataspace_id = H5Screate_simple(1, &dims, NULL); H5_CHK(dataspace_id);
-    hid_t attr_id = H5Acreate(group, name, H5T_NATIVE_INT, dataspace_id,
-			      H5P_DEFAULT, H5P_DEFAULT); H5_CHK(attr_id);
-    if (dims > 0) {
-      ierr = H5Awrite(attr_id, H5T_NATIVE_INT, pv->u_int_array.vals); CE;
+    case PT_FLOAT:
+    case MRC_VAR_FLOAT:
+      ierr = H5LTset_attribute_float(group, ".", name, &pv->u_float, 1);
+      CE;
+      break;
+    case PT_DOUBLE:
+    case MRC_VAR_DOUBLE:
+      ierr = H5LTset_attribute_double(group, ".", name, &pv->u_double, 1);
+      CE;
+      break;
+    case PT_STRING:
+      if (pv->u_string) {
+        ierr = H5LTset_attribute_string(group, ".", name, pv->u_string);
+        CE;
+      } else {
+        ierr = H5LTset_attribute_string(group, ".", name, "(NULL)");
+        CE;
+      }
+      break;
+    case PT_INT3:
+      ierr = H5LTset_attribute_int(group, ".", name, pv->u_int3, 3);
+      CE;
+      break;
+    case PT_FLOAT3:
+      ierr = H5LTset_attribute_float(group, ".", name, pv->u_float3, 3);
+      CE;
+      break;
+    case PT_DOUBLE3:
+    case MRC_VAR_DOUBLE3:
+      ierr = H5LTset_attribute_double(group, ".", name, pv->u_double3, 3);
+      CE;
+      break;
+    case PT_INT_ARRAY: {
+      hsize_t dims = pv->u_int_array.nr_vals;
+      hid_t dataspace_id = H5Screate_simple(1, &dims, NULL);
+      H5_CHK(dataspace_id);
+      hid_t attr_id = H5Acreate(group, name, H5T_NATIVE_INT, dataspace_id,
+                                H5P_DEFAULT, H5P_DEFAULT);
+      H5_CHK(attr_id);
+      if (dims > 0) {
+        ierr = H5Awrite(attr_id, H5T_NATIVE_INT, pv->u_int_array.vals);
+        CE;
+      }
+      ierr = H5Sclose(dataspace_id);
+      CE;
+      ierr = H5Aclose(attr_id);
+      CE;
+      break;
     }
-    ierr = H5Sclose(dataspace_id); CE;
-    ierr = H5Aclose(attr_id); CE;
-    break;
-  }
-  case PT_FLOAT_ARRAY: {
-    hsize_t dims = pv->u_float_array.nr_vals;
-    hid_t dataspace_id = H5Screate_simple(1, &dims, NULL); H5_CHK(dataspace_id);
-    hid_t attr_id = H5Acreate(group, name, H5T_NATIVE_FLOAT, dataspace_id,
-			      H5P_DEFAULT, H5P_DEFAULT); H5_CHK(attr_id);
-    if (dims > 0) {
-      ierr = H5Awrite(attr_id, H5T_NATIVE_FLOAT, pv->u_float_array.vals); CE;
+    case PT_FLOAT_ARRAY: {
+      hsize_t dims = pv->u_float_array.nr_vals;
+      hid_t dataspace_id = H5Screate_simple(1, &dims, NULL);
+      H5_CHK(dataspace_id);
+      hid_t attr_id = H5Acreate(group, name, H5T_NATIVE_FLOAT, dataspace_id,
+                                H5P_DEFAULT, H5P_DEFAULT);
+      H5_CHK(attr_id);
+      if (dims > 0) {
+        ierr = H5Awrite(attr_id, H5T_NATIVE_FLOAT, pv->u_float_array.vals);
+        CE;
+      }
+      ierr = H5Sclose(dataspace_id);
+      CE;
+      ierr = H5Aclose(attr_id);
+      CE;
+      break;
     }
-    ierr = H5Sclose(dataspace_id); CE;
-    ierr = H5Aclose(attr_id); CE;
-    break;
+    default:
+      mpi_printf(mrc_io_comm(io),
+                 "WARNING: not writing unhandled attr type %d\n", type);
   }
-  default:
-    mpi_printf(mrc_io_comm(io), "WARNING: not writing unhandled attr type %d\n", type);
-  }
-  ierr = H5Gclose(group); CE;
+  ierr = H5Gclose(group);
+  CE;
 }
 
-static void
-copy_and_scale(struct mrc_fld *vfld, int m, struct mrc_fld *fld, int fld_m,
-	       float scale)
+static void copy_and_scale(struct mrc_fld* vfld, int m, struct mrc_fld* fld,
+                           int fld_m, float scale)
 {
-  const int *dims = mrc_fld_dims(vfld);
-  float *arr = vfld->_nd->arr;
+  const int* dims = mrc_fld_dims(vfld);
+  float* arr = vfld->_nd->arr;
   int nr_comps = mrc_fld_nr_comps(vfld);
-  mrc_fld_foreach(vfld, ix,iy,iz, 0, 0) {
-    // cannot use MRC_F3, because the layout is different (for vecs, fast component)!
+  mrc_fld_foreach(vfld, ix, iy, iz, 0, 0)
+  {
+    // cannot use MRC_F3, because the layout is different (for vecs, fast
+    // component)!
     arr[(((iz * dims[1]) + iy) * dims[0] + ix) * nr_comps + m] =
-      scale * MRC_F3(fld, fld_m, ix,iy,iz);
-  } mrc_fld_foreach_end;
+      scale * MRC_F3(fld, fld_m, ix, iy, iz);
+  }
+  mrc_fld_foreach_end;
 }
 
-static void
-copy_back(struct mrc_fld *vfld, int m, struct mrc_fld *fld, int fld_m)
+static void copy_back(struct mrc_fld* vfld, int m, struct mrc_fld* fld,
+                      int fld_m)
 {
-  const int *dims = mrc_fld_dims(vfld);
-  float *arr = vfld->_nd->arr;
+  const int* dims = mrc_fld_dims(vfld);
+  float* arr = vfld->_nd->arr;
   int nr_comps = mrc_fld_nr_comps(vfld);
-  mrc_fld_foreach(vfld, ix,iy,iz, 0, 0) {
-    // cannot use MRC_F3, because the layout is different (for vecs, fast component)!
-    MRC_F3(fld, fld_m, ix,iy,iz) = 
+  mrc_fld_foreach(vfld, ix, iy, iz, 0, 0)
+  {
+    // cannot use MRC_F3, because the layout is different (for vecs, fast
+    // component)!
+    MRC_F3(fld, fld_m, ix, iy, iz) =
       arr[(((iz * dims[1]) + iy) * dims[0] + ix) * nr_comps + m];
-  } mrc_fld_foreach_end;
+  }
+  mrc_fld_foreach_end;
 }
 
-static void
-save_fld_info(struct xdmf_spatial *xs, char *fld_name, char *path, bool is_vec)
+static void save_fld_info(struct xdmf_spatial* xs, char* fld_name, char* path,
+                          bool is_vec)
 {
   assert(xs->nr_fld_info < MAX_FLD_INFO);
-  struct fld_info *fld_info = &xs->fld_info[xs->nr_fld_info++];
+  struct fld_info* fld_info = &xs->fld_info[xs->nr_fld_info++];
 
   fld_info->name = fld_name;
   fld_info->path = path;
   fld_info->is_vec = is_vec;
 }
 
-static struct xdmf_spatial *
-xdmf_spatial_create_3d(struct mrc_io *io, const int im[3], int p, int nr_subdomains)
+static struct xdmf_spatial* xdmf_spatial_create_3d(struct mrc_io* io,
+                                                   const int im[3], int p,
+                                                   int nr_subdomains)
 {
   // OPT, we could skip this on procs which aren't writing xdmf
 
-  struct xdmf_subdomain *subdomains = calloc(nr_subdomains, sizeof(*subdomains));
+  struct xdmf_subdomain* subdomains =
+    calloc(nr_subdomains, sizeof(*subdomains));
   for (int s = 0; s < nr_subdomains; s++) {
     for (int d = 0; d < 3; d++) {
       subdomains[s].im[d] = im[d];
     }
   }
 
-  return xdmf_spatial_create(io, "3df", -1, p, nr_subdomains, subdomains, io->size,
-			     xdmf_write_topology_3d, xdmf_write_fld_3d);
+  return xdmf_spatial_create(io, "3df", -1, p, nr_subdomains, subdomains,
+                             io->size, xdmf_write_topology_3d,
+                             xdmf_write_fld_3d);
 }
 
-static struct xdmf_spatial *
-xdmf_spatial_create_2d_x(struct mrc_io *io, int im[2], 
-			 const char *sfx, float sheet, int nr_subdomains)
+static struct xdmf_spatial* xdmf_spatial_create_2d_x(struct mrc_io* io,
+                                                     int im[2], const char* sfx,
+                                                     float sheet,
+                                                     int nr_subdomains)
 {
   // OPT, we could skip this on procs which aren't writing xdmf
 
-  struct xdmf_subdomain *subdomains = calloc(nr_subdomains, sizeof(*subdomains));
+  struct xdmf_subdomain* subdomains =
+    calloc(nr_subdomains, sizeof(*subdomains));
   for (int s = 0; s < nr_subdomains; s++) {
     for (int d = 0; d < 2; d++) {
       subdomains[s].im[d] = im[d];
     }
   }
 
-  return xdmf_spatial_create(io, sfx, sheet, -1, nr_subdomains, subdomains, io->size,
-			     xdmf_write_topology_2d_x, xdmf_write_fld_2d_x);
+  return xdmf_spatial_create(io, sfx, sheet, -1, nr_subdomains, subdomains,
+                             io->size, xdmf_write_topology_2d_x,
+                             xdmf_write_fld_2d_x);
 }
 
-static struct xdmf_spatial *
-xdmf_spatial_create_2d_y(struct mrc_io *io, int im[2], 
-			 const char *sfx, float sheet, int nr_subdomains)
+static struct xdmf_spatial* xdmf_spatial_create_2d_y(struct mrc_io* io,
+                                                     int im[2], const char* sfx,
+                                                     float sheet,
+                                                     int nr_subdomains)
 {
   // OPT, we could skip this on procs which aren't writing xdmf
 
-  struct xdmf_subdomain *subdomains = calloc(nr_subdomains, sizeof(*subdomains));
+  struct xdmf_subdomain* subdomains =
+    calloc(nr_subdomains, sizeof(*subdomains));
   for (int s = 0; s < nr_subdomains; s++) {
     for (int d = 0; d < 2; d++) {
       subdomains[s].im[d] = im[d];
     }
   }
 
-  return xdmf_spatial_create(io, sfx, sheet, -1, nr_subdomains, subdomains, io->size,
-			     xdmf_write_topology_2d_y, xdmf_write_fld_2d_y);
+  return xdmf_spatial_create(io, sfx, sheet, -1, nr_subdomains, subdomains,
+                             io->size, xdmf_write_topology_2d_y,
+                             xdmf_write_fld_2d_y);
 }
 
-static struct xdmf_spatial *
-xdmf_spatial_create_2d_z(struct mrc_io *io, int im[2], 
-			 const char *sfx, float sheet, int nr_subdomains)
+static struct xdmf_spatial* xdmf_spatial_create_2d_z(struct mrc_io* io,
+                                                     int im[2], const char* sfx,
+                                                     float sheet,
+                                                     int nr_subdomains)
 {
   // OPT, we could skip this on procs which aren't writing xdmf
 
-  struct xdmf_subdomain *subdomains = calloc(nr_subdomains, sizeof(*subdomains));
+  struct xdmf_subdomain* subdomains =
+    calloc(nr_subdomains, sizeof(*subdomains));
   for (int s = 0; s < nr_subdomains; s++) {
     for (int d = 0; d < 2; d++) {
       subdomains[s].im[d] = im[d];
     }
   }
 
-  return xdmf_spatial_create(io, sfx, sheet, -1, nr_subdomains, subdomains, io->size,
-			     xdmf_write_topology_2d_z, xdmf_write_fld_2d_z);
+  return xdmf_spatial_create(io, sfx, sheet, -1, nr_subdomains, subdomains,
+                             io->size, xdmf_write_topology_2d_z,
+                             xdmf_write_fld_2d_z);
 }
 
-static struct xdmf_spatial *
-xdmf_spatial_create_iono(struct mrc_io *io, int im[2])
+static struct xdmf_spatial* xdmf_spatial_create_iono(struct mrc_io* io,
+                                                     int im[2])
 {
-  struct xdmf_subdomain *subdomain = calloc(1, sizeof(*subdomain));
+  struct xdmf_subdomain* subdomain = calloc(1, sizeof(*subdomain));
   for (int d = 0; d < 2; d++) {
     subdomain->im[d] = im[d];
   }
 
   return xdmf_spatial_create(io, "iof", -1, -1, 1, subdomain, 1,
-			     xdmf_write_topology_iono, xdmf_write_fld_2d_iono);
+                             xdmf_write_topology_iono, xdmf_write_fld_2d_iono);
 }
 
-static void
-ds_xdmf_write_field(struct mrc_io *io, const char *path,
-		    float scale, struct mrc_fld *fld, int m)
+static void ds_xdmf_write_field(struct mrc_io* io, const char* path,
+                                float scale, struct mrc_fld* fld, int m)
 {
   herr_t ierr;
-  struct diag_hdf5 *hdf5 = diag_hdf5(io);
+  struct diag_hdf5* hdf5 = diag_hdf5(io);
 
   // on diagsrv, ghost points have already been dropped
-  const int *dims = mrc_fld_dims(fld);
-  struct xdmf_spatial *xs;
+  const int* dims = mrc_fld_dims(fld);
+  struct xdmf_spatial* xs;
   xs = xdmf_spatial_find(io, "3df", -1);
   if (!xs) {
     xs = xdmf_spatial_create_3d(io, dims, -1, io->size);
     hdf5_write_crds(io, dims, fld->_domain, fld->_sw.vals[0]);
   }
 
-  hid_t group0 = H5Gopen(hdf5->file, path, H5P_DEFAULT); H5_CHK(group0);
-  const char *fldname = mrc_fld_comp_name(fld, m);
+  hid_t group0 = H5Gopen(hdf5->file, path, H5P_DEFAULT);
+  H5_CHK(group0);
+  const char* fldname = mrc_fld_comp_name(fld, m);
   char c = fldname[strlen(fldname) - 1];
   if (c == 'x') {
     assert(!hdf5->vfld);
     hdf5->vfld = mrc_fld_create(mrc_fld_comm(fld));
     mrc_fld_set_param_int_array(hdf5->vfld, "dims", 4,
-			       (int[4]) { dims[0], dims[1], dims[2], 3 });
+                                (int[4]){dims[0], dims[1], dims[2], 3});
     mrc_fld_setup(hdf5->vfld);
     copy_and_scale(hdf5->vfld, 0, fld, m, scale);
   } else if (c == 'y') {
     copy_and_scale(hdf5->vfld, 1, fld, m, scale);
   } else if (c == 'z') {
     copy_and_scale(hdf5->vfld, 2, fld, m, scale);
-    char *vec_name = strdup(fldname);
+    char* vec_name = strdup(fldname);
     vec_name[strlen(fldname) - 1] = 0;
     save_fld_info(xs, vec_name, strdup(path), true);
-    struct mrc_fld *vfld = hdf5->vfld;
-    const int *dim = mrc_fld_dims(vfld);
-    hsize_t hdims[4] = { dim[2], dim[1], dim[0], mrc_fld_nr_comps(vfld) };
-    hid_t group = H5Gcreate(group0, vec_name, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
-    ierr = H5LTmake_dataset_float(group, "3d", 4, hdims, vfld->_nd->arr); CE;
-    ierr = H5Gclose(group); CE;
+    struct mrc_fld* vfld = hdf5->vfld;
+    const int* dim = mrc_fld_dims(vfld);
+    hsize_t hdims[4] = {dim[2], dim[1], dim[0], mrc_fld_nr_comps(vfld)};
+    hid_t group =
+      H5Gcreate(group0, vec_name, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
+    ierr = H5LTmake_dataset_float(group, "3d", 4, hdims, vfld->_nd->arr);
+    CE;
+    ierr = H5Gclose(group);
+    CE;
 
     mrc_fld_destroy(vfld);
     hdf5->vfld = NULL;
@@ -1026,86 +1181,107 @@ ds_xdmf_write_field(struct mrc_io *io, const char *path,
     if (io->rank < 0) { // FIXME not happening anymore, still optimize this case
       // on diag srv, ghost points are already gone and scaling is done
       assert(scale == 1.f);
-      const int *dim = mrc_fld_dims(fld);
-      hsize_t hdims[3] = { dim[2], dim[1], dim[0] };
-      hid_t group = H5Gcreate(group0, fldname, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
-      ierr = H5LTmake_dataset_float(group, "3d", 3, hdims, &MRC_F3(fld, m, 0,0,0)); CE;
-      ierr = H5Gclose(group); CE;
+      const int* dim = mrc_fld_dims(fld);
+      hsize_t hdims[3] = {dim[2], dim[1], dim[0]};
+      hid_t group =
+        H5Gcreate(group0, fldname, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
+      ierr =
+        H5LTmake_dataset_float(group, "3d", 3, hdims, &MRC_F3(fld, m, 0, 0, 0));
+      CE;
+      ierr = H5Gclose(group);
+      CE;
     } else {
-      struct mrc_fld *sfld = mrc_fld_create(mrc_fld_comm(fld));
+      struct mrc_fld* sfld = mrc_fld_create(mrc_fld_comm(fld));
       mrc_fld_set_param_int_array(sfld, "dims", 4,
-				 (int[4]) { dims[0], dims[1], dims[2], 1 });
+                                  (int[4]){dims[0], dims[1], dims[2], 1});
       mrc_fld_setup(sfld);
       copy_and_scale(sfld, 0, fld, m, scale);
 
-      const int *dim = mrc_fld_dims(sfld);
-      hsize_t hdims[3] = { dim[2], dim[1], dim[0] };
-      hid_t group = H5Gcreate(group0, fldname, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
-      ierr = H5LTmake_dataset_float(group, "3d", 3, hdims, sfld->_nd->arr); CE;
-      ierr = H5Gclose(group); CE;
+      const int* dim = mrc_fld_dims(sfld);
+      hsize_t hdims[3] = {dim[2], dim[1], dim[0]};
+      hid_t group =
+        H5Gcreate(group0, fldname, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
+      ierr = H5LTmake_dataset_float(group, "3d", 3, hdims, sfld->_nd->arr);
+      CE;
+      ierr = H5Gclose(group);
+      CE;
       mrc_fld_destroy(sfld);
     }
   }
   H5Gclose(group0);
 }
 
-static void
-ds_xdmf_write_field2d(struct mrc_io *io, float scale, struct mrc_fld *fld,
-		      int outtype, float sheet)
+static void ds_xdmf_write_field2d(struct mrc_io* io, float scale,
+                                  struct mrc_fld* fld, int outtype, float sheet)
 {
-  struct diag_hdf5 *hdf5 = diag_hdf5(io);
+  struct diag_hdf5* hdf5 = diag_hdf5(io);
   int ierr;
 
   // diagsrv xdmf_serial / single proc only for now
   int bnd = 0;
-  int im[2] = { fld->_dims.vals[0] - bnd, fld->_dims.vals[1] - bnd };
+  int im[2] = {fld->_dims.vals[0] - bnd, fld->_dims.vals[1] - bnd};
 
-  struct xdmf_spatial *xs = NULL;
-  char sfx[10]; make_sfx(sfx, outtype, sheet);
-  char path[100]; make_path(path, sfx);
+  struct xdmf_spatial* xs = NULL;
+  char sfx[10];
+  make_sfx(sfx, outtype, sheet);
+  char path[100];
+  make_path(path, sfx);
   xs = xdmf_spatial_find(io, sfx, sheet);
   if (!xs) {
     if (outtype == DIAG_TYPE_2D_X) {
       xs = xdmf_spatial_create_2d_x(io, im, sfx, sheet, io->size);
-      hdf5_write_crds(io, (int[]) { 0, im[0], im[1] }, fld->_domain, fld->_sw.vals[0]);
+      hdf5_write_crds(io, (int[]){0, im[0], im[1]}, fld->_domain,
+                      fld->_sw.vals[0]);
     } else if (outtype == DIAG_TYPE_2D_Y) {
       xs = xdmf_spatial_create_2d_y(io, im, sfx, sheet, io->size);
-      hdf5_write_crds(io, (int[]) { im[0], 0, im[1] }, fld->_domain, fld->_sw.vals[0]);
+      hdf5_write_crds(io, (int[]){im[0], 0, im[1]}, fld->_domain,
+                      fld->_sw.vals[0]);
     } else if (outtype == DIAG_TYPE_2D_Z) {
       xs = xdmf_spatial_create_2d_z(io, im, sfx, sheet, io->size);
-      hdf5_write_crds(io, (int[]) { im[0], im[1], 0 }, fld->_domain, fld->_sw.vals[0]);
+      hdf5_write_crds(io, (int[]){im[0], im[1], 0}, fld->_domain,
+                      fld->_sw.vals[0]);
     } else if (outtype == DIAG_TYPE_2D_IONO) {
       xs = xdmf_spatial_create_iono(io, im);
     }
-    hid_t group = H5Gcreate(hdf5->file, path, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
-    ierr = H5Gclose(group); CE;
+    hid_t group =
+      H5Gcreate(hdf5->file, path, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
+    ierr = H5Gclose(group);
+    CE;
   }
 
   save_fld_info(xs, strdup(mrc_fld_comp_name(fld, 0)), strdup(path), false);
   hdf5_write_field2d_serial(io, scale, fld, path);
 }
 
-static void
-ds_xdmf_write_m1(struct mrc_io *io, const char *path, struct mrc_fld *m1)
+static void ds_xdmf_write_m1(struct mrc_io* io, const char* path,
+                             struct mrc_fld* m1)
 {
   int ierr;
-  struct diag_hdf5 *hdf5 = diag_hdf5(io);
+  struct diag_hdf5* hdf5 = diag_hdf5(io);
 
-  hid_t group0 = H5Gopen(hdf5->file, path, H5P_DEFAULT); H5_CHK(group0);
+  hid_t group0 = H5Gopen(hdf5->file, path, H5P_DEFAULT);
+  H5_CHK(group0);
   int nr_patches = mrc_fld_nr_patches(m1);
   H5LTset_attribute_int(group0, ".", "nr_patches", &nr_patches, 1);
 
-  mrc_m1_foreach_patch(m1, p) {
-    char name[10]; sprintf(name, "p%d", p);
-    hid_t group = H5Gcreate(group0, name, H5P_DEFAULT, H5P_DEFAULT,
-			    H5P_DEFAULT); H5_CHK(group);
+  mrc_m1_foreach_patch(m1, p)
+  {
+    char name[10];
+    sprintf(name, "p%d", p);
+    hid_t group =
+      H5Gcreate(group0, name, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
+    H5_CHK(group);
 
-    hsize_t hdims[1] = { mrc_fld_ghost_dims(m1)[0] };
+    hsize_t hdims[1] = {mrc_fld_ghost_dims(m1)[0]};
     for (int m = 0; m < mrc_fld_nr_comps(m1); m++) {
-      hid_t groupc = H5Gcreate(group, mrc_fld_comp_name(m1, m), H5P_DEFAULT, H5P_DEFAULT,
-			       H5P_DEFAULT); H5_CHK(groupc);
-      ierr = H5LTset_attribute_int(groupc, ".", "m", &m, 1); CE;
-      ierr = H5LTmake_dataset_float(groupc, "1d", 1, hdims, &MRC_M1(m1, m, mrc_fld_ghost_offs(m1)[0], p)); CE;
+      hid_t groupc = H5Gcreate(group, mrc_fld_comp_name(m1, m), H5P_DEFAULT,
+                               H5P_DEFAULT, H5P_DEFAULT);
+      H5_CHK(groupc);
+      ierr = H5LTset_attribute_int(groupc, ".", "m", &m, 1);
+      CE;
+      ierr = H5LTmake_dataset_float(
+        groupc, "1d", 1, hdims, &MRC_M1(m1, m, mrc_fld_ghost_offs(m1)[0], p));
+      CE;
       H5Gclose(groupc);
     }
     H5Gclose(group);
@@ -1114,88 +1290,104 @@ ds_xdmf_write_m1(struct mrc_io *io, const char *path, struct mrc_fld *m1)
   H5Gclose(group0);
 }
 
-struct read_m1_cb_data {
-  struct mrc_io *io;
-  struct mrc_fld *m1;
+struct read_m1_cb_data
+{
+  struct mrc_io* io;
+  struct mrc_fld* m1;
   int p;
   hid_t filespace;
   hid_t memspace;
 };
 
-static herr_t
-read_m1_cb(hid_t g_id, const char *name, const H5L_info_t *info, void *op_data)
+static herr_t read_m1_cb(hid_t g_id, const char* name, const H5L_info_t* info,
+                         void* op_data)
 {
-  struct read_m1_cb_data *data = op_data;
+  struct read_m1_cb_data* data = op_data;
   herr_t ierr;
 
-  hid_t group = H5Gopen(g_id, name, H5P_DEFAULT); H5_CHK(group);
+  hid_t group = H5Gopen(g_id, name, H5P_DEFAULT);
+  H5_CHK(group);
   int m;
-  ierr = H5LTget_attribute_int(group, ".", "m", &m); CE;
+  ierr = H5LTget_attribute_int(group, ".", "m", &m);
+  CE;
 
-  hid_t dset = H5Dopen(group, "1d", H5P_DEFAULT); H5_CHK(dset);
-  ierr = H5Dread(dset, H5T_NATIVE_FLOAT, data->memspace, data->filespace, H5P_DEFAULT,
-		 &MRC_M1(data->m1, m, mrc_fld_ghost_offs(data->m1)[0], data->p)); CE;
-  ierr = H5Dclose(dset); CE;
+  hid_t dset = H5Dopen(group, "1d", H5P_DEFAULT);
+  H5_CHK(dset);
+  ierr = H5Dread(
+    dset, H5T_NATIVE_FLOAT, data->memspace, data->filespace, H5P_DEFAULT,
+    &MRC_M1(data->m1, m, mrc_fld_ghost_offs(data->m1)[0], data->p));
+  CE;
+  ierr = H5Dclose(dset);
+  CE;
 
-  ierr = H5Gclose(group); CE;
+  ierr = H5Gclose(group);
+  CE;
   return 0;
 }
 
-static void
-ds_xdmf_read_m1(struct mrc_io *io, const char *path, struct mrc_fld *m1)
+static void ds_xdmf_read_m1(struct mrc_io* io, const char* path,
+                            struct mrc_fld* m1)
 {
-  struct diag_hdf5 *hdf5 = diag_hdf5(io);
+  struct diag_hdf5* hdf5 = diag_hdf5(io);
   herr_t ierr;
 
 #ifndef NDEBUG
   MPI_Barrier(io->obj.comm);
 #endif
 
-  hid_t group0 = H5Gopen(hdf5->file, path, H5P_DEFAULT); H5_CHK(group0);
+  hid_t group0 = H5Gopen(hdf5->file, path, H5P_DEFAULT);
+  H5_CHK(group0);
   for (int p = 0; p < mrc_fld_nr_patches(m1); p++) {
-    char name[10]; sprintf(name, "p%d", p);
-    hid_t group = H5Gopen(group0, name, H5P_DEFAULT); H5_CHK(group);
-    hsize_t hdims[1] = { mrc_fld_ghost_dims(m1)[0] };
+    char name[10];
+    sprintf(name, "p%d", p);
+    hid_t group = H5Gopen(group0, name, H5P_DEFAULT);
+    H5_CHK(group);
+    hsize_t hdims[1] = {mrc_fld_ghost_dims(m1)[0]};
     hid_t filespace = H5Screate_simple(1, hdims, NULL);
     hid_t memspace = H5Screate_simple(1, hdims, NULL);
 
     struct read_m1_cb_data cb_data = {
-      .io        = io,
-      .m1        = m1,
-      .p         = p,
+      .io = io,
+      .m1 = m1,
+      .p = p,
       .filespace = filespace,
-      .memspace  = memspace,
+      .memspace = memspace,
     };
     hsize_t idx = 0;
     ierr = H5Literate_by_name(group, ".", H5_INDEX_NAME, H5_ITER_INC, &idx,
-			      read_m1_cb, &cb_data, H5P_DEFAULT); CE;
+                              read_m1_cb, &cb_data, H5P_DEFAULT);
+    CE;
 
-    ierr = H5Sclose(filespace); CE;
-    ierr = H5Sclose(memspace); CE;
-    ierr = H5Gclose(group); CE;
+    ierr = H5Sclose(filespace);
+    CE;
+    ierr = H5Sclose(memspace);
+    CE;
+    ierr = H5Gclose(group);
+    CE;
   }
 
-  ierr = H5Gclose(group0); CE;
+  ierr = H5Gclose(group0);
+  CE;
 }
 
-static hid_t
-get_h5_datatype(int data_type)
+static hid_t get_h5_datatype(int data_type)
 {
   switch (data_type) {
-  case MRC_NT_FLOAT : return H5T_NATIVE_FLOAT;
-  case MRC_NT_DOUBLE: return H5T_NATIVE_DOUBLE;
-  case MRC_NT_INT   : return H5T_NATIVE_INT;
-  default: assert(0);
+    case MRC_NT_FLOAT: return H5T_NATIVE_FLOAT;
+    case MRC_NT_DOUBLE: return H5T_NATIVE_DOUBLE;
+    case MRC_NT_INT: return H5T_NATIVE_INT;
+    default: assert(0);
   }
 }
 
-static void
-ds_xdmf_read_fld(struct mrc_io *io, const char *path, struct mrc_fld *fld)
+static void ds_xdmf_read_fld(struct mrc_io* io, const char* path,
+                             struct mrc_fld* fld)
 {
   int ierr;
-  struct diag_hdf5 *hdf5 = diag_hdf5(io);
+  struct diag_hdf5* hdf5 = diag_hdf5(io);
 
-  hid_t group0 = H5Gopen(hdf5->file, path, H5P_DEFAULT); H5_CHK(group0);
+  hid_t group0 = H5Gopen(hdf5->file, path, H5P_DEFAULT);
+  H5_CHK(group0);
 
   hsize_t hdims[fld->_dims.nr_vals];
   for (int d = 0; d < fld->_dims.nr_vals; d++) {
@@ -1203,65 +1395,83 @@ ds_xdmf_read_fld(struct mrc_io *io, const char *path, struct mrc_fld *fld)
   }
   hid_t filespace = H5Screate_simple(fld->_dims.nr_vals, hdims, NULL);
   hid_t datatype = get_h5_datatype(mrc_fld_data_type(fld));
-  hid_t dset = H5Dopen(group0, "fld", H5P_DEFAULT); H5_CHK(dset);
-  ierr = H5Dread(dset, datatype, H5S_ALL, filespace, H5P_DEFAULT, fld->_nd->arr); CE;
-  ierr = H5Dclose(dset); CE;
-  ierr = H5Sclose(filespace); CE;
+  hid_t dset = H5Dopen(group0, "fld", H5P_DEFAULT);
+  H5_CHK(dset);
+  ierr =
+    H5Dread(dset, datatype, H5S_ALL, filespace, H5P_DEFAULT, fld->_nd->arr);
+  CE;
+  ierr = H5Dclose(dset);
+  CE;
+  ierr = H5Sclose(filespace);
+  CE;
 
-  ierr = H5Gclose(group0); CE;
+  ierr = H5Gclose(group0);
+  CE;
 }
 
-static void
-ds_xdmf_write_fld(struct mrc_io *io, const char *path, struct mrc_fld *fld)
+static void ds_xdmf_write_fld(struct mrc_io* io, const char* path,
+                              struct mrc_fld* fld)
 {
   int ierr;
-  struct diag_hdf5 *hdf5 = diag_hdf5(io);
+  struct diag_hdf5* hdf5 = diag_hdf5(io);
 
   if (fld->_dims.nr_vals == 0) {
     mprintf("WARNING: not writing mrc_fld with 0 dims!\n");
     return;
   }
 
-  hid_t group0 = H5Gopen(hdf5->file, path, H5P_DEFAULT); H5_CHK(group0);
+  hid_t group0 = H5Gopen(hdf5->file, path, H5P_DEFAULT);
+  H5_CHK(group0);
 
   hsize_t hdims[fld->_dims.nr_vals];
   for (int d = 0; d < fld->_dims.nr_vals; d++) {
     hdims[d] = mrc_fld_ghost_dims(fld)[fld->_dims.nr_vals - 1 - d];
   }
-  hid_t filespace = H5Screate_simple(fld->_dims.nr_vals, hdims, NULL); H5_CHK(filespace);
-  hid_t datatype = get_h5_datatype(mrc_fld_data_type(fld)); H5_CHK(datatype);
+  hid_t filespace = H5Screate_simple(fld->_dims.nr_vals, hdims, NULL);
+  H5_CHK(filespace);
+  hid_t datatype = get_h5_datatype(mrc_fld_data_type(fld));
+  H5_CHK(datatype);
   hid_t dset = H5Dcreate(group0, "fld", datatype, filespace, H5P_DEFAULT,
-			 H5P_DEFAULT, H5P_DEFAULT); H5_CHK(dset);
-  ierr = H5Dwrite(dset, datatype, H5S_ALL, filespace, H5P_DEFAULT, fld->_nd->arr); CE;
-  ierr = H5Dclose(dset); CE;
-  ierr = H5Sclose(filespace); CE;
+                         H5P_DEFAULT, H5P_DEFAULT);
+  H5_CHK(dset);
+  ierr =
+    H5Dwrite(dset, datatype, H5S_ALL, filespace, H5P_DEFAULT, fld->_nd->arr);
+  CE;
+  ierr = H5Dclose(dset);
+  CE;
+  ierr = H5Sclose(filespace);
+  CE;
 
-  ierr = H5Gclose(group0); CE;
+  ierr = H5Gclose(group0);
+  CE;
 }
 
-static void
-ds_xdmf_write_m3(struct mrc_io *io, const char *path, struct mrc_fld *m3)
+static void ds_xdmf_write_m3(struct mrc_io* io, const char* path,
+                             struct mrc_fld* m3)
 {
   int ierr;
-  struct diag_hdf5 *hdf5 = diag_hdf5(io);
+  struct diag_hdf5* hdf5 = diag_hdf5(io);
 
-  hid_t group0 = H5Gopen(hdf5->file, path, H5P_DEFAULT); H5_CHK(group0);
+  hid_t group0 = H5Gopen(hdf5->file, path, H5P_DEFAULT);
+  H5_CHK(group0);
   int nr_patches = mrc_fld_nr_patches(m3);
   H5LTset_attribute_int(group0, ".", "nr_patches", &nr_patches, 1);
 
   int bnd = 0; // number of ghost point layers to write
   // FIXME, this should be settable by the user somehow
 
-  mrc_fld_foreach_patch(m3, p) {
-    struct mrc_fld_patch *m3p = mrc_fld_patch_get(m3, p);
+  mrc_fld_foreach_patch(m3, p)
+  {
+    struct mrc_fld_patch* m3p = mrc_fld_patch_get(m3, p);
 
-    struct xdmf_spatial *xs = xdmf_spatial_find(io, "3df", -1);
+    struct xdmf_spatial* xs = xdmf_spatial_find(io, "3df", -1);
     if (!xs) {
       int np[3];
       mrc_domain_get_param_int3(m3->_domain, "np", np);
-      xs = xdmf_spatial_create_3d(io, m3->_ghost_dims, p, np[0] * np[1] * np[2]);
+      xs =
+        xdmf_spatial_create_3d(io, m3->_ghost_dims, p, np[0] * np[1] * np[2]);
       if (p == 0) {
-	hdf5_write_mcrds(io, m3->_domain, bnd);
+        hdf5_write_mcrds(io, m3->_domain, bnd);
       }
     }
 
@@ -1269,214 +1479,250 @@ ds_xdmf_write_m3(struct mrc_io *io, const char *path, struct mrc_fld *m3)
       char fld_name[strlen(mrc_fld_comp_name(m3, m)) + 5];
 
       if (nr_patches == 1) {
-	sprintf(fld_name, "%s", mrc_fld_comp_name(m3, m));
+        sprintf(fld_name, "%s", mrc_fld_comp_name(m3, m));
       } else {
-	sprintf(fld_name, "%s-%d", mrc_fld_comp_name(m3, m), p);
+        sprintf(fld_name, "%s-%d", mrc_fld_comp_name(m3, m), p);
       }
 
       save_fld_info(xs, strdup(fld_name), strdup(path), false);
 
-      hsize_t fdims[3] = { mrc_fld_dims(m3)[2] + 2 * bnd,
-			   mrc_fld_dims(m3)[1] + 2 * bnd,
-			   mrc_fld_dims(m3)[0] + 2 * bnd };
-      hsize_t mdims[3] = { mrc_fld_ghost_dims(m3)[2],
-			   mrc_fld_ghost_dims(m3)[1],
-			   mrc_fld_ghost_dims(m3)[0] };
-      hsize_t offs[3] = { -mrc_fld_ghost_offs(m3)[2] - bnd,
-			  -mrc_fld_ghost_offs(m3)[1] - bnd,
-			  -mrc_fld_ghost_offs(m3)[0] - bnd};
+      hsize_t fdims[3] = {mrc_fld_dims(m3)[2] + 2 * bnd,
+                          mrc_fld_dims(m3)[1] + 2 * bnd,
+                          mrc_fld_dims(m3)[0] + 2 * bnd};
+      hsize_t mdims[3] = {mrc_fld_ghost_dims(m3)[2], mrc_fld_ghost_dims(m3)[1],
+                          mrc_fld_ghost_dims(m3)[0]};
+      hsize_t offs[3] = {-mrc_fld_ghost_offs(m3)[2] - bnd,
+                         -mrc_fld_ghost_offs(m3)[1] - bnd,
+                         -mrc_fld_ghost_offs(m3)[0] - bnd};
 
       hid_t filespace = H5Screate_simple(3, fdims, NULL);
       hid_t memspace = H5Screate_simple(3, mdims, NULL);
       H5Sselect_hyperslab(memspace, H5S_SELECT_SET, offs, NULL, fdims, NULL);
 
-      hid_t group = H5Gcreate(group0, fld_name, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
-      hid_t dset = H5Dcreate(group, "3d", H5T_NATIVE_FLOAT, filespace, H5P_DEFAULT,
-			     H5P_DEFAULT, H5P_DEFAULT);
-      ierr  = H5Dwrite(dset, H5T_NATIVE_FLOAT, memspace, filespace, H5P_DEFAULT,
-		       &MRC_M3(m3p, 0, m3->_ghost_offs[0], m3->_ghost_offs[1], m3->_ghost_offs[2])); CE;
-      ierr = H5Dclose(dset); CE;
-      
+      hid_t group =
+        H5Gcreate(group0, fld_name, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
+      hid_t dset = H5Dcreate(group, "3d", H5T_NATIVE_FLOAT, filespace,
+                             H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
+      ierr = H5Dwrite(dset, H5T_NATIVE_FLOAT, memspace, filespace, H5P_DEFAULT,
+                      &MRC_M3(m3p, 0, m3->_ghost_offs[0], m3->_ghost_offs[1],
+                              m3->_ghost_offs[2]));
+      CE;
+      ierr = H5Dclose(dset);
+      CE;
+
       // ierr = H5LTmake_dataset_float(group, "3d", 3, hdims,
-      // 				    &MRC_M3(m3p, 0, m3->_ghost_offs[0], m3->_ghost_offs[1], m3->_ghost_offs[2])); CE;
-      ierr = H5Gclose(group); CE;
+      // 				    &MRC_M3(m3p, 0, m3->_ghost_offs[0],
+      // m3->_ghost_offs[1], m3->_ghost_offs[2])); CE;
+      ierr = H5Gclose(group);
+      CE;
       mrc_fld_patch_put(m3);
     }
   }
 
-  ierr = H5Gclose(group0); CE;
+  ierr = H5Gclose(group0);
+  CE;
 }
 
-struct read_fld_cb0_data {
-  struct mrc_io *io;
-  struct mrc_fld *fld;
+struct read_fld_cb0_data
+{
+  struct mrc_io* io;
+  struct mrc_fld* fld;
   hid_t filespace;
   hid_t memspace;
 };
 
-static herr_t
-read_fld_cb0(hid_t g_id, const char *name, const H5L_info_t *info, void *op_data)
+static herr_t read_fld_cb0(hid_t g_id, const char* name, const H5L_info_t* info,
+                           void* op_data)
 {
-  struct read_fld_cb0_data *data = op_data;
-  struct mrc_fld *fld = data->fld;
+  struct read_fld_cb0_data* data = op_data;
+  struct mrc_fld* fld = data->fld;
   herr_t ierr;
 
-  hid_t group = H5Gopen(g_id, name, H5P_DEFAULT); H5_CHK(group);
+  hid_t group = H5Gopen(g_id, name, H5P_DEFAULT);
+  H5_CHK(group);
   int m;
-  ierr = H5LTget_attribute_int(group, ".", "m", &m); CE;
+  ierr = H5LTget_attribute_int(group, ".", "m", &m);
+  CE;
   mrc_fld_set_comp_name(fld, m, name);
 
-  hid_t dset = H5Dopen(group, "3d", H5P_DEFAULT); H5_CHK(dset);
-  ierr = H5Dread(dset, H5T_NATIVE_FLOAT, data->memspace, data->filespace, H5P_DEFAULT,
-		 &MRC_F3(fld, m, fld->_ghost_offs[0], fld->_ghost_offs[1],
-			 fld->_ghost_offs[2])); CE;
-  ierr = H5Dclose(dset); CE;
+  hid_t dset = H5Dopen(group, "3d", H5P_DEFAULT);
+  H5_CHK(dset);
+  ierr = H5Dread(dset, H5T_NATIVE_FLOAT, data->memspace, data->filespace,
+                 H5P_DEFAULT,
+                 &MRC_F3(fld, m, fld->_ghost_offs[0], fld->_ghost_offs[1],
+                         fld->_ghost_offs[2]));
+  CE;
+  ierr = H5Dclose(dset);
+  CE;
 
-  ierr = H5Gclose(group); CE;
+  ierr = H5Gclose(group);
+  CE;
   return 0;
 }
 
-static void
-ds_xdmf_read_f3(struct mrc_io *io, const char *path, struct mrc_fld *fld)
+static void ds_xdmf_read_f3(struct mrc_io* io, const char* path,
+                            struct mrc_fld* fld)
 {
-  struct diag_hdf5 *hdf5 = diag_hdf5(io);
+  struct diag_hdf5* hdf5 = diag_hdf5(io);
   herr_t ierr;
 
-  hid_t group = H5Gopen(hdf5->file, path, H5P_DEFAULT); H5_CHK(group);
-  hsize_t hdims[3] = { fld->_ghost_dims[0], fld->_ghost_dims[1], fld->_ghost_dims[2] };
+  hid_t group = H5Gopen(hdf5->file, path, H5P_DEFAULT);
+  H5_CHK(group);
+  hsize_t hdims[3] = {fld->_ghost_dims[0], fld->_ghost_dims[1],
+                      fld->_ghost_dims[2]};
   hid_t filespace = H5Screate_simple(3, hdims, NULL);
   hid_t memspace = H5Screate_simple(3, hdims, NULL);
 
   struct read_fld_cb0_data cb_data = {
-    .io        = io,
-    .fld        = fld,
+    .io = io,
+    .fld = fld,
     .filespace = filespace,
-    .memspace  = memspace,
+    .memspace = memspace,
   };
   hsize_t idx = 0;
   ierr = H5Literate_by_name(group, ".", H5_INDEX_NAME, H5_ITER_INC, &idx,
-			    read_fld_cb0, &cb_data, H5P_DEFAULT); CE;
-  
-  ierr = H5Sclose(filespace); CE;
-  ierr = H5Sclose(memspace); CE;
-  ierr = H5Gclose(group); CE;
+                            read_fld_cb0, &cb_data, H5P_DEFAULT);
+  CE;
+
+  ierr = H5Sclose(filespace);
+  CE;
+  ierr = H5Sclose(memspace);
+  CE;
+  ierr = H5Gclose(group);
+  CE;
 }
 
-static void
-ds_xdmf_write_ndarray(struct mrc_io *io, const char *path, struct mrc_ndarray *nd)
+static void ds_xdmf_write_ndarray(struct mrc_io* io, const char* path,
+                                  struct mrc_ndarray* nd)
 {
   int ierr;
-  struct diag_hdf5 *hdf5 = diag_hdf5(io);
+  struct diag_hdf5* hdf5 = diag_hdf5(io);
 
   assert(nd->n_dims);
   assert(mrc_ndarray_f_contiguous(nd));
 
-  hid_t group0 = H5Gopen(hdf5->file, path, H5P_DEFAULT); H5_CHK(group0);
+  hid_t group0 = H5Gopen(hdf5->file, path, H5P_DEFAULT);
+  H5_CHK(group0);
 
   hsize_t hdims[nd->n_dims];
   // reverse dims because HDF5 expects C order
   for (int d = 0; d < nd->n_dims; d++) {
     hdims[d] = nd->dims.vals[nd->n_dims - 1 - d];
   }
-  hid_t filespace = H5Screate_simple(nd->n_dims, hdims, NULL); H5_CHK(filespace);
-  hid_t datatype = get_h5_datatype(mrc_ndarray_data_type(nd)); H5_CHK(datatype);
+  hid_t filespace = H5Screate_simple(nd->n_dims, hdims, NULL);
+  H5_CHK(filespace);
+  hid_t datatype = get_h5_datatype(mrc_ndarray_data_type(nd));
+  H5_CHK(datatype);
   hid_t dset = H5Dcreate(group0, "ndarray", datatype, filespace, H5P_DEFAULT,
-			 H5P_DEFAULT, H5P_DEFAULT); H5_CHK(dset);
-  ierr = H5Dwrite(dset, datatype, H5S_ALL, filespace, H5P_DEFAULT, nd->arr); CE;
-  ierr = H5Dclose(dset); CE;
-  ierr = H5Sclose(filespace); CE;
+                         H5P_DEFAULT, H5P_DEFAULT);
+  H5_CHK(dset);
+  ierr = H5Dwrite(dset, datatype, H5S_ALL, filespace, H5P_DEFAULT, nd->arr);
+  CE;
+  ierr = H5Dclose(dset);
+  CE;
+  ierr = H5Sclose(filespace);
+  CE;
 
-  ierr = H5Gclose(group0); CE;
+  ierr = H5Gclose(group0);
+  CE;
 }
 
-static void
-ds_xdmf_read_ndarray(struct mrc_io *io, const char *path, struct mrc_ndarray *nd)
+static void ds_xdmf_read_ndarray(struct mrc_io* io, const char* path,
+                                 struct mrc_ndarray* nd)
 {
   int ierr;
-  struct diag_hdf5 *hdf5 = diag_hdf5(io);
+  struct diag_hdf5* hdf5 = diag_hdf5(io);
 
   assert(mrc_ndarray_f_contiguous(nd));
 
-  hid_t group0 = H5Gopen(hdf5->file, path, H5P_DEFAULT); H5_CHK(group0);
+  hid_t group0 = H5Gopen(hdf5->file, path, H5P_DEFAULT);
+  H5_CHK(group0);
 
   hsize_t hdims[nd->n_dims];
   // reverse dims because HDF5 expects C order
   for (int d = 0; d < nd->n_dims; d++) {
     hdims[d] = nd->dims.vals[nd->n_dims - 1 - d];
   }
-  hid_t filespace = H5Screate_simple(nd->n_dims, hdims, NULL); H5_CHK(filespace);
-  hid_t datatype = get_h5_datatype(mrc_ndarray_data_type(nd)); H5_CHK(datatype);
-  hid_t dset = H5Dopen(group0, "ndarray", H5P_DEFAULT); H5_CHK(dset);
-  ierr = H5Dread(dset, datatype, H5S_ALL, filespace, H5P_DEFAULT, nd->arr); CE;
-  ierr = H5Dclose(dset); CE;
-  ierr = H5Sclose(filespace); CE;
+  hid_t filespace = H5Screate_simple(nd->n_dims, hdims, NULL);
+  H5_CHK(filespace);
+  hid_t datatype = get_h5_datatype(mrc_ndarray_data_type(nd));
+  H5_CHK(datatype);
+  hid_t dset = H5Dopen(group0, "ndarray", H5P_DEFAULT);
+  H5_CHK(dset);
+  ierr = H5Dread(dset, datatype, H5S_ALL, filespace, H5P_DEFAULT, nd->arr);
+  CE;
+  ierr = H5Dclose(dset);
+  CE;
+  ierr = H5Sclose(filespace);
+  CE;
 
-  ierr = H5Gclose(group0); CE;
+  ierr = H5Gclose(group0);
+  CE;
 }
 
-static void
-ds_xdmf_get_h5_file(struct mrc_io *io, long *h5_file)
+static void ds_xdmf_get_h5_file(struct mrc_io* io, long* h5_file)
 {
-  struct diag_hdf5 *hdf5 = diag_hdf5(io);
+  struct diag_hdf5* hdf5 = diag_hdf5(io);
   *h5_file = hdf5->file;
 }
 
 struct mrc_io_ops mrc_io_xdmf_ops = {
-  .name          = "xdmf",
-  .size          = sizeof(struct diag_hdf5),
-  .parallel      = true,
-  .destroy       = ds_xdmf_destroy,
-  .setup         = ds_xdmf_setup,
-  .open          = ds_xdmf_open,
-  .close         = ds_xdmf_close,
-  .write_field   = ds_xdmf_write_field,
+  .name = "xdmf",
+  .size = sizeof(struct diag_hdf5),
+  .parallel = true,
+  .destroy = ds_xdmf_destroy,
+  .setup = ds_xdmf_setup,
+  .open = ds_xdmf_open,
+  .close = ds_xdmf_close,
+  .write_field = ds_xdmf_write_field,
   .write_field2d = ds_xdmf_write_field2d,
-  .write_attr    = ds_xdmf_write_attr,
-  .write_m1      = ds_xdmf_write_m1,
-  .write_m3      = ds_xdmf_write_m3,
+  .write_attr = ds_xdmf_write_attr,
+  .write_m1 = ds_xdmf_write_m1,
+  .write_m3 = ds_xdmf_write_m3,
 };
 
 struct mrc_io_ops mrc_io_xdmf_serial_ops = {
-  .name          = "xdmf_serial",
-  .size          = sizeof(struct diag_hdf5),
-  .destroy       = ds_xdmf_destroy,
-  .setup         = ds_xdmf_setup,
-  .open          = ds_xdmf_open,
-  .close         = ds_xdmf_close,
-  .write_field   = ds_xdmf_write_field,
+  .name = "xdmf_serial",
+  .size = sizeof(struct diag_hdf5),
+  .destroy = ds_xdmf_destroy,
+  .setup = ds_xdmf_setup,
+  .open = ds_xdmf_open,
+  .close = ds_xdmf_close,
+  .write_field = ds_xdmf_write_field,
   .write_field2d = ds_xdmf_write_field2d,
-  .write_m3      = ds_xdmf_write_m3,
-  .read_f3       = ds_xdmf_read_f3,
-  .write_m1      = ds_xdmf_write_m1,
-  .read_m1       = ds_xdmf_read_m1,
-  .write_attr    = ds_xdmf_write_attr,
-  .read_attr     = ds_xdmf_read_attr,
-  .get_h5_file   = ds_xdmf_get_h5_file,
+  .write_m3 = ds_xdmf_write_m3,
+  .read_f3 = ds_xdmf_read_f3,
+  .write_m1 = ds_xdmf_write_m1,
+  .read_m1 = ds_xdmf_read_m1,
+  .write_attr = ds_xdmf_write_attr,
+  .read_attr = ds_xdmf_read_attr,
+  .get_h5_file = ds_xdmf_get_h5_file,
 };
 
 struct mrc_io_ops mrc_io_hdf5_serial_ops = {
-  .name          = "hdf5_serial",
-  .size          = sizeof(struct diag_hdf5),
-  .destroy       = ds_xdmf_destroy,
-  .setup         = ds_xdmf_setup,
-  .open          = ds_xdmf_open,
-  .close         = ds_xdmf_close,
-  .write_field   = ds_xdmf_write_field,
+  .name = "hdf5_serial",
+  .size = sizeof(struct diag_hdf5),
+  .destroy = ds_xdmf_destroy,
+  .setup = ds_xdmf_setup,
+  .open = ds_xdmf_open,
+  .close = ds_xdmf_close,
+  .write_field = ds_xdmf_write_field,
   .write_field2d = ds_xdmf_write_field2d,
-  .write_fld     = ds_xdmf_write_fld,
-  .read_fld      = ds_xdmf_read_fld,
-  .write_m1      = ds_xdmf_write_m1,
-  .read_m1       = ds_xdmf_read_m1,
+  .write_fld = ds_xdmf_write_fld,
+  .read_fld = ds_xdmf_read_fld,
+  .write_m1 = ds_xdmf_write_m1,
+  .read_m1 = ds_xdmf_read_m1,
   .write_ndarray = ds_xdmf_write_ndarray,
-  .read_ndarray  = ds_xdmf_read_ndarray,
-  .write_attr    = ds_xdmf_write_attr,
-  .read_attr     = ds_xdmf_read_attr,
-  .get_h5_file   = ds_xdmf_get_h5_file,
+  .read_ndarray = ds_xdmf_read_ndarray,
+  .write_attr = ds_xdmf_write_attr,
+  .read_attr = ds_xdmf_read_attr,
+  .get_h5_file = ds_xdmf_get_h5_file,
 };
 
 // ======================================================================
 
-enum {
+enum
+{
   TAG_OFF_DIMS = 150000,
   TAG_DATA,
   TAG_CRDX,
@@ -1484,15 +1730,14 @@ enum {
   TAG_CRDZ,
 };
 
-static void
-ds_xdmf_to_one_open(struct mrc_io *io, const char *mode) 
+static void ds_xdmf_to_one_open(struct mrc_io* io, const char* mode)
 {
   assert(strcmp(mode, "w") == 0);
 #ifndef NDEBUG
   MPI_Barrier(io->obj.comm);
 #endif
-  
-  struct diag_hdf5 *hdf5 = diag_hdf5(io);
+
+  struct diag_hdf5* hdf5 = diag_hdf5(io);
   hdf5->crds_done = false;
   if (io->rank != 0)
     return;
@@ -1500,41 +1745,41 @@ ds_xdmf_to_one_open(struct mrc_io *io, const char *mode)
   xdmf_open(io, mode);
 }
 
-static void
-ds_xdmf_to_one_close(struct mrc_io *io)
+static void ds_xdmf_to_one_close(struct mrc_io* io)
 {
   herr_t ierr;
 #ifndef NDEBUG
   MPI_Barrier(io->obj.comm);
 #endif
-  
+
   if (io->rank != 0)
     return;
 
-  struct diag_hdf5 *hdf5 = diag_hdf5(io);
+  struct diag_hdf5* hdf5 = diag_hdf5(io);
 
-  ierr = H5Gclose(hdf5->group_crd); CE;
+  ierr = H5Gclose(hdf5->group_crd);
+  CE;
   hdf5_close(io);
 }
 
-static void
-ds_xdmf_to_one_write_attr(struct mrc_io *io, const char *path, int type,
-			 const char *name, union param_u *pv)
+static void ds_xdmf_to_one_write_attr(struct mrc_io* io, const char* path,
+                                      int type, const char* name,
+                                      union param_u* pv)
 {
   if (io->rank == 0) {
     ds_xdmf_write_attr(io, path, type, name, pv);
   }
 }
 
-static void
-communicate_crds(struct mrc_io *io, struct mrc_fld *gfld, struct mrc_fld *lfld)
+static void communicate_crds(struct mrc_io* io, struct mrc_fld* gfld,
+                             struct mrc_fld* lfld)
 {
-  struct mrc_domain *gdomain = gfld->_domain;
-  struct mrc_crds *gcrds = mrc_domain_get_crds(gdomain);
+  struct mrc_domain* gdomain = gfld->_domain;
+  struct mrc_crds* gcrds = mrc_domain_get_crds(gdomain);
   if (io->rank != 0) {
     int iw[6], *ib = iw, *im = iw + 3;
     int nr_patches;
-    struct mrc_patch *patches = mrc_domain_get_patches(gdomain, &nr_patches);
+    struct mrc_patch* patches = mrc_domain_get_patches(gdomain, &nr_patches);
     assert(nr_patches == 1);
     for (int d = 0; d < 3; d++) {
       ib[d] = patches[0].off[d];
@@ -1543,98 +1788,104 @@ communicate_crds(struct mrc_io *io, struct mrc_fld *gfld, struct mrc_fld *lfld)
     MPI_Send(iw, 6, MPI_INT, 0, TAG_OFF_DIMS, io->obj.comm);
     for (int d = 0; d < 3; d++) {
       MPI_Send(&MRC_CRD(gcrds, d, gfld->_sw.vals[d]), im[d], MPI_FLOAT, 0,
-	       TAG_CRDX + d, io->obj.comm);
+               TAG_CRDX + d, io->obj.comm);
     }
   } else { // io->rank == 0
-    struct mrc_domain *ldomain = lfld->_domain;
-    struct mrc_crds *lcrds = mrc_domain_get_crds(ldomain);
+    struct mrc_domain* ldomain = lfld->_domain;
+    struct mrc_crds* lcrds = mrc_domain_get_crds(ldomain);
     for (int n = 0; n < io->size; n++) {
-      float *recv_crds[3];
+      float* recv_crds[3];
       int iw[6], *ib = iw, *im = iw + 3;
       if (n == 0) {
-	int nr_patches;
-	struct mrc_patch *patches = mrc_domain_get_patches(gdomain, &nr_patches);
-	assert(nr_patches == 1);
-	for (int d = 0; d < 3; d++) {
-	  ib[d] = patches[0].off[d];
-	  im[d] = patches[0].ldims[d];
-	}
-	for (int d = 0; d < 3; d++) {
-	  recv_crds[d] = &MRC_CRD(gcrds, d, gfld->_sw.vals[d]);
-	}
+        int nr_patches;
+        struct mrc_patch* patches =
+          mrc_domain_get_patches(gdomain, &nr_patches);
+        assert(nr_patches == 1);
+        for (int d = 0; d < 3; d++) {
+          ib[d] = patches[0].off[d];
+          im[d] = patches[0].ldims[d];
+        }
+        for (int d = 0; d < 3; d++) {
+          recv_crds[d] = &MRC_CRD(gcrds, d, gfld->_sw.vals[d]);
+        }
       } else {
-	MPI_Recv(iw, 6, MPI_INT, n, TAG_OFF_DIMS, io->obj.comm, MPI_STATUS_IGNORE);
-	for (int d = 0; d < 3; d++) {
-	  recv_crds[d] = calloc(im[d], sizeof(*recv_crds[d]));
-	  MPI_Recv(recv_crds[d], im[d], MPI_FLOAT, n, TAG_CRDX + d, io->obj.comm,
-		   MPI_STATUS_IGNORE);
-	}
+        MPI_Recv(iw, 6, MPI_INT, n, TAG_OFF_DIMS, io->obj.comm,
+                 MPI_STATUS_IGNORE);
+        for (int d = 0; d < 3; d++) {
+          recv_crds[d] = calloc(im[d], sizeof(*recv_crds[d]));
+          MPI_Recv(recv_crds[d], im[d], MPI_FLOAT, n, TAG_CRDX + d,
+                   io->obj.comm, MPI_STATUS_IGNORE);
+        }
       }
 
       for (int d = 0; d < 3; d++) {
-	for (int i = 0; i < im[d]; i++) {
-	  MRC_CRD(lcrds, d, i + ib[d]) = recv_crds[d][i];
-	}
+        for (int i = 0; i < im[d]; i++) {
+          MRC_CRD(lcrds, d, i + ib[d]) = recv_crds[d][i];
+        }
       }
-      
+
       if (n != 0) {
-	for (int d = 0; d < 3; d++) {
-	  free(recv_crds[d]);
-	}
+        for (int d = 0; d < 3; d++) {
+          free(recv_crds[d]);
+        }
       }
     }
   }
 }
 
-static void
-communicate_fld(struct mrc_io *io, struct mrc_fld *gfld, int m, float scale,
-		struct mrc_fld *lfld)
+static void communicate_fld(struct mrc_io* io, struct mrc_fld* gfld, int m,
+                            float scale, struct mrc_fld* lfld)
 {
-  struct mrc_fld *send_fld = mrc_domain_fld_create(gfld->_domain, SW_0, NULL);
+  struct mrc_fld* send_fld = mrc_domain_fld_create(gfld->_domain, SW_0, NULL);
   mrc_fld_setup(send_fld);
   copy_and_scale(send_fld, 0, gfld, m, scale);
 
   if (io->rank != 0) {
     int iw[6], *off = iw, *dim = iw + 3;
     int nr_patches;
-    struct mrc_patch *patches = mrc_domain_get_patches(send_fld->_domain, &nr_patches);
+    struct mrc_patch* patches =
+      mrc_domain_get_patches(send_fld->_domain, &nr_patches);
     assert(nr_patches == 1);
     for (int d = 0; d < 3; d++) {
       off[d] = patches[0].off[d];
       dim[d] = patches[0].ldims[d];
     }
     MPI_Send(iw, 6, MPI_INT, 0, TAG_OFF_DIMS, io->obj.comm);
-    MPI_Send(send_fld->_nd->arr, mrc_fld_len(send_fld), MPI_FLOAT, 0, TAG_DATA, io->obj.comm);
+    MPI_Send(send_fld->_nd->arr, mrc_fld_len(send_fld), MPI_FLOAT, 0, TAG_DATA,
+             io->obj.comm);
   } else { // io->rank == 0
     for (int n = 0; n < io->size; n++) {
-      struct mrc_fld *recv_fld;
+      struct mrc_fld* recv_fld;
       if (n == 0) {
-	recv_fld = mrc_fld_create(MPI_COMM_SELF);
-	const int *dims = mrc_fld_dims(send_fld);
-	const int *offs = mrc_fld_offs(send_fld);
-	mrc_fld_set_param_int_array(recv_fld, "dims", 4,
-				   (int[4]) { dims[0], dims[1], dims[2], 1 });
-	mrc_fld_set_param_int_array(recv_fld, "offs", 4,
-				   (int[4]) { offs[0], offs[1], offs[2], 0 });
-	mrc_fld_set_array(recv_fld, send_fld->_nd->arr);
-	mrc_fld_setup(recv_fld);
+        recv_fld = mrc_fld_create(MPI_COMM_SELF);
+        const int* dims = mrc_fld_dims(send_fld);
+        const int* offs = mrc_fld_offs(send_fld);
+        mrc_fld_set_param_int_array(recv_fld, "dims", 4,
+                                    (int[4]){dims[0], dims[1], dims[2], 1});
+        mrc_fld_set_param_int_array(recv_fld, "offs", 4,
+                                    (int[4]){offs[0], offs[1], offs[2], 0});
+        mrc_fld_set_array(recv_fld, send_fld->_nd->arr);
+        mrc_fld_setup(recv_fld);
       } else {
-	int iw[6], *off = iw, *dim = iw + 3;
-	MPI_Recv(iw, 6, MPI_INT, n, TAG_OFF_DIMS, io->obj.comm, MPI_STATUS_IGNORE);
-	recv_fld = mrc_fld_create(MPI_COMM_SELF);
-	mrc_fld_set_param_int_array(recv_fld, "dims", 4,
-				   (int[4]) { dim[0], dim[1], dim[2], 1 });
-	mrc_fld_set_param_int_array(recv_fld, "offs", 4,
-				   (int[4]) { off[0], off[1], off[2], 0 });
-	mrc_fld_setup(recv_fld);
-	MPI_Recv(recv_fld->_nd->arr, mrc_fld_len(recv_fld), MPI_FLOAT, n, TAG_DATA, io->obj.comm,
-		 MPI_STATUS_IGNORE);
+        int iw[6], *off = iw, *dim = iw + 3;
+        MPI_Recv(iw, 6, MPI_INT, n, TAG_OFF_DIMS, io->obj.comm,
+                 MPI_STATUS_IGNORE);
+        recv_fld = mrc_fld_create(MPI_COMM_SELF);
+        mrc_fld_set_param_int_array(recv_fld, "dims", 4,
+                                    (int[4]){dim[0], dim[1], dim[2], 1});
+        mrc_fld_set_param_int_array(recv_fld, "offs", 4,
+                                    (int[4]){off[0], off[1], off[2], 0});
+        mrc_fld_setup(recv_fld);
+        MPI_Recv(recv_fld->_nd->arr, mrc_fld_len(recv_fld), MPI_FLOAT, n,
+                 TAG_DATA, io->obj.comm, MPI_STATUS_IGNORE);
       }
-      
-      mrc_fld_foreach(recv_fld, ix,iy,iz, 0, 0) {
-	MRC_F3(lfld,0, ix,iy,iz) = MRC_F3(recv_fld,0, ix,iy,iz);
-      } mrc_fld_foreach_end;
-      
+
+      mrc_fld_foreach(recv_fld, ix, iy, iz, 0, 0)
+      {
+        MRC_F3(lfld, 0, ix, iy, iz) = MRC_F3(recv_fld, 0, ix, iy, iz);
+      }
+      mrc_fld_foreach_end;
+
       mrc_fld_destroy(recv_fld);
     }
   }
@@ -1642,26 +1893,25 @@ communicate_fld(struct mrc_io *io, struct mrc_fld *gfld, int m, float scale,
   mrc_fld_destroy(send_fld);
 }
 
-static void
-ds_xdmf_to_one_write_field(struct mrc_io *io, const char *path,
-			   float scale, struct mrc_fld *fld, int m)
+static void ds_xdmf_to_one_write_field(struct mrc_io* io, const char* path,
+                                       float scale, struct mrc_fld* fld, int m)
 {
-  struct diag_hdf5 *hdf5 = diag_hdf5(io);
+  struct diag_hdf5* hdf5 = diag_hdf5(io);
   herr_t ierr;
 
 #ifndef NDEBUG
   MPI_Barrier(io->obj.comm);
 #endif
   int gdims[3];
-  struct mrc_domain *ldomain = NULL;
-  struct mrc_fld *lfld = NULL;
+  struct mrc_domain* ldomain = NULL;
+  struct mrc_fld* lfld = NULL;
 
   if (io->rank == 0) {
     mrc_domain_get_global_dims(fld->_domain, gdims);
     ldomain = mrc_domain_create(MPI_COMM_SELF);
     mrc_domain_set_type(ldomain, "simple");
     mrc_domain_set_param_int3(ldomain, "m", gdims);
-    struct mrc_crds *crds = mrc_domain_get_crds(ldomain);
+    struct mrc_crds* crds = mrc_domain_get_crds(ldomain);
     mrc_crds_set_type(crds, "rectilinear");
     mrc_domain_setup(ldomain);
     lfld = mrc_domain_fld_create(ldomain, SW_0, NULL);
@@ -1679,35 +1929,38 @@ ds_xdmf_to_one_write_field(struct mrc_io *io, const char *path,
     return;
   }
 
-  struct xdmf_spatial *xs = xdmf_spatial_find(io, "3df", -1);
+  struct xdmf_spatial* xs = xdmf_spatial_find(io, "3df", -1);
   if (!xs) {
     xs = xdmf_spatial_create_3d(io, gdims, -1, 1);
     hdf5_write_crds(io, gdims, ldomain, fld->_sw.vals[0]);
   }
   save_fld_info(xs, strdup(mrc_fld_comp_name(fld, m)), strdup(path), false);
 
-  hid_t group0 = H5Gopen(hdf5->file, path, H5P_DEFAULT); H5_CHK(group0);
-  const int *dims = mrc_fld_dims(lfld);
-  hsize_t hdims[3] = { dims[2], dims[1], dims[0] };
-  hid_t group = H5Gcreate(group0, mrc_fld_comp_name(fld, m), H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
+  hid_t group0 = H5Gopen(hdf5->file, path, H5P_DEFAULT);
+  H5_CHK(group0);
+  const int* dims = mrc_fld_dims(lfld);
+  hsize_t hdims[3] = {dims[2], dims[1], dims[0]};
+  hid_t group = H5Gcreate(group0, mrc_fld_comp_name(fld, m), H5P_DEFAULT,
+                          H5P_DEFAULT, H5P_DEFAULT);
   H5LTmake_dataset_float(group, "3d", 3, hdims, lfld->_nd->arr);
-  ierr = H5Gclose(group); CE;
-  ierr = H5Gclose(group0); CE;
+  ierr = H5Gclose(group);
+  CE;
+  ierr = H5Gclose(group0);
+  CE;
 
   mrc_fld_destroy(lfld);
 }
 
-
 struct mrc_io_ops mrc_io_xdmf_to_one_ops = {
-  .name          = "xdmf_to_one",
-  .size          = sizeof(struct diag_hdf5),
-  .parallel      = true,
-  .destroy       = ds_xdmf_destroy,
-  .setup         = ds_xdmf_setup,
-  .open          = ds_xdmf_to_one_open,
-  .close         = ds_xdmf_to_one_close,
-  .write_field   = ds_xdmf_to_one_write_field,
-  .write_attr    = ds_xdmf_to_one_write_attr,
+  .name = "xdmf_to_one",
+  .size = sizeof(struct diag_hdf5),
+  .parallel = true,
+  .destroy = ds_xdmf_destroy,
+  .setup = ds_xdmf_setup,
+  .open = ds_xdmf_to_one_open,
+  .close = ds_xdmf_to_one_close,
+  .write_field = ds_xdmf_to_one_write_field,
+  .write_attr = ds_xdmf_to_one_write_attr,
 };
 
 #ifdef H5_HAVE_PARALLEL
@@ -1715,29 +1968,31 @@ struct mrc_io_ops mrc_io_xdmf_to_one_ops = {
 // ======================================================================
 // xdmf_parallel
 
-static void
-ds_xdmf_parallel_open(struct mrc_io *io, const char *mode) 
+static void ds_xdmf_parallel_open(struct mrc_io* io, const char* mode)
 {
 #ifndef NDEBUG
   MPI_Barrier(io->obj.comm);
 #endif
-  
-  struct diag_hdf5 *hdf5 = diag_hdf5(io);
+
+  struct diag_hdf5* hdf5 = diag_hdf5(io);
   hdf5->mode = strdup(mode);
   hdf5->crds_done = false;
 
   char filename[strlen(io->par.outdir) + strlen(io->par.basename) + 20];
   sprintf(filename, "%s/%s.%06d_p%06d.h5", io->par.outdir, io->par.basename,
-	  io->step, 0);
+          io->step, 0);
 
   hid_t plist = H5Pcreate(H5P_FILE_ACCESS);
   H5Pset_fapl_mpio(plist, io->obj.comm, MPI_INFO_NULL);
   if (strcmp(mode, "w") == 0) {
     hdf5->file = H5Fcreate(filename, H5F_ACC_TRUNC, H5P_DEFAULT, plist);
-    hdf5->group_crd = H5Gcreate(hdf5->file, "crd", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
+    hdf5->group_crd =
+      H5Gcreate(hdf5->file, "crd", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
   } else if (strcmp(mode, "r") == 0) {
-    hdf5->file = H5Fopen(filename, H5F_ACC_RDONLY, plist); H5_CHK(hdf5->file);
-    hdf5->group_crd = H5Gopen(hdf5->file, "crd", H5P_DEFAULT); H5_CHK(hdf5->group_crd);
+    hdf5->file = H5Fopen(filename, H5F_ACC_RDONLY, plist);
+    H5_CHK(hdf5->file);
+    hdf5->group_crd = H5Gopen(hdf5->file, "crd", H5P_DEFAULT);
+    H5_CHK(hdf5->group_crd);
   } else {
     assert(0);
   }
@@ -1750,17 +2005,17 @@ ds_xdmf_parallel_open(struct mrc_io *io, const char *mode)
   INIT_LIST_HEAD(&hdf5->xdmf_spatial_list);
 }
 
-static void
-ds_xdmf_parallel_close(struct mrc_io *io)
+static void ds_xdmf_parallel_close(struct mrc_io* io)
 {
 #ifndef NDEBUG
   MPI_Barrier(io->obj.comm);
 #endif
-  
-  struct diag_hdf5 *hdf5 = diag_hdf5(io);
+
+  struct diag_hdf5* hdf5 = diag_hdf5(io);
   herr_t ierr;
 
-  ierr = H5Gclose(hdf5->group_crd); CE;
+  ierr = H5Gclose(hdf5->group_crd);
+  CE;
   if (strcmp(hdf5->mode, "w") == 0) {
     hdf5_close(io);
   } else {
@@ -1773,17 +2028,16 @@ ds_xdmf_parallel_close(struct mrc_io *io)
   xdmf_close(io);
 }
 
-static void
-hdf5_write_crds_parallel(struct mrc_io *io, struct mrc_fld *fld)
+static void hdf5_write_crds_parallel(struct mrc_io* io, struct mrc_fld* fld)
 {
-  struct diag_hdf5 *hdf5 = diag_hdf5(io);
+  struct diag_hdf5* hdf5 = diag_hdf5(io);
 
-  const char *xyz[3] = { "x", "y", "z" };
+  const char* xyz[3] = {"x", "y", "z"};
 
   int gdims[3], nr_procs[3];
   mrc_domain_get_global_dims(fld->_domain, gdims);
   int nr_patches;
-  struct mrc_patch *patches = mrc_domain_get_patches(fld->_domain, &nr_patches);
+  struct mrc_patch* patches = mrc_domain_get_patches(fld->_domain, &nr_patches);
   assert(nr_patches == 1);
   int *ldims = patches[0].ldims, *off = patches[0].off;
   struct mrc_patch_info info;
@@ -1793,46 +2047,48 @@ hdf5_write_crds_parallel(struct mrc_io *io, struct mrc_fld *fld)
     bool skip_write = false;
     for (int dd = 0; dd < 3; dd++) {
       if (dd != d && info.idx3[dd] != 0) {
-	skip_write = true;
-	break;
+        skip_write = true;
+        break;
       }
     }
-    hsize_t hgdims[1] = { gdims[d] + 1 };
-    hsize_t hldims[1] = { ldims[d] };
-    hsize_t hoff[1] = { off[d] };
+    hsize_t hgdims[1] = {gdims[d] + 1};
+    hsize_t hldims[1] = {ldims[d]};
+    hsize_t hoff[1] = {off[d]};
     if (info.idx3[d] == nr_procs[d] - 1) {
       hldims[0]++;
     }
     hid_t filespace = H5Screate_simple(1, hgdims, NULL);
     hid_t memspace = H5Screate_simple(1, hldims, NULL);
-    hid_t dset = H5Dcreate(hdf5->group_crd, xyz[d], H5T_NATIVE_FLOAT, filespace, H5P_DEFAULT,
-			   H5P_DEFAULT, H5P_DEFAULT);
+    hid_t dset = H5Dcreate(hdf5->group_crd, xyz[d], H5T_NATIVE_FLOAT, filespace,
+                           H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
     if (!skip_write) {
       // FIXME make sure it is indep I/O
       H5Sselect_hyperslab(filespace, H5S_SELECT_SET, hoff, NULL, hldims, NULL);
-      struct mrc_crds *crds = mrc_domain_get_crds(fld->_domain);
-      float *crd = &MRC_CRD(crds, d, fld->_sw.vals[0]);
-      float *crd_nc = calloc(ldims[d] + 1, sizeof(*crd_nc));
+      struct mrc_crds* crds = mrc_domain_get_crds(fld->_domain);
+      float* crd = &MRC_CRD(crds, d, fld->_sw.vals[0]);
+      float* crd_nc = calloc(ldims[d] + 1, sizeof(*crd_nc));
 
       if (fld->_sw.vals[0] > 0) { // FIXME, shouldn't be done here, and should
-	                 // be based on sw for the crds
-	for (int i = 0; i <= ldims[d]; i++) {
-	  crd_nc[i] = .5 * (crd[i-1] + crd[i]);
-	}
+                                  // be based on sw for the crds
+        for (int i = 0; i <= ldims[d]; i++) {
+          crd_nc[i] = .5 * (crd[i - 1] + crd[i]);
+        }
       } else {
-	if (ldims[d] > 1) {
-	  for (int i = 1; i < ldims[d]; i++) {
-	    crd_nc[i] = .5 * (crd[i-1] + crd[i]);
-	  }
-	  // extrapolate
-	  crd_nc[0]  = crd[0] - .5 * (crd[1] - crd[0]);
-	  crd_nc[ldims[d]] = crd[ldims[d]-1] + .5 * (crd[ldims[d]-1] - crd[ldims[d]-2]);
-	} else { // this is an invariant direction...
-	  crd_nc[0] = crd[0] - 5e-3;
-	  crd_nc[1] = crd[0] + 5e-3;
-	}
+        if (ldims[d] > 1) {
+          for (int i = 1; i < ldims[d]; i++) {
+            crd_nc[i] = .5 * (crd[i - 1] + crd[i]);
+          }
+          // extrapolate
+          crd_nc[0] = crd[0] - .5 * (crd[1] - crd[0]);
+          crd_nc[ldims[d]] =
+            crd[ldims[d] - 1] + .5 * (crd[ldims[d] - 1] - crd[ldims[d] - 2]);
+        } else { // this is an invariant direction...
+          crd_nc[0] = crd[0] - 5e-3;
+          crd_nc[1] = crd[0] + 5e-3;
+        }
       }
-      H5Dwrite(dset, H5T_NATIVE_FLOAT, memspace, filespace, H5P_DEFAULT, crd_nc);
+      H5Dwrite(dset, H5T_NATIVE_FLOAT, memspace, filespace, H5P_DEFAULT,
+               crd_nc);
     }
     H5Dclose(dset);
     H5Sclose(filespace);
@@ -1840,19 +2096,20 @@ hdf5_write_crds_parallel(struct mrc_io *io, struct mrc_fld *fld)
   }
 }
 
-struct read_f1_cb_data {
-  struct mrc_io *io;
-  struct mrc_fld *fld;
-  struct mrc_fld *lfld;
+struct read_f1_cb_data
+{
+  struct mrc_io* io;
+  struct mrc_fld* fld;
+  struct mrc_fld* lfld;
   hid_t filespace;
   hid_t memspace;
   hid_t dxpl;
 };
 
-static herr_t
-read_f1_cb(hid_t g_id, const char *name, const H5L_info_t *info, void *op_data)
+static herr_t read_f1_cb(hid_t g_id, const char* name, const H5L_info_t* info,
+                         void* op_data)
 {
-  struct read_f1_cb_data *data = op_data;
+  struct read_f1_cb_data* data = op_data;
   herr_t ierr;
 
   hid_t group = H5Gopen(g_id, name, H5P_DEFAULT);
@@ -1860,18 +2117,20 @@ read_f1_cb(hid_t g_id, const char *name, const H5L_info_t *info, void *op_data)
   H5LTget_attribute_int(group, ".", "m", &m);
 
   hid_t dset = H5Dopen(group, "1d", H5P_DEFAULT);
-  H5Dread(dset, H5T_NATIVE_FLOAT, data->memspace, data->filespace, data->dxpl, data->fld->_nd->arr);
+  H5Dread(dset, H5T_NATIVE_FLOAT, data->memspace, data->filespace, data->dxpl,
+          data->fld->_nd->arr);
   H5Dclose(dset);
 
-  ierr = H5Gclose(group); CE;
+  ierr = H5Gclose(group);
+  CE;
 
   return 0;
 }
 
-static void
-ds_xdmf_parallel_read_m1(struct mrc_io *io, const char *path, struct mrc_fld *f1)
+static void ds_xdmf_parallel_read_m1(struct mrc_io* io, const char* path,
+                                     struct mrc_fld* f1)
 {
-  struct diag_hdf5 *hdf5 = diag_hdf5(io);
+  struct diag_hdf5* hdf5 = diag_hdf5(io);
   herr_t ierr;
 
   assert(mrc_fld_nr_patches(f1) == 1);
@@ -1882,8 +2141,8 @@ ds_xdmf_parallel_read_m1(struct mrc_io *io, const char *path, struct mrc_fld *f1
 #endif
 
   hid_t group0 = H5Gopen(hdf5->file, path, H5P_DEFAULT);
-  const int *ghost_dims = mrc_fld_ghost_dims(f1);
-  hsize_t hdims[1] = { ghost_dims[0] };
+  const int* ghost_dims = mrc_fld_ghost_dims(f1);
+  hsize_t hdims[1] = {ghost_dims[0]};
 
   hid_t filespace = H5Screate_simple(1, hdims, NULL);
   hid_t memspace = H5Screate_simple(1, hdims, NULL);
@@ -1895,36 +2154,38 @@ ds_xdmf_parallel_read_m1(struct mrc_io *io, const char *path, struct mrc_fld *f1
   }
 
   struct read_f1_cb_data cb_data = {
-    .io        = io,
-    .fld       = f1,
+    .io = io,
+    .fld = f1,
     .filespace = filespace,
-    .memspace  = memspace,
-    .dxpl      = dxpl,
+    .memspace = memspace,
+    .dxpl = dxpl,
   };
   hsize_t idx = 0;
-  H5Literate_by_name(group0, ".", H5_INDEX_NAME, H5_ITER_INC, &idx,
-		     read_f1_cb, &cb_data, H5P_DEFAULT);
+  H5Literate_by_name(group0, ".", H5_INDEX_NAME, H5_ITER_INC, &idx, read_f1_cb,
+                     &cb_data, H5P_DEFAULT);
 
   H5Pclose(dxpl);
   H5Sclose(filespace);
   H5Sclose(memspace);
 
-  ierr = H5Gclose(group0); CE;
+  ierr = H5Gclose(group0);
+  CE;
 }
 
-struct read_fld_cb_data {
-  struct mrc_io *io;
-  struct mrc_fld *fld;
-  struct mrc_fld *lfld;
+struct read_fld_cb_data
+{
+  struct mrc_io* io;
+  struct mrc_fld* fld;
+  struct mrc_fld* lfld;
   hid_t filespace;
   hid_t memspace;
   hid_t dxpl;
 };
 
-static herr_t
-read_fld_cb(hid_t g_id, const char *name, const H5L_info_t *info, void *op_data)
+static herr_t read_fld_cb(hid_t g_id, const char* name, const H5L_info_t* info,
+                          void* op_data)
 {
-  struct read_fld_cb_data *data = op_data;
+  struct read_fld_cb_data* data = op_data;
   herr_t ierr;
 
   hid_t group = H5Gopen(g_id, name, H5P_DEFAULT);
@@ -1932,21 +2193,23 @@ read_fld_cb(hid_t g_id, const char *name, const H5L_info_t *info, void *op_data)
   H5LTget_attribute_int(group, ".", "m", &m);
 
   hid_t dset = H5Dopen(group, "3d", H5P_DEFAULT);
-  H5Dread(dset, H5T_NATIVE_FLOAT, data->memspace, data->filespace, data->dxpl, data->lfld->_nd->arr);
+  H5Dread(dset, H5T_NATIVE_FLOAT, data->memspace, data->filespace, data->dxpl,
+          data->lfld->_nd->arr);
   H5Dclose(dset);
 
   // FIXME, could be done w/hyperslab, vectors...
   copy_back(data->lfld, 0, data->fld, m);
 
-  ierr = H5Gclose(group); CE;
+  ierr = H5Gclose(group);
+  CE;
 
   return 0;
 }
 
-static void
-ds_xdmf_parallel_read_f3(struct mrc_io *io, const char *path, struct mrc_fld *fld)
+static void ds_xdmf_parallel_read_f3(struct mrc_io* io, const char* path,
+                                     struct mrc_fld* fld)
 {
-  struct diag_hdf5 *hdf5 = diag_hdf5(io);
+  struct diag_hdf5* hdf5 = diag_hdf5(io);
   herr_t ierr;
 
 #ifndef NDEBUG
@@ -1956,19 +2219,19 @@ ds_xdmf_parallel_read_f3(struct mrc_io *io, const char *path, struct mrc_fld *fl
   int gdims[3];
   mrc_domain_get_global_dims(fld->_domain, gdims);
   int nr_patches;
-  struct mrc_patch *patches = mrc_domain_get_patches(fld->_domain, &nr_patches);
+  struct mrc_patch* patches = mrc_domain_get_patches(fld->_domain, &nr_patches);
   assert(nr_patches == 1);
   int *off = patches[0].off, *ldims = patches[0].ldims;
 
-  struct mrc_fld *lfld = mrc_fld_create(MPI_COMM_SELF);
+  struct mrc_fld* lfld = mrc_fld_create(MPI_COMM_SELF);
   mrc_fld_set_param_int_array(lfld, "dims", 4,
-			     (int[4]) { ldims[0], ldims[1], ldims[2], 1 });
+                              (int[4]){ldims[0], ldims[1], ldims[2], 1});
   mrc_fld_setup(lfld);
 
   hid_t group0 = H5Gopen(hdf5->file, path, H5P_DEFAULT);
-  hsize_t hgdims[3] = { gdims[2], gdims[1], gdims[0] };
-  hsize_t hldims[3] = { ldims[2], ldims[1], ldims[0] };
-  hsize_t hoff[3]   = { off[2], off[1], off[0] };
+  hsize_t hgdims[3] = {gdims[2], gdims[1], gdims[0]};
+  hsize_t hldims[3] = {ldims[2], ldims[1], ldims[0]};
+  hsize_t hoff[3] = {off[2], off[1], off[0]};
 
   hid_t filespace = H5Screate_simple(3, hgdims, NULL);
   H5Sselect_hyperslab(filespace, H5S_SELECT_SET, hoff, NULL, hldims, NULL);
@@ -1981,30 +2244,31 @@ ds_xdmf_parallel_read_f3(struct mrc_io *io, const char *path, struct mrc_fld *fl
   }
 
   struct read_fld_cb_data cb_data = {
-    .io        = io,
-    .fld       = fld,
-    .lfld      = lfld,
+    .io = io,
+    .fld = fld,
+    .lfld = lfld,
     .filespace = filespace,
-    .memspace  = memspace,
-    .dxpl      = dxpl,
+    .memspace = memspace,
+    .dxpl = dxpl,
   };
   hsize_t idx = 0;
-  H5Literate_by_name(group0, ".", H5_INDEX_NAME, H5_ITER_INC, &idx,
-		     read_fld_cb, &cb_data, H5P_DEFAULT);
+  H5Literate_by_name(group0, ".", H5_INDEX_NAME, H5_ITER_INC, &idx, read_fld_cb,
+                     &cb_data, H5P_DEFAULT);
 
   H5Pclose(dxpl);
   H5Sclose(filespace);
   H5Sclose(memspace);
 
-  ierr = H5Gclose(group0); CE;
+  ierr = H5Gclose(group0);
+  CE;
 
   mrc_fld_destroy(lfld);
 }
 
-static void
-ds_xdmf_parallel_write_m1(struct mrc_io *io, const char *path, struct mrc_fld *f1)
+static void ds_xdmf_parallel_write_m1(struct mrc_io* io, const char* path,
+                                      struct mrc_fld* f1)
 {
-  struct diag_hdf5 *hdf5 = diag_hdf5(io);
+  struct diag_hdf5* hdf5 = diag_hdf5(io);
   herr_t ierr;
 
   assert(mrc_fld_nr_patches(f1) == 1);
@@ -2018,12 +2282,13 @@ ds_xdmf_parallel_write_m1(struct mrc_io *io, const char *path, struct mrc_fld *f
 
   assert(io->size == 1);
   hid_t group0 = H5Gopen(hdf5->file, path, H5P_DEFAULT);
-  const int *ghost_dims = mrc_fld_ghost_dims(f1);
-  hsize_t hdims[1] = { ghost_dims[0] };
+  const int* ghost_dims = mrc_fld_ghost_dims(f1);
+  hsize_t hdims[1] = {ghost_dims[0]};
   for (int m = 0; m < mrc_fld_nr_comps(f1); m++) {
-    hid_t group = H5Gcreate(group0, mrc_fld_comp_name(f1, m), H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
+    hid_t group = H5Gcreate(group0, mrc_fld_comp_name(f1, m), H5P_DEFAULT,
+                            H5P_DEFAULT, H5P_DEFAULT);
     H5LTset_attribute_int(group, ".", "m", &m, 1);
-    
+
     hid_t dxpl = H5Pcreate(H5P_DATASET_XFER);
     if (hdf5->par.use_independent_io) {
       H5Pset_dxpl_mpio(dxpl, H5FD_MPIO_INDEPENDENT);
@@ -2032,24 +2297,26 @@ ds_xdmf_parallel_write_m1(struct mrc_io *io, const char *path, struct mrc_fld *f
     }
     hid_t filespace = H5Screate_simple(1, hdims, NULL);
     hid_t memspace = H5Screate_simple(1, hdims, NULL);
-    hid_t dset = H5Dcreate(group, "1d", H5T_NATIVE_FLOAT, filespace, H5P_DEFAULT,
-			   H5P_DEFAULT, H5P_DEFAULT);
+    hid_t dset = H5Dcreate(group, "1d", H5T_NATIVE_FLOAT, filespace,
+                           H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
     H5Dwrite(dset, H5T_NATIVE_FLOAT, memspace, filespace, dxpl, f1->_nd->arr);
     H5Dclose(dset);
     H5Sclose(filespace);
     H5Sclose(memspace);
     H5Pclose(dxpl);
 
-    ierr = H5Gclose(group); CE;
+    ierr = H5Gclose(group);
+    CE;
   }
-  ierr = H5Gclose(group0); CE;
+  ierr = H5Gclose(group0);
+  CE;
 }
 
-static void
-ds_xdmf_parallel_write_field(struct mrc_io *io, const char *path,
-			     float scale, struct mrc_fld *fld, int m)
+static void ds_xdmf_parallel_write_field(struct mrc_io* io, const char* path,
+                                         float scale, struct mrc_fld* fld,
+                                         int m)
 {
-  struct diag_hdf5 *hdf5 = diag_hdf5(io);
+  struct diag_hdf5* hdf5 = diag_hdf5(io);
   herr_t ierr;
 
 #ifndef NDEBUG
@@ -2059,15 +2326,15 @@ ds_xdmf_parallel_write_field(struct mrc_io *io, const char *path,
   int gdims[3];
   mrc_domain_get_global_dims(fld->_domain, gdims);
   int nr_patches;
-  struct mrc_patch *patches = mrc_domain_get_patches(fld->_domain, &nr_patches);
+  struct mrc_patch* patches = mrc_domain_get_patches(fld->_domain, &nr_patches);
   assert(nr_patches == 1);
   int *off = patches[0].off, *ldims = patches[0].ldims;
 
   // strip boundary, could be done through hyperslab, but
   // still have to scale, anyway
-  struct mrc_fld *lfld = mrc_fld_create(MPI_COMM_SELF);
+  struct mrc_fld* lfld = mrc_fld_create(MPI_COMM_SELF);
   mrc_fld_set_param_int_array(lfld, "dims", 4,
-			     (int[4]) { ldims[0], ldims[1], ldims[2], 1});
+                              (int[4]){ldims[0], ldims[1], ldims[2], 1});
   mrc_fld_setup(lfld);
   copy_and_scale(lfld, 0, fld, m, scale);
 
@@ -2077,7 +2344,7 @@ ds_xdmf_parallel_write_field(struct mrc_io *io, const char *path,
   }
 
   if (io->rank == 0) {
-    struct xdmf_spatial *xs = xdmf_spatial_find(io, "3df", -1);
+    struct xdmf_spatial* xs = xdmf_spatial_find(io, "3df", -1);
     if (!xs) {
       xs = xdmf_spatial_create_3d(io, gdims, -1, 1);
     }
@@ -2085,10 +2352,11 @@ ds_xdmf_parallel_write_field(struct mrc_io *io, const char *path,
   }
 
   hid_t group0 = H5Gopen(hdf5->file, path, H5P_DEFAULT);
-  hsize_t hgdims[3] = { gdims[2], gdims[1], gdims[0] };
-  hsize_t hldims[3] = { ldims[2], ldims[1], ldims[0] };
-  hsize_t hoff[3]   = { off[2], off[1], off[0] };
-  hid_t group = H5Gcreate(group0, mrc_fld_comp_name(fld, m), H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
+  hsize_t hgdims[3] = {gdims[2], gdims[1], gdims[0]};
+  hsize_t hldims[3] = {ldims[2], ldims[1], ldims[0]};
+  hsize_t hoff[3] = {off[2], off[1], off[0]};
+  hid_t group = H5Gcreate(group0, mrc_fld_comp_name(fld, m), H5P_DEFAULT,
+                          H5P_DEFAULT, H5P_DEFAULT);
   H5LTset_attribute_int(group, ".", "m", &m, 1);
 
   hid_t dxpl = H5Pcreate(H5P_DATASET_XFER);
@@ -2100,7 +2368,7 @@ ds_xdmf_parallel_write_field(struct mrc_io *io, const char *path,
   hid_t filespace = H5Screate_simple(3, hgdims, NULL);
   hid_t memspace = H5Screate_simple(3, hldims, NULL);
   hid_t dset = H5Dcreate(group, "3d", H5T_NATIVE_FLOAT, filespace, H5P_DEFAULT,
-			 H5P_DEFAULT, H5P_DEFAULT);
+                         H5P_DEFAULT, H5P_DEFAULT);
   H5Sselect_hyperslab(filespace, H5S_SELECT_SET, hoff, NULL, hldims, NULL);
   H5Dwrite(dset, H5T_NATIVE_FLOAT, memspace, filespace, dxpl, lfld->_nd->arr);
   H5Dclose(dset);
@@ -2108,29 +2376,30 @@ ds_xdmf_parallel_write_field(struct mrc_io *io, const char *path,
   H5Sclose(memspace);
   H5Pclose(dxpl);
 
-  ierr = H5Gclose(group); CE;
-  ierr = H5Gclose(group0); CE;
+  ierr = H5Gclose(group);
+  CE;
+  ierr = H5Gclose(group0);
+  CE;
 
   mrc_fld_destroy(lfld);
 }
 
 struct mrc_io_ops mrc_io_xdmf_parallel_ops = {
-  .name          = "xdmf_parallel",
-  .size          = sizeof(struct diag_hdf5),
-  .param_descr   = diag_hdf5_params_descr,
-  .param_offset  = offsetof(struct diag_hdf5, par),
-  .parallel      = true,
-  .destroy       = ds_xdmf_destroy,
-  .setup         = ds_xdmf_setup,
-  .open          = ds_xdmf_parallel_open,
-  .close         = ds_xdmf_parallel_close,
-  .read_m1       = ds_xdmf_parallel_read_m1,
-  .read_f3       = ds_xdmf_parallel_read_f3,
-  .write_m1      = ds_xdmf_parallel_write_m1,
-  .write_field   = ds_xdmf_parallel_write_field,
-  .read_attr     = ds_xdmf_read_attr,
-  .write_attr    = ds_xdmf_write_attr,
+  .name = "xdmf_parallel",
+  .size = sizeof(struct diag_hdf5),
+  .param_descr = diag_hdf5_params_descr,
+  .param_offset = offsetof(struct diag_hdf5, par),
+  .parallel = true,
+  .destroy = ds_xdmf_destroy,
+  .setup = ds_xdmf_setup,
+  .open = ds_xdmf_parallel_open,
+  .close = ds_xdmf_parallel_close,
+  .read_m1 = ds_xdmf_parallel_read_m1,
+  .read_f3 = ds_xdmf_parallel_read_f3,
+  .write_m1 = ds_xdmf_parallel_write_m1,
+  .write_field = ds_xdmf_parallel_write_field,
+  .read_attr = ds_xdmf_read_attr,
+  .write_attr = ds_xdmf_write_attr,
 };
 
 #endif
-

--- a/src/libmrc/src/mrc_io_xdmf2.c
+++ b/src/libmrc/src/mrc_io_xdmf2.c
@@ -75,7 +75,7 @@ static void xdmf_open(struct mrc_io* io, const char* mode)
   struct xdmf* xdmf = to_xdmf(io);
 
   struct xdmf_file* file = &xdmf->file;
-  char filename[strlen(io->par.outdir) + strlen(io->par.basename) + 20];
+  char filename[strlen(io->par.outdir) + strlen(io->par.basename) + 30];
   sprintf(filename, "%s/%s.%06d_p%06d.h5", io->par.outdir, io->par.basename,
           io->step, io->rank);
 
@@ -937,7 +937,7 @@ static void xdmf_parallel_open(struct mrc_io* io, const char* mode)
   assert(strcmp(mode, "w") == 0);
 
   struct xdmf_file* file = &xdmf->file;
-  char filename[strlen(io->par.outdir) + strlen(io->par.basename) + 20];
+  char filename[strlen(io->par.outdir) + strlen(io->par.basename) + 30];
   sprintf(filename, "%s/%s.%06d_p%06d.h5", io->par.outdir, io->par.basename,
           io->step, 0);
 

--- a/src/libmrc/src/mrc_io_xdmf2.c
+++ b/src/libmrc/src/mrc_io_xdmf2.c
@@ -14,42 +14,43 @@
 
 // ----------------------------------------------------------------------
 
-struct xdmf_file {
+struct xdmf_file
+{
   hid_t h5_file;
   list_t xdmf_spatial_list;
 };
 
-struct xdmf {
+struct xdmf
+{
   struct xdmf_file file;
-  struct xdmf_temporal *xdmf_temporal;
+  struct xdmf_temporal* xdmf_temporal;
   int sw;
   // parallel only
   bool use_independent_io;
 };
 
-#define VAR(x) (void *)offsetof(struct xdmf, x)
+#define VAR(x) (void*)offsetof(struct xdmf, x)
 static struct param xdmf2_descr[] = {
-  { "sw"                     , VAR(sw)                      , PARAM_INT(0)           },
+  {"sw", VAR(sw), PARAM_INT(0)},
   {},
 };
 #undef VAR
 
-#define VAR(x) (void *)offsetof(struct xdmf, x)
+#define VAR(x) (void*)offsetof(struct xdmf, x)
 static struct param xdmf_parallel_descr[] = {
-  { "use_independent_io"     , VAR(use_independent_io)      , PARAM_BOOL(false)      },
+  {"use_independent_io", VAR(use_independent_io), PARAM_BOOL(false)},
   {},
 };
 #undef VAR
 
-#define to_xdmf(io) ((struct xdmf *)((io)->obj.subctx))
+#define to_xdmf(io) ((struct xdmf*)((io)->obj.subctx))
 
 // ======================================================================
 // xdmf
 
-static void
-xdmf_setup(struct mrc_io *io)
+static void xdmf_setup(struct mrc_io* io)
 {
-  struct xdmf *xdmf = to_xdmf(io);
+  struct xdmf* xdmf = to_xdmf(io);
 
   char filename[strlen(io->par.outdir) + strlen(io->par.basename) + 7];
   sprintf(filename, "%s/%s.xdmf", io->par.outdir, io->par.basename);
@@ -58,10 +59,9 @@ xdmf_setup(struct mrc_io *io)
   mrc_io_setup_super(io);
 }
 
-static void
-xdmf_destroy(struct mrc_io *io)
+static void xdmf_destroy(struct mrc_io* io)
 {
-  struct xdmf *xdmf = to_xdmf(io);
+  struct xdmf* xdmf = to_xdmf(io);
   if (xdmf->xdmf_temporal) {
     xdmf_temporal_destroy(xdmf->xdmf_temporal);
   }
@@ -70,19 +70,18 @@ xdmf_destroy(struct mrc_io *io)
 // ----------------------------------------------------------------------
 // xdmf_open
 
-static void
-xdmf_open(struct mrc_io *io, const char *mode)
+static void xdmf_open(struct mrc_io* io, const char* mode)
 {
-  struct xdmf *xdmf = to_xdmf(io);
+  struct xdmf* xdmf = to_xdmf(io);
 
-  struct xdmf_file *file = &xdmf->file;
+  struct xdmf_file* file = &xdmf->file;
   char filename[strlen(io->par.outdir) + strlen(io->par.basename) + 20];
   sprintf(filename, "%s/%s.%06d_p%06d.h5", io->par.outdir, io->par.basename,
-	  io->step, io->rank);
-
+          io->step, io->rank);
 
   if (strcmp(mode, "w") == 0) {
-    file->h5_file = H5Fcreate(filename, H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT);
+    file->h5_file =
+      H5Fcreate(filename, H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT);
   } else if (strcmp(mode, "r") == 0) {
     file->h5_file = H5Fopen(filename, H5F_ACC_RDONLY, H5P_DEFAULT);
   } else {
@@ -92,11 +91,10 @@ xdmf_open(struct mrc_io *io, const char *mode)
   xdmf_spatial_open(&file->xdmf_spatial_list);
 }
 
-static void
-xdmf_close(struct mrc_io *io)
+static void xdmf_close(struct mrc_io* io)
 {
-  struct xdmf *xdmf = to_xdmf(io);
-  struct xdmf_file *file = &xdmf->file;
+  struct xdmf* xdmf = to_xdmf(io);
+  struct xdmf_file* file = &xdmf->file;
 
   H5Fclose(file->h5_file);
   xdmf_spatial_close(&file->xdmf_spatial_list, io, xdmf->xdmf_temporal);
@@ -104,155 +102,181 @@ xdmf_close(struct mrc_io *io)
   memset(file, 0, sizeof(*file));
 }
 
-static void
-xdmf_write_attr(struct mrc_io *io, const char *path, int type,
-		const char *name, union param_u *pv)
+static void xdmf_write_attr(struct mrc_io* io, const char* path, int type,
+                            const char* name, union param_u* pv)
 {
-  struct xdmf *xdmf = to_xdmf(io);
-  struct xdmf_file *file = &xdmf->file;
-  
+  struct xdmf* xdmf = to_xdmf(io);
+  struct xdmf_file* file = &xdmf->file;
+
   hid_t group;
   if (H5Lexists(file->h5_file, path, H5P_DEFAULT) > 0) {
     group = H5Gopen(file->h5_file, path, H5P_DEFAULT);
   } else {
-    group = H5Gcreate(file->h5_file, path, H5P_DEFAULT,
-          H5P_DEFAULT, H5P_DEFAULT); H5_CHK(group);
+    group =
+      H5Gcreate(file->h5_file, path, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
+    H5_CHK(group);
   }
-
 
   int ierr;
 
   switch (type) {
-  case PT_SELECT:
-  case PT_INT:
-  case MRC_VAR_INT:
-    ierr = H5LTset_attribute_int(group, ".", name, &pv->u_int, 1); CE;
-    break;
-  case PT_BOOL: 
-  case MRC_VAR_BOOL: {
-    int val = pv->u_bool;
-    ierr = H5LTset_attribute_int(group, ".", name, &val, 1); CE;
-    break;
-  }
-  case PT_FLOAT:
-  case MRC_VAR_FLOAT:
-    ierr = H5LTset_attribute_float(group, ".", name, &pv->u_float, 1); CE;
-    break;
-  case PT_DOUBLE:
-  case MRC_VAR_DOUBLE:
-    ierr = H5LTset_attribute_double(group, ".", name, &pv->u_double, 1); CE;
-    break;
-  case PT_STRING:
-    if (pv->u_string) {
-      ierr = H5LTset_attribute_string(group, ".", name, pv->u_string); CE;
-    } else {
-      ierr = H5LTset_attribute_string(group, ".", name, "(NULL)"); CE;
+    case PT_SELECT:
+    case PT_INT:
+    case MRC_VAR_INT:
+      ierr = H5LTset_attribute_int(group, ".", name, &pv->u_int, 1);
+      CE;
+      break;
+    case PT_BOOL:
+    case MRC_VAR_BOOL: {
+      int val = pv->u_bool;
+      ierr = H5LTset_attribute_int(group, ".", name, &val, 1);
+      CE;
+      break;
     }
-    break;
+    case PT_FLOAT:
+    case MRC_VAR_FLOAT:
+      ierr = H5LTset_attribute_float(group, ".", name, &pv->u_float, 1);
+      CE;
+      break;
+    case PT_DOUBLE:
+    case MRC_VAR_DOUBLE:
+      ierr = H5LTset_attribute_double(group, ".", name, &pv->u_double, 1);
+      CE;
+      break;
+    case PT_STRING:
+      if (pv->u_string) {
+        ierr = H5LTset_attribute_string(group, ".", name, pv->u_string);
+        CE;
+      } else {
+        ierr = H5LTset_attribute_string(group, ".", name, "(NULL)");
+        CE;
+      }
+      break;
 
-  case PT_INT3:
-    ierr = H5LTset_attribute_int(group, ".", name, pv->u_int3, 3); CE;
-    break;
+    case PT_INT3:
+      ierr = H5LTset_attribute_int(group, ".", name, pv->u_int3, 3);
+      CE;
+      break;
 
-  case PT_FLOAT3:
-    ierr = H5LTset_attribute_float(group, ".", name, pv->u_float3, 3); CE;
-    break;
+    case PT_FLOAT3:
+      ierr = H5LTset_attribute_float(group, ".", name, pv->u_float3, 3);
+      CE;
+      break;
 
-  case PT_DOUBLE3:
-  case MRC_VAR_DOUBLE3:
-    ierr = H5LTset_attribute_double(group, ".", name, pv->u_double3, 3); CE;
-    break;
-  case PT_INT_ARRAY: {
-    hsize_t dims = pv->u_int_array.nr_vals;
-    hid_t dataspace_id = H5Screate_simple(1, &dims, NULL); H5_CHK(dataspace_id);
-    hid_t attr_id = H5Acreate(group, name, H5T_NATIVE_INT, dataspace_id,
-			      H5P_DEFAULT, H5P_DEFAULT); H5_CHK(attr_id);
-    if (dims > 0) {
-      ierr = H5Awrite(attr_id, H5T_NATIVE_INT, pv->u_int_array.vals); CE;
+    case PT_DOUBLE3:
+    case MRC_VAR_DOUBLE3:
+      ierr = H5LTset_attribute_double(group, ".", name, pv->u_double3, 3);
+      CE;
+      break;
+    case PT_INT_ARRAY: {
+      hsize_t dims = pv->u_int_array.nr_vals;
+      hid_t dataspace_id = H5Screate_simple(1, &dims, NULL);
+      H5_CHK(dataspace_id);
+      hid_t attr_id = H5Acreate(group, name, H5T_NATIVE_INT, dataspace_id,
+                                H5P_DEFAULT, H5P_DEFAULT);
+      H5_CHK(attr_id);
+      if (dims > 0) {
+        ierr = H5Awrite(attr_id, H5T_NATIVE_INT, pv->u_int_array.vals);
+        CE;
+      }
+      ierr = H5Sclose(dataspace_id);
+      CE;
+      ierr = H5Aclose(attr_id);
+      CE;
+      break;
     }
-    ierr = H5Sclose(dataspace_id); CE;
-    ierr = H5Aclose(attr_id); CE;
-    break;
+    case PT_PTR: break;
+    default:
+      mpi_printf(mrc_io_comm(io),
+                 "mrc_io_xdmf2: not writing attr '%s' (type %d)\n", name, type);
+      assert(0);
   }
-  case PT_PTR:
-    break;
-  default:
-    mpi_printf(mrc_io_comm(io), "mrc_io_xdmf2: not writing attr '%s' (type %d)\n",
-      name, type);
-    assert(0);
-  }
-  ierr = H5Gclose(group); CE;
+  ierr = H5Gclose(group);
+  CE;
 }
 
-static void
-xdmf_read_attr(struct mrc_io *io, const char *path, int type,
-    const char *name, union param_u *pv)
+static void xdmf_read_attr(struct mrc_io* io, const char* path, int type,
+                           const char* name, union param_u* pv)
 {
-  struct xdmf *xdmf = to_xdmf(io);
-  struct xdmf_file *file = &xdmf->file;
-  
-  hid_t group = H5Gopen(file->h5_file, path, H5P_DEFAULT); H5_CHK(group);
+  struct xdmf* xdmf = to_xdmf(io);
+  struct xdmf_file* file = &xdmf->file;
+
+  hid_t group = H5Gopen(file->h5_file, path, H5P_DEFAULT);
+  H5_CHK(group);
 
   int ierr;
   switch (type) {
-  case PT_SELECT:
-  case PT_INT:
-  case MRC_VAR_INT:
-    ierr = H5LTget_attribute_int(group, ".", name, &pv->u_int); CE;
-    break;
-  case PT_BOOL:
-  case MRC_VAR_BOOL: ;
-    int val;
-    ierr = H5LTget_attribute_int(group, ".", name, &val); CE;
-    pv->u_bool = val;
-    break;
-  case PT_FLOAT:
-    ierr = H5LTget_attribute_float(group, ".", name, &pv->u_float); CE;
-    break;
-  case PT_DOUBLE:
-    ierr = H5LTget_attribute_double(group, ".", name, &pv->u_double); CE;
-    break;
-  case PT_STRING: ;
-    hsize_t dims;
-    H5T_class_t class;
-    size_t sz;
-    ierr = H5LTget_attribute_info(group, ".", name, &dims, &class, &sz); CE;
-    pv->u_string = malloc(sz);
-    ierr = H5LTget_attribute_string(group, ".", name, (char *)pv->u_string); CE;
-    if (strcmp(pv->u_string, "(NULL)") == 0) {
-      free((char *) pv->u_string);
-      pv->u_string = NULL;
+    case PT_SELECT:
+    case PT_INT:
+    case MRC_VAR_INT:
+      ierr = H5LTget_attribute_int(group, ".", name, &pv->u_int);
+      CE;
+      break;
+    case PT_BOOL:
+    case MRC_VAR_BOOL:;
+      int val;
+      ierr = H5LTget_attribute_int(group, ".", name, &val);
+      CE;
+      pv->u_bool = val;
+      break;
+    case PT_FLOAT:
+      ierr = H5LTget_attribute_float(group, ".", name, &pv->u_float);
+      CE;
+      break;
+    case PT_DOUBLE:
+      ierr = H5LTget_attribute_double(group, ".", name, &pv->u_double);
+      CE;
+      break;
+    case PT_STRING:;
+      hsize_t dims;
+      H5T_class_t class;
+      size_t sz;
+      ierr = H5LTget_attribute_info(group, ".", name, &dims, &class, &sz);
+      CE;
+      pv->u_string = malloc(sz);
+      ierr = H5LTget_attribute_string(group, ".", name, (char*)pv->u_string);
+      CE;
+      if (strcmp(pv->u_string, "(NULL)") == 0) {
+        free((char*)pv->u_string);
+        pv->u_string = NULL;
+      }
+      break;
+    case PT_INT3:
+      ierr = H5LTget_attribute_int(group, ".", name, pv->u_int3);
+      CE;
+      break;
+    case PT_FLOAT3:
+      ierr = H5LTget_attribute_float(group, ".", name, pv->u_float3);
+      CE;
+      break;
+    case PT_DOUBLE3:
+      ierr = H5LTget_attribute_double(group, ".", name, pv->u_double3);
+      CE;
+      break;
+    case PT_INT_ARRAY: {
+      int attr = H5Aopen(group, name, H5P_DEFAULT);
+      H5_CHK(attr);
+      H5A_info_t ainfo;
+      ierr = H5Aget_info(attr, &ainfo);
+      CE;
+      ierr = H5Aclose(attr);
+      CE;
+      pv->u_int_array.nr_vals = ainfo.data_size / sizeof(int);
+      pv->u_int_array.vals = calloc(pv->u_int_array.nr_vals, sizeof(int));
+      ierr = H5LTget_attribute_int(group, ".", name, pv->u_int_array.vals);
+      CE;
+      break;
     }
-    break;
-  case PT_INT3:
-    ierr = H5LTget_attribute_int(group, ".", name, pv->u_int3); CE;
-    break;
-  case PT_FLOAT3:
-    ierr = H5LTget_attribute_float(group, ".", name, pv->u_float3); CE;
-    break;
-  case PT_DOUBLE3:
-    ierr = H5LTget_attribute_double(group, ".", name, pv->u_double3); CE;
-    break;
-  case PT_INT_ARRAY: {
-    int attr = H5Aopen(group, name, H5P_DEFAULT); H5_CHK(attr);
-    H5A_info_t ainfo;
-    ierr = H5Aget_info(attr, &ainfo); CE;
-    ierr = H5Aclose(attr); CE;
-    pv->u_int_array.nr_vals = ainfo.data_size / sizeof(int);
-    pv->u_int_array.vals = calloc(pv->u_int_array.nr_vals, sizeof(int));
-    ierr = H5LTget_attribute_int(group, ".", name, pv->u_int_array.vals); CE;
-    break;
+    case PT_PTR: break;
+    default:
+      mpi_printf(mrc_io_comm(io),
+                 "mrc_io_xdmf2: not reading attr '%s' (type %d)\n", name, type);
+      assert(0);
+      break;
   }
-  case PT_PTR:
-    break;
-  default:
-    mpi_printf(mrc_io_comm(io), "mrc_io_xdmf2: not reading attr '%s' (type %d)\n", name, type);
-    assert(0);
-    break;
-  }
-  ierr = H5Gclose(group); CE;
+  ierr = H5Gclose(group);
+  CE;
 }
-
 
 // static void
 // xdmf_spatial_write_mcrds_multi(struct mrc_io *io, struct xdmf_file *file,
@@ -279,14 +303,16 @@ xdmf_read_attr(struct mrc_io *io, const char *path, int type,
 // 	  crd_nc[i + sw] = .5 * (MRC_M1(mcrd,0, i-1, p) + MRC_M1(mcrd,0, i, p));
 // 	}
 // 	// extrapolate
-// 	crd_nc[0      ] = MRC_M1(mcrd,0, -sw    , p) - .5 * (MRC_M1(mcrd,0, -sw+1  , p) - MRC_M1(mcrd,0, -sw    , p));
-// 	crd_nc[im+2*sw] = MRC_M1(mcrd,0, im+sw-1, p) + .5 * (MRC_M1(mcrd,0, im+sw-1, p) - MRC_M1(mcrd,0, im+sw-2, p));
+// 	crd_nc[0      ] = MRC_M1(mcrd,0, -sw    , p) - .5 * (MRC_M1(mcrd,0,
+// -sw+1  , p) - MRC_M1(mcrd,0, -sw    , p)); 	crd_nc[im+2*sw] = MRC_M1(mcrd,0,
+// im+sw-1, p) + .5 * (MRC_M1(mcrd,0, im+sw-1, p) - MRC_M1(mcrd,0, im+sw-2, p));
 //       }
 //       hsize_t im1 = im + 2*sw + 1;
 //       char s_patch[10];
 //       sprintf(s_patch, "p%d", p);
 //       hid_t group_crdp = H5Gcreate(group_crd1, s_patch, H5P_DEFAULT,
-// 				   H5P_DEFAULT, H5P_DEFAULT); H5_CHK(group_crdp);
+// 				   H5P_DEFAULT, H5P_DEFAULT);
+// H5_CHK(group_crdp);
 //       H5LTmake_dataset_float(group_crdp, "1d", 1, &im1, crd_nc);
 //       H5Gclose(group_crdp);
 
@@ -298,8 +324,8 @@ xdmf_read_attr(struct mrc_io *io, const char *path, int type,
 // }
 
 // static void
-// xdmf_spatial_write_mcrds(struct mrc_io *io, struct xdmf_spatial *xs, struct xdmf_file *file,
-// 			 struct mrc_domain *domain, int sw)
+// xdmf_spatial_write_mcrds(struct mrc_io *io, struct xdmf_spatial *xs, struct
+// xdmf_file *file, 			 struct mrc_domain *domain, int sw)
 // {
 //   if (xs->crds_done)
 //     return;
@@ -318,7 +344,8 @@ xdmf_read_attr(struct mrc_io *io, const char *path, int type,
 //   for (int d = 0; d < 1; d++) {
 //     struct mrc_fld *crd = crds->crd[d];
 
-//     hid_t group_crd1 = H5Gcreate(file->h5_file, mrc_fld_name(crd), H5P_DEFAULT,
+//     hid_t group_crd1 = H5Gcreate(file->h5_file, mrc_fld_name(crd),
+//     H5P_DEFAULT,
 // 				 H5P_DEFAULT, H5P_DEFAULT); H5_CHK(group_crd1);
 
 //     const int *dims = mrc_fld_dims(crd);
@@ -351,15 +378,15 @@ xdmf_read_attr(struct mrc_io *io, const char *path, int type,
 //   }
 // }
 
-static void
-xdmf_write_m3(struct mrc_io *io, const char *path, struct mrc_fld *m3_any)
+static void xdmf_write_m3(struct mrc_io* io, const char* path,
+                          struct mrc_fld* m3_any)
 {
-  struct xdmf *xdmf = to_xdmf(io);
-  struct xdmf_file *file = &xdmf->file;
+  struct xdmf* xdmf = to_xdmf(io);
+  struct xdmf_file* file = &xdmf->file;
   int ierr;
 
   // If we have an aos field, we need to get it as soa
-  struct mrc_fld *m3 = m3_any;
+  struct mrc_fld* m3 = m3_any;
   if (m3_any->_aos) {
     switch (mrc_fld_data_type(m3_any)) {
       case MRC_NT_FLOAT: m3 = mrc_fld_get_as(m3_any, "float"); break;
@@ -379,49 +406,58 @@ xdmf_write_m3(struct mrc_io *io, const char *path, struct mrc_fld *m3_any)
   int nr_patches = mrc_fld_nr_patches(m3);
   H5LTset_attribute_int(group0, ".", "nr_patches", &nr_patches, 1);
 
-  struct xdmf_spatial *xs = xdmf_spatial_find(&file->xdmf_spatial_list,
-                mrc_domain_name(m3->_domain));
+  struct xdmf_spatial* xs =
+    xdmf_spatial_find(&file->xdmf_spatial_list, mrc_domain_name(m3->_domain));
   if (!xs) {
     xs = xdmf_spatial_create_m3(&file->xdmf_spatial_list,
-        mrc_domain_name(m3->_domain), m3->_domain, io, xdmf->sw);
-    //xdmf_spatial_write_mcrds(io, xs, file, m3->_domain, xdmf->sw);
+                                mrc_domain_name(m3->_domain), m3->_domain, io,
+                                xdmf->sw);
+    // xdmf_spatial_write_mcrds(io, xs, file, m3->_domain, xdmf->sw);
   }
 
   for (int m = 0; m < mrc_fld_nr_comps(m3); m++) {
     char default_name[100];
-    const char *compname;
+    const char* compname;
 
     // If the comps aren't named just name them by their component number
-    if ( !(compname = mrc_fld_comp_name(m3, m)) ) {
+    if (!(compname = mrc_fld_comp_name(m3, m))) {
       sprintf(default_name, "_UNSET_%d", m);
-      compname = (const char *) default_name;
+      compname = (const char*)default_name;
     }
 
-    xdmf_spatial_save_fld_info(xs, strdup(compname), strdup(path), false, mrc_fld_data_type(m3));
+    xdmf_spatial_save_fld_info(xs, strdup(compname), strdup(path), false,
+                               mrc_fld_data_type(m3));
 
-    hid_t group_fld = H5Gcreate(group0, compname, H5P_DEFAULT,
-        H5P_DEFAULT, H5P_DEFAULT); H5_CHK(group_fld);
+    hid_t group_fld =
+      H5Gcreate(group0, compname, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
+    H5_CHK(group_fld);
 
-    ierr = H5LTset_attribute_int(group_fld, ".", "m", &m, 1); CE;
+    ierr = H5LTset_attribute_int(group_fld, ".", "m", &m, 1);
+    CE;
 
-    mrc_fld_foreach_patch(m3, p) {
-      struct mrc_fld_patch *m3p = mrc_fld_patch_get(m3, p);
+    mrc_fld_foreach_patch(m3, p)
+    {
+      struct mrc_fld_patch* m3p = mrc_fld_patch_get(m3, p);
 
       char s_patch[10];
       sprintf(s_patch, "p%d", p);
 
-      hsize_t mdims[3] = { m3->_ghost_dims[2], m3->_ghost_dims[1], m3->_ghost_dims[0] };
-      hsize_t fdims[3] = { m3->_ghost_dims[2] + 2 * m3->_ghost_offs[2] + 2*sw[2],
-         m3->_ghost_dims[1] + 2 * m3->_ghost_offs[1] + 2*sw[1],
-         m3->_ghost_dims[0] + 2 * m3->_ghost_offs[0] + 2*sw[0]};
-      hsize_t off[3] = { -m3->_ghost_offs[2]-sw[2], -m3->_ghost_offs[1]-sw[1], -m3->_ghost_offs[0]-sw[0] };
+      hsize_t mdims[3] = {m3->_ghost_dims[2], m3->_ghost_dims[1],
+                          m3->_ghost_dims[0]};
+      hsize_t fdims[3] = {
+        m3->_ghost_dims[2] + 2 * m3->_ghost_offs[2] + 2 * sw[2],
+        m3->_ghost_dims[1] + 2 * m3->_ghost_offs[1] + 2 * sw[1],
+        m3->_ghost_dims[0] + 2 * m3->_ghost_offs[0] + 2 * sw[0]};
+      hsize_t off[3] = {-m3->_ghost_offs[2] - sw[2],
+                        -m3->_ghost_offs[1] - sw[1],
+                        -m3->_ghost_offs[0] - sw[0]};
       /* mprintf("fdims %lld:%lld:%lld\n", fdims[0], fdims[1], fdims[2]); */
       /* mprintf("mdims %lld:%lld:%lld\n", mdims[0], mdims[1], mdims[2]); */
       /* mprintf("off   %lld:%lld:%lld\n", off[0], off[1], off[2]); */
-      
 
-      hid_t group = H5Gcreate(group_fld, s_patch, H5P_DEFAULT,
-            H5P_DEFAULT, H5P_DEFAULT); H5_CHK(group);
+      hid_t group =
+        H5Gcreate(group_fld, s_patch, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
+      H5_CHK(group);
       struct mrc_patch_info info;
       mrc_domain_get_local_patch_info(m3->_domain, p, &info);
       H5LTset_attribute_int(group, ".", "global_patch", &info.global_patch, 1);
@@ -430,31 +466,40 @@ xdmf_write_m3(struct mrc_io *io, const char *path, struct mrc_fld *m3_any)
       H5Sselect_hyperslab(memspace, H5S_SELECT_SET, off, NULL, fdims, NULL);
 
       hid_t dtype;
-      void *arr;
+      void* arr;
       switch (mrc_fld_data_type(m3)) {
         case MRC_NT_FLOAT: {
-          arr = (void *) &MRC_S5((m3p)->_fld, m3->_ghost_offs[0], m3->_ghost_offs[1], m3->_ghost_offs[2], m, (m3p)->_p);
-          dtype = H5T_NATIVE_FLOAT; 
+          arr =
+            (void*)&MRC_S5((m3p)->_fld, m3->_ghost_offs[0], m3->_ghost_offs[1],
+                           m3->_ghost_offs[2], m, (m3p)->_p);
+          dtype = H5T_NATIVE_FLOAT;
           break;
         }
         case MRC_NT_DOUBLE: {
-          arr = (void *) &MRC_D5((m3p)->_fld, m3->_ghost_offs[0], m3->_ghost_offs[1], m3->_ghost_offs[2], m, (m3p)->_p);
-          dtype = H5T_NATIVE_DOUBLE; 
+          arr =
+            (void*)&MRC_D5((m3p)->_fld, m3->_ghost_offs[0], m3->_ghost_offs[1],
+                           m3->_ghost_offs[2], m, (m3p)->_p);
+          dtype = H5T_NATIVE_DOUBLE;
           break;
         }
         case MRC_NT_INT: {
-          arr = (void *) &MRC_I5((m3p)->_fld, m3->_ghost_offs[0], m3->_ghost_offs[1], m3->_ghost_offs[2], m, (m3p)->_p);
-          dtype = H5T_NATIVE_INT; 
+          arr =
+            (void*)&MRC_I5((m3p)->_fld, m3->_ghost_offs[0], m3->_ghost_offs[1],
+                           m3->_ghost_offs[2], m, (m3p)->_p);
+          dtype = H5T_NATIVE_INT;
           break;
         }
         default: assert(0);
       }
 
       hid_t dset = H5Dcreate(group, "3d", dtype, filespace, H5P_DEFAULT,
-           H5P_DEFAULT, H5P_DEFAULT);
-      ierr = H5Dwrite(dset, dtype, memspace, filespace, H5P_DEFAULT, arr); CE;
-      ierr = H5Dclose(dset); CE;
-      ierr = H5Gclose(group); CE;
+                             H5P_DEFAULT, H5P_DEFAULT);
+      ierr = H5Dwrite(dset, dtype, memspace, filespace, H5P_DEFAULT, arr);
+      CE;
+      ierr = H5Dclose(dset);
+      CE;
+      ierr = H5Gclose(group);
+      CE;
       mrc_fld_patch_put(m3);
     }
     H5Gclose(group_fld);
@@ -465,37 +510,41 @@ xdmf_write_m3(struct mrc_io *io, const char *path, struct mrc_fld *m3_any)
   if (m3_any->_aos) {
     mrc_fld_put_as(m3, m3_any);
   }
-
 }
 
-struct read_m3_cb_data {
-  struct mrc_io *io;
-  struct mrc_fld *m3;
+struct read_m3_cb_data
+{
+  struct mrc_io* io;
+  struct mrc_fld* m3;
   int sw[3];
 };
 
-static herr_t
-read_m3_cb(hid_t g_id, const char *name, const H5L_info_t *info, void *op_data)
+static herr_t read_m3_cb(hid_t g_id, const char* name, const H5L_info_t* info,
+                         void* op_data)
 {
 
   int ierr;
-  struct read_m3_cb_data *data = op_data;
-  struct mrc_fld *m3 = data->m3;
-  int *sw = data->sw;
+  struct read_m3_cb_data* data = op_data;
+  struct mrc_fld* m3 = data->m3;
+  int* sw = data->sw;
 
-  hid_t group_fld = H5Gopen(g_id, name, H5P_DEFAULT); H5_CHK(group_fld);
+  hid_t group_fld = H5Gopen(g_id, name, H5P_DEFAULT);
+  H5_CHK(group_fld);
 
   int m;
-  ierr = H5LTget_attribute_int(group_fld, ".", "m", &m); CE;
+  ierr = H5LTget_attribute_int(group_fld, ".", "m", &m);
+  CE;
 
-  mrc_fld_foreach_patch(m3, p) {
+  mrc_fld_foreach_patch(m3, p)
+  {
 
-    struct mrc_fld_patch *m3p = mrc_fld_patch_get(m3, p);
+    struct mrc_fld_patch* m3p = mrc_fld_patch_get(m3, p);
 
     char s_patch[10];
     sprintf(s_patch, "p%d", p);
 
-    hid_t group = H5Gopen(group_fld, s_patch, H5P_DEFAULT); H5_CHK(group);
+    hid_t group = H5Gopen(group_fld, s_patch, H5P_DEFAULT);
+    H5_CHK(group);
 
     struct mrc_patch_info info;
     mrc_domain_get_local_patch_info(m3->_domain, p, &info);
@@ -504,33 +553,40 @@ read_m3_cb(hid_t g_id, const char *name, const H5L_info_t *info, void *op_data)
     H5LTget_attribute_int(group, ".", "global_patch", &file_gpatch);
     assert(info.global_patch == file_gpatch);
 
-
-    hsize_t mdims[3] = { m3->_ghost_dims[2], m3->_ghost_dims[1], m3->_ghost_dims[0] };
-    hsize_t fdims[3] = { m3->_ghost_dims[2] + 2 * m3->_ghost_offs[2] + 2*sw[2],
-       m3->_ghost_dims[1] + 2 * m3->_ghost_offs[1] + 2*sw[1],
-       m3->_ghost_dims[0] + 2 * m3->_ghost_offs[0] + 2*sw[0]};
-    hsize_t off[3] = { -m3->_ghost_offs[2]-sw[2], -m3->_ghost_offs[1]-sw[1], -m3->_ghost_offs[0]-sw[0] };
+    hsize_t mdims[3] = {m3->_ghost_dims[2], m3->_ghost_dims[1],
+                        m3->_ghost_dims[0]};
+    hsize_t fdims[3] = {m3->_ghost_dims[2] + 2 * m3->_ghost_offs[2] + 2 * sw[2],
+                        m3->_ghost_dims[1] + 2 * m3->_ghost_offs[1] + 2 * sw[1],
+                        m3->_ghost_dims[0] + 2 * m3->_ghost_offs[0] +
+                          2 * sw[0]};
+    hsize_t off[3] = {-m3->_ghost_offs[2] - sw[2], -m3->_ghost_offs[1] - sw[1],
+                      -m3->_ghost_offs[0] - sw[0]};
 
     hid_t memspace = H5Screate_simple(3, mdims, NULL);
     H5Sselect_hyperslab(memspace, H5S_SELECT_SET, off, NULL, fdims, NULL);
 
-
     hid_t dtype;
-    void *arr;
+    void* arr;
     switch (mrc_fld_data_type(m3)) {
       case MRC_NT_FLOAT: {
-        arr = (void *) &MRC_S5((m3p)->_fld, m3->_ghost_offs[0], m3->_ghost_offs[1], m3->_ghost_offs[2], m, (m3p)->_p);
-        dtype = H5T_NATIVE_FLOAT; 
+        arr =
+          (void*)&MRC_S5((m3p)->_fld, m3->_ghost_offs[0], m3->_ghost_offs[1],
+                         m3->_ghost_offs[2], m, (m3p)->_p);
+        dtype = H5T_NATIVE_FLOAT;
         break;
       }
       case MRC_NT_DOUBLE: {
-        arr = (void *) &MRC_D5((m3p)->_fld, m3->_ghost_offs[0], m3->_ghost_offs[1], m3->_ghost_offs[2], m, (m3p)->_p);
-        dtype = H5T_NATIVE_DOUBLE; 
+        arr =
+          (void*)&MRC_D5((m3p)->_fld, m3->_ghost_offs[0], m3->_ghost_offs[1],
+                         m3->_ghost_offs[2], m, (m3p)->_p);
+        dtype = H5T_NATIVE_DOUBLE;
         break;
       }
       case MRC_NT_INT: {
-        arr = (void *) &MRC_I5((m3p)->_fld, m3->_ghost_offs[0], m3->_ghost_offs[1], m3->_ghost_offs[2], m, (m3p)->_p);
-        dtype = H5T_NATIVE_INT; 
+        arr =
+          (void*)&MRC_I5((m3p)->_fld, m3->_ghost_offs[0], m3->_ghost_offs[1],
+                         m3->_ghost_offs[2], m, (m3p)->_p);
+        dtype = H5T_NATIVE_INT;
         break;
       }
       default: assert(0);
@@ -538,24 +594,27 @@ read_m3_cb(hid_t g_id, const char *name, const H5L_info_t *info, void *op_data)
 
     hid_t dset = H5Dopen(group, "3d", H5P_DEFAULT);
     hid_t filespace = H5Dget_space(dset);
-    ierr = H5Dread(dset, dtype, memspace, filespace, H5P_DEFAULT, arr); CE;
-    ierr = H5Dclose(dset); CE;
-    ierr = H5Gclose(group); CE;
+    ierr = H5Dread(dset, dtype, memspace, filespace, H5P_DEFAULT, arr);
+    CE;
+    ierr = H5Dclose(dset);
+    CE;
+    ierr = H5Gclose(group);
+    CE;
     mrc_fld_patch_put(m3);
   }
   H5Gclose(group_fld);
   return 0;
 }
 
-static void
-xdmf_read_m3(struct mrc_io *io, const char *path, struct mrc_fld *m3_any)
+static void xdmf_read_m3(struct mrc_io* io, const char* path,
+                         struct mrc_fld* m3_any)
 {
 
-  struct xdmf *xdmf = to_xdmf(io);
-  struct xdmf_file *file = &xdmf->file;
+  struct xdmf* xdmf = to_xdmf(io);
+  struct xdmf_file* file = &xdmf->file;
 
   // If we have an aos field, we need to get it as soa
-  struct mrc_fld *m3 = m3_any;
+  struct mrc_fld* m3 = m3_any;
   if (m3_any->_aos) {
     switch (mrc_fld_data_type(m3_any)) {
       case MRC_NT_FLOAT: m3 = mrc_fld_get_as(m3_any, "float"); break;
@@ -573,39 +632,37 @@ xdmf_read_m3(struct mrc_io *io, const char *path, struct mrc_fld *m3_any)
   }
   hid_t group0 = H5Gopen(file->h5_file, path, H5P_DEFAULT);
   int nr_patches = mrc_fld_nr_patches(m3);
-  
-  int file_patches;  
+
+  int file_patches;
   H5LTget_attribute_int(group0, ".", "nr_patches", &file_patches);
   assert(nr_patches == file_patches);
 
   struct read_m3_cb_data cb_data = {
-    .io        = io,
-    .m3        = m3,
-    .sw        = {sw[0], sw[1], sw[2]},
+    .io = io,
+    .m3 = m3,
+    .sw = {sw[0], sw[1], sw[2]},
   };
-  
-  hsize_t idx = 0;
-  H5Literate_by_name(group0, ".", H5_INDEX_NAME, H5_ITER_INC, &idx,
-         read_m3_cb, &cb_data, H5P_DEFAULT);
 
+  hsize_t idx = 0;
+  H5Literate_by_name(group0, ".", H5_INDEX_NAME, H5_ITER_INC, &idx, read_m3_cb,
+                     &cb_data, H5P_DEFAULT);
 
   H5Gclose(group0);
 
   if (m3_any->_aos) {
     mrc_fld_put_as(m3, m3_any);
   }
-
 }
 
-static void
-xdmf_write_m1(struct mrc_io *io, const char *path, struct mrc_fld *m1_any)
+static void xdmf_write_m1(struct mrc_io* io, const char* path,
+                          struct mrc_fld* m1_any)
 {
-  struct xdmf *xdmf = to_xdmf(io);
-  struct xdmf_file *file = &xdmf->file;
+  struct xdmf* xdmf = to_xdmf(io);
+  struct xdmf_file* file = &xdmf->file;
   int ierr;
 
   // If we have an aos field, we need to get it as soa
-  struct mrc_fld *m1 = m1_any;
+  struct mrc_fld* m1 = m1_any;
   if (m1_any->_aos) {
     switch (mrc_fld_data_type(m1_any)) {
       case MRC_NT_FLOAT: m1 = mrc_fld_get_as(m1_any, "float"); break;
@@ -633,38 +690,43 @@ xdmf_write_m1(struct mrc_io *io, const char *path, struct mrc_fld *m1_any)
   // }
 
   for (int m = 0; m < mrc_fld_nr_comps(m1); m++) {
-    //xdmf_spatial_save_fld_info(xs, strdup(mrc_fld_comp_name(m1, m)), strdup(path), false);
+    // xdmf_spatial_save_fld_info(xs, strdup(mrc_fld_comp_name(m1, m)),
+    // strdup(path), false);
 
     char default_name[100];
-    const char *compname;
+    const char* compname;
 
     // If the comps aren't named just name them by their component number
-    if ( !(compname = mrc_fld_comp_name(m1, m)) ) {
+    if (!(compname = mrc_fld_comp_name(m1, m))) {
       sprintf(default_name, "_UNSET_%d", m);
-      compname = (const char *) default_name;
+      compname = (const char*)default_name;
     }
 
-    hid_t group_fld = H5Gcreate(group0, compname, H5P_DEFAULT,
-        H5P_DEFAULT, H5P_DEFAULT); H5_CHK(group_fld);
+    hid_t group_fld =
+      H5Gcreate(group0, compname, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
+    H5_CHK(group_fld);
 
-    ierr = H5LTset_attribute_int(group_fld, ".", "m", &m, 1); CE;
+    ierr = H5LTset_attribute_int(group_fld, ".", "m", &m, 1);
+    CE;
 
-    mrc_fld_foreach_patch(m1, p) {
-      struct mrc_fld_patch *m1p = mrc_fld_patch_get(m1, p);
+    mrc_fld_foreach_patch(m1, p)
+    {
+      struct mrc_fld_patch* m1p = mrc_fld_patch_get(m1, p);
 
       char s_patch[10];
       sprintf(s_patch, "p%d", p);
 
-      hsize_t mdims[1] = { m1->_ghost_dims[0] };
-      hsize_t fdims[1] = { m1->_ghost_dims[0] + 2 * m1->_ghost_offs[0] + 2*sw[0]};
-      hsize_t off[1] = { -m1->_ghost_offs[0]-sw[0] };
+      hsize_t mdims[1] = {m1->_ghost_dims[0]};
+      hsize_t fdims[1] = {m1->_ghost_dims[0] + 2 * m1->_ghost_offs[0] +
+                          2 * sw[0]};
+      hsize_t off[1] = {-m1->_ghost_offs[0] - sw[0]};
       /* mprintf("fdims %lld:%lld:%lld\n", fdims[0], fdims[1], fdims[2]); */
       /* mprintf("mdims %lld:%lld:%lld\n", mdims[0], mdims[1], mdims[2]); */
       /* mprintf("off   %lld:%lld:%lld\n", off[0], off[1], off[2]); */
-      
 
-      hid_t group = H5Gcreate(group_fld, s_patch, H5P_DEFAULT,
-            H5P_DEFAULT, H5P_DEFAULT); H5_CHK(group);
+      hid_t group =
+        H5Gcreate(group_fld, s_patch, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
+      H5_CHK(group);
       struct mrc_patch_info info;
       mrc_domain_get_local_patch_info(m1->_domain, p, &info);
       H5LTset_attribute_int(group, ".", "global_patch", &info.global_patch, 1);
@@ -673,31 +735,34 @@ xdmf_write_m1(struct mrc_io *io, const char *path, struct mrc_fld *m1_any)
       H5Sselect_hyperslab(memspace, H5S_SELECT_SET, off, NULL, fdims, NULL);
 
       hid_t dtype;
-      void *arr;
+      void* arr;
       switch (mrc_fld_data_type(m1)) {
         case MRC_NT_FLOAT: {
-          arr = (void *) &MRC_S3((m1p)->_fld, m1->_ghost_offs[0], m, (m1p)->_p);
-          dtype = H5T_NATIVE_FLOAT; 
+          arr = (void*)&MRC_S3((m1p)->_fld, m1->_ghost_offs[0], m, (m1p)->_p);
+          dtype = H5T_NATIVE_FLOAT;
           break;
         }
         case MRC_NT_DOUBLE: {
-          arr = (void *) &MRC_D3((m1p)->_fld, m1->_ghost_offs[0], m, (m1p)->_p);
-          dtype = H5T_NATIVE_DOUBLE; 
+          arr = (void*)&MRC_D3((m1p)->_fld, m1->_ghost_offs[0], m, (m1p)->_p);
+          dtype = H5T_NATIVE_DOUBLE;
           break;
         }
         case MRC_NT_INT: {
-          arr = (void *) &MRC_I3((m1p)->_fld, m1->_ghost_offs[0], m, (m1p)->_p);
-          dtype = H5T_NATIVE_INT; 
+          arr = (void*)&MRC_I3((m1p)->_fld, m1->_ghost_offs[0], m, (m1p)->_p);
+          dtype = H5T_NATIVE_INT;
           break;
         }
         default: assert(0);
       }
 
       hid_t dset = H5Dcreate(group, "1d", dtype, filespace, H5P_DEFAULT,
-           H5P_DEFAULT, H5P_DEFAULT);
-      ierr = H5Dwrite(dset, dtype, memspace, filespace, H5P_DEFAULT, arr); CE;
-      ierr = H5Dclose(dset); CE;
-      ierr = H5Gclose(group); CE;
+                             H5P_DEFAULT, H5P_DEFAULT);
+      ierr = H5Dwrite(dset, dtype, memspace, filespace, H5P_DEFAULT, arr);
+      CE;
+      ierr = H5Dclose(dset);
+      CE;
+      ierr = H5Gclose(group);
+      CE;
       mrc_fld_patch_put(m1);
     }
     H5Gclose(group_fld);
@@ -707,35 +772,39 @@ xdmf_write_m1(struct mrc_io *io, const char *path, struct mrc_fld *m1_any)
   if (m1_any->_aos) {
     mrc_fld_put_as(m1, m1_any);
   }
-
 }
 
-struct read_m1_cb_data {
-  struct mrc_io *io;
-  struct mrc_fld *m1;
+struct read_m1_cb_data
+{
+  struct mrc_io* io;
+  struct mrc_fld* m1;
   int sw[1];
 };
 
-static herr_t
-read_m1_cb(hid_t g_id, const char *name, const H5L_info_t *info, void *op_data)
+static herr_t read_m1_cb(hid_t g_id, const char* name, const H5L_info_t* info,
+                         void* op_data)
 {
   int ierr;
-  struct read_m1_cb_data *data = op_data;
-  struct mrc_fld *m1 = data->m1;
-  int *sw = data->sw;
+  struct read_m1_cb_data* data = op_data;
+  struct mrc_fld* m1 = data->m1;
+  int* sw = data->sw;
 
-  hid_t group_fld = H5Gopen(g_id, name, H5P_DEFAULT); H5_CHK(group_fld);
+  hid_t group_fld = H5Gopen(g_id, name, H5P_DEFAULT);
+  H5_CHK(group_fld);
 
   int m;
-  ierr = H5LTget_attribute_int(group_fld, ".", "m", &m); CE;
+  ierr = H5LTget_attribute_int(group_fld, ".", "m", &m);
+  CE;
 
-  mrc_fld_foreach_patch(m1, p) {
-    struct mrc_fld_patch *m1p = mrc_fld_patch_get(m1, p);
+  mrc_fld_foreach_patch(m1, p)
+  {
+    struct mrc_fld_patch* m1p = mrc_fld_patch_get(m1, p);
 
     char s_patch[10];
     sprintf(s_patch, "p%d", p);
 
-    hid_t group = H5Gopen(group_fld, s_patch, H5P_DEFAULT); H5_CHK(group);
+    hid_t group = H5Gopen(group_fld, s_patch, H5P_DEFAULT);
+    H5_CHK(group);
 
     struct mrc_patch_info info;
     mrc_domain_get_local_patch_info(m1->_domain, p, &info);
@@ -744,31 +813,30 @@ read_m1_cb(hid_t g_id, const char *name, const H5L_info_t *info, void *op_data)
     H5LTget_attribute_int(group, ".", "global_patch", &file_gpatch);
     assert(info.global_patch == file_gpatch);
 
-    hsize_t mdims[1] = { m1->_ghost_dims[0] };
-    hsize_t fdims[1] = { m1->_ghost_dims[0] + 2 * m1->_ghost_offs[0] + 2*sw[0]};
-    hsize_t off[1] = { -m1->_ghost_offs[0]-sw[0] };
-
+    hsize_t mdims[1] = {m1->_ghost_dims[0]};
+    hsize_t fdims[1] = {m1->_ghost_dims[0] + 2 * m1->_ghost_offs[0] +
+                        2 * sw[0]};
+    hsize_t off[1] = {-m1->_ghost_offs[0] - sw[0]};
 
     hid_t memspace = H5Screate_simple(1, mdims, NULL);
     H5Sselect_hyperslab(memspace, H5S_SELECT_SET, off, NULL, fdims, NULL);
 
-
     hid_t dtype;
-    void *arr;
+    void* arr;
     switch (mrc_fld_data_type(m1)) {
       case MRC_NT_FLOAT: {
-        arr = (void *) &MRC_S3((m1p)->_fld, m1->_ghost_offs[0], m, (m1p)->_p);
-        dtype = H5T_NATIVE_FLOAT; 
+        arr = (void*)&MRC_S3((m1p)->_fld, m1->_ghost_offs[0], m, (m1p)->_p);
+        dtype = H5T_NATIVE_FLOAT;
         break;
       }
       case MRC_NT_DOUBLE: {
-        arr = (void *) &MRC_D3((m1p)->_fld, m1->_ghost_offs[0], m, (m1p)->_p);
-        dtype = H5T_NATIVE_DOUBLE; 
+        arr = (void*)&MRC_D3((m1p)->_fld, m1->_ghost_offs[0], m, (m1p)->_p);
+        dtype = H5T_NATIVE_DOUBLE;
         break;
       }
       case MRC_NT_INT: {
-        arr = (void *) &MRC_I3((m1p)->_fld, m1->_ghost_offs[0], m, (m1p)->_p);
-        dtype = H5T_NATIVE_INT; 
+        arr = (void*)&MRC_I3((m1p)->_fld, m1->_ghost_offs[0], m, (m1p)->_p);
+        dtype = H5T_NATIVE_INT;
         break;
       }
       default: assert(0);
@@ -776,24 +844,27 @@ read_m1_cb(hid_t g_id, const char *name, const H5L_info_t *info, void *op_data)
 
     hid_t dset = H5Dopen(group, "1d", H5P_DEFAULT);
     hid_t filespace = H5Dget_space(dset);
-    ierr = H5Dread(dset, dtype, memspace, filespace, H5P_DEFAULT, arr); CE;
-    ierr = H5Dclose(dset); CE;
-    ierr = H5Gclose(group); CE;
+    ierr = H5Dread(dset, dtype, memspace, filespace, H5P_DEFAULT, arr);
+    CE;
+    ierr = H5Dclose(dset);
+    CE;
+    ierr = H5Gclose(group);
+    CE;
     mrc_fld_patch_put(m1);
   }
   H5Gclose(group_fld);
   return 0;
 }
 
-static void
-xdmf_read_m1(struct mrc_io *io, const char *path, struct mrc_fld *m1_any)
+static void xdmf_read_m1(struct mrc_io* io, const char* path,
+                         struct mrc_fld* m1_any)
 {
 
-  struct xdmf *xdmf = to_xdmf(io);
-  struct xdmf_file *file = &xdmf->file;
+  struct xdmf* xdmf = to_xdmf(io);
+  struct xdmf_file* file = &xdmf->file;
 
   // If we have an aos field, we need to get it as soa
-  struct mrc_fld *m1 = m1_any;
+  struct mrc_fld* m1 = m1_any;
   if (m1_any->_aos) {
     switch (mrc_fld_data_type(m1_any)) {
       case MRC_NT_FLOAT: m1 = mrc_fld_get_as(m1_any, "float"); break;
@@ -811,51 +882,47 @@ xdmf_read_m1(struct mrc_io *io, const char *path, struct mrc_fld *m1_any)
   }
   hid_t group0 = H5Gopen(file->h5_file, path, H5P_DEFAULT);
   int nr_patches = mrc_fld_nr_patches(m1);
-  
-  int file_patches;  
+
+  int file_patches;
   H5LTget_attribute_int(group0, ".", "nr_patches", &file_patches);
   assert(nr_patches == file_patches);
 
   struct read_m1_cb_data cb_data = {
-    .io        = io,
-    .m1        = m1,
-    .sw        = {sw[0]},
+    .io = io,
+    .m1 = m1,
+    .sw = {sw[0]},
   };
-  
-  hsize_t idx = 0;
-  H5Literate_by_name(group0, ".", H5_INDEX_NAME, H5_ITER_INC, &idx,
-         read_m1_cb, &cb_data, H5P_DEFAULT);
 
+  hsize_t idx = 0;
+  H5Literate_by_name(group0, ".", H5_INDEX_NAME, H5_ITER_INC, &idx, read_m1_cb,
+                     &cb_data, H5P_DEFAULT);
 
   H5Gclose(group0);
 
   if (m1_any->_aos) {
     mrc_fld_put_as(m1, m1_any);
   }
-
 }
-
 
 // ----------------------------------------------------------------------
 // mrc_io_ops_xdmf
 
 struct mrc_io_ops mrc_io_xdmf2_ops = {
-  .name          = "xdmf2",
-  .size          = sizeof(struct xdmf),
-  .param_descr   = xdmf2_descr,
-  .parallel      = true,
-  .setup         = xdmf_setup,
-  .destroy       = xdmf_destroy,
-  .open          = xdmf_open,
-  .close         = xdmf_close,
-  .write_attr    = xdmf_write_attr,
-  .read_attr     = xdmf_read_attr,
-  .write_m3      = xdmf_write_m3,
-  .read_m3       = xdmf_read_m3,
-  .write_m1      = xdmf_write_m1,
-  .read_m1       = xdmf_read_m1,
+  .name = "xdmf2",
+  .size = sizeof(struct xdmf),
+  .param_descr = xdmf2_descr,
+  .parallel = true,
+  .setup = xdmf_setup,
+  .destroy = xdmf_destroy,
+  .open = xdmf_open,
+  .close = xdmf_close,
+  .write_attr = xdmf_write_attr,
+  .read_attr = xdmf_read_attr,
+  .write_m3 = xdmf_write_m3,
+  .read_m3 = xdmf_read_m3,
+  .write_m1 = xdmf_write_m1,
+  .read_m1 = xdmf_read_m1,
 };
-
 
 // ======================================================================
 
@@ -864,16 +931,15 @@ struct mrc_io_ops mrc_io_xdmf2_ops = {
 // ----------------------------------------------------------------------
 // xdmf_parallel_open
 
-static void
-xdmf_parallel_open(struct mrc_io *io, const char *mode)
+static void xdmf_parallel_open(struct mrc_io* io, const char* mode)
 {
-  struct xdmf *xdmf = to_xdmf(io);
+  struct xdmf* xdmf = to_xdmf(io);
   assert(strcmp(mode, "w") == 0);
 
-  struct xdmf_file *file = &xdmf->file;
+  struct xdmf_file* file = &xdmf->file;
   char filename[strlen(io->par.outdir) + strlen(io->par.basename) + 20];
   sprintf(filename, "%s/%s.%06d_p%06d.h5", io->par.outdir, io->par.basename,
-	  io->step, 0);
+          io->step, 0);
 
   hid_t plist = H5Pcreate(H5P_FILE_ACCESS);
 #ifdef H5_HAVE_PARALLEL
@@ -888,11 +954,10 @@ xdmf_parallel_open(struct mrc_io *io, const char *mode)
 // ----------------------------------------------------------------------
 // xdmf_parallel_close
 
-static void
-xdmf_parallel_close(struct mrc_io *io)
+static void xdmf_parallel_close(struct mrc_io* io)
 {
-  struct xdmf *xdmf = to_xdmf(io);
-  struct xdmf_file *file = &xdmf->file;
+  struct xdmf* xdmf = to_xdmf(io);
+  struct xdmf_file* file = &xdmf->file;
 
   H5Fclose(file->h5_file);
   xdmf_spatial_close(&file->xdmf_spatial_list, io, xdmf->xdmf_temporal);
@@ -903,71 +968,76 @@ xdmf_parallel_close(struct mrc_io *io)
 // ----------------------------------------------------------------------
 // xdmf_spatial_write_mcrds_multi_parallel
 
-static void
-xdmf_spatial_write_mcrds_multi_parallel(struct xdmf_file *file,
-					struct mrc_domain *domain)
+static void xdmf_spatial_write_mcrds_multi_parallel(struct xdmf_file* file,
+                                                    struct mrc_domain* domain)
 {
-  struct mrc_crds *crds = mrc_domain_get_crds(domain);
+  struct mrc_crds* crds = mrc_domain_get_crds(domain);
   int gdims[3];
   mrc_domain_get_global_dims(domain, gdims);
 
   for (int d = 0; d < 3; d++) {
-    struct mrc_fld *mcrd = crds->crd[d];
+    struct mrc_fld* mcrd = crds->crd[d];
 
     hid_t group_crd1 = H5Gcreate(file->h5_file, mrc_fld_name(mcrd), H5P_DEFAULT,
-				 H5P_DEFAULT, H5P_DEFAULT); H5_CHK(group_crd1);
+                                 H5P_DEFAULT, H5P_DEFAULT);
+    H5_CHK(group_crd1);
 
-    hid_t group_crdp = H5Gcreate(group_crd1, "p0", H5P_DEFAULT,
-				 H5P_DEFAULT, H5P_DEFAULT); H5_CHK(group_crdp);
-    
-    hsize_t fdims[1] = { gdims[d] + 1 };
+    hid_t group_crdp =
+      H5Gcreate(group_crd1, "p0", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
+    H5_CHK(group_crdp);
+
+    hsize_t fdims[1] = {gdims[d] + 1};
     hid_t filespace = H5Screate_simple(1, fdims, NULL);
-    hid_t dset = H5Dcreate(group_crdp, "1d", H5T_NATIVE_FLOAT, filespace, H5P_DEFAULT,
-			   H5P_DEFAULT, H5P_DEFAULT);
+    hid_t dset = H5Dcreate(group_crdp, "1d", H5T_NATIVE_FLOAT, filespace,
+                           H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
 
-    mrc_m1_foreach_patch(mcrd, p) {
+    mrc_m1_foreach_patch(mcrd, p)
+    {
       struct mrc_patch_info info;
       mrc_domain_get_local_patch_info(domain, p, &info);
       bool skip_write = false;
       for (int dd = 0; dd < 3; dd++) {
-	if (d != dd && info.off[dd] != 0) {
-	  skip_write = true;
-	  break;
-	}
+        if (d != dd && info.off[dd] != 0) {
+          skip_write = true;
+          break;
+        }
       }
       // indep I/O only!
       // FIXME, do collective ?
       if (skip_write) {
-	continue;
+        continue;
       }
 
       // get node-centered coordinates
       int im = info.ldims[d];
-      float *crd_nc = calloc(im + 1, sizeof(*crd_nc));
+      float* crd_nc = calloc(im + 1, sizeof(*crd_nc));
       if (mrc_fld_ghost_offs(mcrd)[0] < 0) {
-	for (int i = 0; i <= im; i++) {
-	  crd_nc[i] = .5 * (MRC_M1(mcrd,0, i-1, p) + MRC_M1(mcrd,0, i, p));
-	}
+        for (int i = 0; i <= im; i++) {
+          crd_nc[i] = .5 * (MRC_M1(mcrd, 0, i - 1, p) + MRC_M1(mcrd, 0, i, p));
+        }
       } else {
-	for (int i = 1; i < im; i++) {
-	  crd_nc[i] = .5 * (MRC_M1(mcrd,0, i-1, p) + MRC_M1(mcrd,0, i, p));
-	}
-	// extrapolate
-	crd_nc[0]  = MRC_M1(mcrd,0, 0   , p) - .5 * (MRC_M1(mcrd,0, 1   , p) - MRC_M1(mcrd,0, 0   , p));
-	crd_nc[im] = MRC_M1(mcrd,0, im-1, p) + .5 * (MRC_M1(mcrd,0, im-1, p) - MRC_M1(mcrd,0, im-2, p));
+        for (int i = 1; i < im; i++) {
+          crd_nc[i] = .5 * (MRC_M1(mcrd, 0, i - 1, p) + MRC_M1(mcrd, 0, i, p));
+        }
+        // extrapolate
+        crd_nc[0] = MRC_M1(mcrd, 0, 0, p) -
+                    .5 * (MRC_M1(mcrd, 0, 1, p) - MRC_M1(mcrd, 0, 0, p));
+        crd_nc[im] =
+          MRC_M1(mcrd, 0, im - 1, p) +
+          .5 * (MRC_M1(mcrd, 0, im - 1, p) - MRC_M1(mcrd, 0, im - 2, p));
       }
 
-      hsize_t mdims[1] = { info.ldims[d] + (info.off[d] == 0 ? 1 : 0) };
-      hsize_t off[1] = { info.off[d] + (info.off[d] == 0 ? 0 : 1) };
+      hsize_t mdims[1] = {info.ldims[d] + (info.off[d] == 0 ? 1 : 0)};
+      hsize_t off[1] = {info.off[d] + (info.off[d] == 0 ? 0 : 1)};
       hid_t memspace = H5Screate_simple(1, mdims, NULL);
       H5Sselect_hyperslab(filespace, H5S_SELECT_SET, off, NULL, mdims, NULL);
 
       H5Dwrite(dset, H5T_NATIVE_FLOAT, memspace, filespace, H5P_DEFAULT,
-	       &crd_nc[(info.off[d] == 0) ? 0 : 1]);
+               &crd_nc[(info.off[d] == 0) ? 0 : 1]);
 
       H5Sclose(memspace);
     }
-    
+
     H5Dclose(dset);
     H5Sclose(filespace);
 
@@ -979,12 +1049,12 @@ xdmf_spatial_write_mcrds_multi_parallel(struct xdmf_file *file,
 // ----------------------------------------------------------------------
 // xdmf_spatial_write_crds_multi_parallel
 
-static void
-xdmf_spatial_write_crds_multi_parallel(struct mrc_io *io, struct mrc_domain *domain)
+static void xdmf_spatial_write_crds_multi_parallel(struct mrc_io* io,
+                                                   struct mrc_domain* domain)
 {
-  struct xdmf *xdmf = to_xdmf(io);
-  struct xdmf_file *file = &xdmf->file;
-  struct mrc_crds *crds = mrc_domain_get_crds(domain);
+  struct xdmf* xdmf = to_xdmf(io);
+  struct xdmf_file* file = &xdmf->file;
+  struct mrc_crds* crds = mrc_domain_get_crds(domain);
   int gdims[3], np[3], nr_global_patches, nr_patches;
   mrc_domain_get_global_dims(domain, gdims);
   mrc_domain_get_nr_procs(domain, np);
@@ -992,73 +1062,77 @@ xdmf_spatial_write_crds_multi_parallel(struct mrc_io *io, struct mrc_domain *dom
   mrc_domain_get_patches(domain, &nr_patches);
 
   for (int d = 0; d < 3; d++) {
-    struct mrc_fld *crd = crds->crd[d];
+    struct mrc_fld* crd = crds->crd[d];
 
-    MPI_Request *send_reqs = calloc(nr_patches, sizeof(*send_reqs));
+    MPI_Request* send_reqs = calloc(nr_patches, sizeof(*send_reqs));
     int nr_send_reqs = 0;
     assert(nr_patches == 1); // otherwise need to redo tmp_nc
-    float *tmp_nc = NULL;
+    float* tmp_nc = NULL;
     for (int p = 0; p < nr_patches; p++) {
       struct mrc_patch_info info;
       mrc_domain_get_local_patch_info(domain, p, &info);
       bool skip_write = false;
       for (int dd = 0; dd < 3; dd++) {
-	if (d != dd && info.off[dd] != 0) {
-	  skip_write = true;
-	  break;
-	}
+        if (d != dd && info.off[dd] != 0) {
+          skip_write = true;
+          break;
+        }
       }
       if (!skip_write) {
-	tmp_nc = calloc(info.ldims[d] + 1, sizeof(*tmp_nc));
+        tmp_nc = calloc(info.ldims[d] + 1, sizeof(*tmp_nc));
 
-	// get node-centered coordinates
-	if (crd->_sw.vals[0] > 0) {
-	  for (int i = 0; i <= info.ldims[d]; i++) {
-	    tmp_nc[i] = .5 * (MRC_F1(crd,0, i-1) + MRC_F1(crd,0, i));
-	  }
-	} else {
-	  int ld = info.ldims[d];
-	  for (int i = 1; i < ld; i++) {
-	    tmp_nc[i] = .5 * (MRC_F1(crd,0, i-1) + MRC_F1(crd,0, i));
-	  }
-	  // extrapolate
-	  tmp_nc[0]  = MRC_F1(crd,0, 0) - .5 * (MRC_F1(crd,0, 1) - MRC_F1(crd,0, 0));
-	  tmp_nc[ld] = MRC_F1(crd,0, ld-1) + .5 * (MRC_F1(crd,0, ld-1) - MRC_F1(crd,0, ld-2));
-	}
+        // get node-centered coordinates
+        if (crd->_sw.vals[0] > 0) {
+          for (int i = 0; i <= info.ldims[d]; i++) {
+            tmp_nc[i] = .5 * (MRC_F1(crd, 0, i - 1) + MRC_F1(crd, 0, i));
+          }
+        } else {
+          int ld = info.ldims[d];
+          for (int i = 1; i < ld; i++) {
+            tmp_nc[i] = .5 * (MRC_F1(crd, 0, i - 1) + MRC_F1(crd, 0, i));
+          }
+          // extrapolate
+          tmp_nc[0] =
+            MRC_F1(crd, 0, 0) - .5 * (MRC_F1(crd, 0, 1) - MRC_F1(crd, 0, 0));
+          tmp_nc[ld] = MRC_F1(crd, 0, ld - 1) +
+                       .5 * (MRC_F1(crd, 0, ld - 1) - MRC_F1(crd, 0, ld - 2));
+        }
 
- 	/* mprintf("Isend off %d %d %d gp %d\n", info.off[0], info.off[1], info.off[2], */
-	/* 	info.global_patch); */
-	MPI_Isend(tmp_nc + (info.off[d] == 0 ? 0 : 1),
-		  info.ldims[d] + (info.off[d] == 0 ? 1 : 0), MPI_FLOAT,
-		  0, info.global_patch,
-		  mrc_io_comm(io), &send_reqs[nr_send_reqs++]);
+        /* mprintf("Isend off %d %d %d gp %d\n", info.off[0], info.off[1],
+         * info.off[2], */
+        /* 	info.global_patch); */
+        MPI_Isend(tmp_nc + (info.off[d] == 0 ? 0 : 1),
+                  info.ldims[d] + (info.off[d] == 0 ? 1 : 0), MPI_FLOAT, 0,
+                  info.global_patch, mrc_io_comm(io),
+                  &send_reqs[nr_send_reqs++]);
       }
     }
 
     int im = gdims[d];
-    float *crd_nc = NULL;
+    float* crd_nc = NULL;
 
     if (io->rank == 0) { // only on first writer
       crd_nc = calloc(im + 1, sizeof(*crd_nc));
-      MPI_Request *recv_reqs = calloc(np[d], sizeof(*recv_reqs));
+      MPI_Request* recv_reqs = calloc(np[d], sizeof(*recv_reqs));
       int nr_recv_reqs = 0;
       for (int gp = 0; gp < nr_global_patches; gp++) {
-	struct mrc_patch_info info;
-	mrc_domain_get_global_patch_info(domain, gp, &info);
-	bool skip_write = false;
-	for (int dd = 0; dd < 3; dd++) {
-	  if (d != dd && info.off[dd] != 0) {
-	    skip_write = true;
-	    break;
-	  }
-	}
-	if (skip_write) {
-	  continue;
-	}
-	/* mprintf("Irecv off %d %d %d gp %d\n", info.off[0], info.off[1], info.off[2], gp); */
-	MPI_Irecv(&crd_nc[info.off[d] + (info.off[d] == 0 ? 0 : 1)],
-		  info.ldims[d] + (info.off[d] == 0 ? 1 : 0), MPI_FLOAT, info.rank,
-		  gp, mrc_io_comm(io), &recv_reqs[nr_recv_reqs++]);
+        struct mrc_patch_info info;
+        mrc_domain_get_global_patch_info(domain, gp, &info);
+        bool skip_write = false;
+        for (int dd = 0; dd < 3; dd++) {
+          if (d != dd && info.off[dd] != 0) {
+            skip_write = true;
+            break;
+          }
+        }
+        if (skip_write) {
+          continue;
+        }
+        /* mprintf("Irecv off %d %d %d gp %d\n", info.off[0], info.off[1],
+         * info.off[2], gp); */
+        MPI_Irecv(&crd_nc[info.off[d] + (info.off[d] == 0 ? 0 : 1)],
+                  info.ldims[d] + (info.off[d] == 0 ? 1 : 0), MPI_FLOAT,
+                  info.rank, gp, mrc_io_comm(io), &recv_reqs[nr_recv_reqs++]);
       }
       assert(nr_recv_reqs == np[d]);
 
@@ -1071,16 +1145,17 @@ xdmf_spatial_write_crds_multi_parallel(struct mrc_io *io, struct mrc_domain *dom
     free(send_reqs);
 
     // this group has been generated by generic mrc_obj code
-    hid_t group_crd1 = H5Gopen(file->h5_file, mrc_fld_name(crd),
-			       H5P_DEFAULT); H5_CHK(group_crd1);
+    hid_t group_crd1 = H5Gopen(file->h5_file, mrc_fld_name(crd), H5P_DEFAULT);
+    H5_CHK(group_crd1);
 
-    hid_t group_crdp = H5Gcreate(group_crd1, "p0", H5P_DEFAULT,
-				 H5P_DEFAULT, H5P_DEFAULT); H5_CHK(group_crd1);
-    
-    hsize_t fdims[1] = { gdims[d] + 1 };
+    hid_t group_crdp =
+      H5Gcreate(group_crd1, "p0", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
+    H5_CHK(group_crd1);
+
+    hsize_t fdims[1] = {gdims[d] + 1};
     hid_t filespace = H5Screate_simple(1, fdims, NULL);
-    hid_t dset = H5Dcreate(group_crdp, "1d", H5T_NATIVE_FLOAT, filespace, H5P_DEFAULT,
-			   H5P_DEFAULT, H5P_DEFAULT);
+    hid_t dset = H5Dcreate(group_crdp, "1d", H5T_NATIVE_FLOAT, filespace,
+                           H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
 
     hid_t memspace;
     if (io->rank == 0) {
@@ -1090,11 +1165,11 @@ xdmf_spatial_write_crds_multi_parallel(struct mrc_io *io, struct mrc_domain *dom
       H5Sselect_none(memspace);
       H5Sselect_none(filespace);
     }
-    
+
     H5Dwrite(dset, H5T_NATIVE_FLOAT, memspace, filespace, H5P_DEFAULT, crd_nc);
-    
+
     H5Sclose(memspace);
-    
+
     H5Dclose(dset);
     H5Sclose(filespace);
 
@@ -1108,24 +1183,25 @@ xdmf_spatial_write_crds_multi_parallel(struct mrc_io *io, struct mrc_domain *dom
 // ----------------------------------------------------------------------
 // xdmf_spatial_write_crds_uniform_parallel
 
-static void
-xdmf_spatial_write_crds_uniform_parallel(struct xdmf_file *file,
-					 struct mrc_domain *domain)
+static void xdmf_spatial_write_crds_uniform_parallel(struct xdmf_file* file,
+                                                     struct mrc_domain* domain)
 {
-  struct mrc_crds *crds = mrc_domain_get_crds(domain);
+  struct mrc_crds* crds = mrc_domain_get_crds(domain);
 
   double xl[3], xh[3];
   mrc_crds_get_param_double3(crds, "l", xl);
   mrc_crds_get_param_double3(crds, "h", xh);
 
   for (int d = 0; d < 3; d++) {
-    struct mrc_fld *mcrd = crds->crd[d];
+    struct mrc_fld* mcrd = crds->crd[d];
 
     hid_t group_crd1 = H5Gcreate(file->h5_file, mrc_fld_name(mcrd), H5P_DEFAULT,
-				 H5P_DEFAULT, H5P_DEFAULT); H5_CHK(group_crd1);
+                                 H5P_DEFAULT, H5P_DEFAULT);
+    H5_CHK(group_crd1);
 
-    hid_t group_crdp = H5Gcreate(group_crd1, "p0", H5P_DEFAULT,
-				 H5P_DEFAULT, H5P_DEFAULT); H5_CHK(group_crd1);
+    hid_t group_crdp =
+      H5Gcreate(group_crd1, "p0", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
+    H5_CHK(group_crd1);
     H5LTset_attribute_double(group_crdp, ".", "xl", &xl[d], 1);
     H5LTset_attribute_double(group_crdp, ".", "xh", &xh[d], 1);
     H5Gclose(group_crdp);
@@ -1136,19 +1212,18 @@ xdmf_spatial_write_crds_uniform_parallel(struct xdmf_file *file,
 // ----------------------------------------------------------------------
 // xdmf_spatial_write_mcrds_parallel
 
-static void
-xdmf_spatial_write_mcrds_parallel(struct xdmf_spatial *xs,
-				  struct mrc_io *io,
-				  struct mrc_domain *domain)
+static void xdmf_spatial_write_mcrds_parallel(struct xdmf_spatial* xs,
+                                              struct mrc_io* io,
+                                              struct mrc_domain* domain)
 {
-  struct xdmf *xdmf = to_xdmf(io);
-  struct xdmf_file *file = &xdmf->file;
+  struct xdmf* xdmf = to_xdmf(io);
+  struct xdmf_file* file = &xdmf->file;
   if (xs->crds_done)
     return;
 
   xs->crds_done = true;
 
-  struct mrc_crds *crds = mrc_domain_get_crds(domain);
+  struct mrc_crds* crds = mrc_domain_get_crds(domain);
   if (strcmp(mrc_crds_type(crds), "uniform") == 0) {
     xdmf_spatial_write_crds_uniform_parallel(file, domain);
   } else if (strcmp(mrc_crds_type(crds), "multi") == 0) {
@@ -1166,33 +1241,34 @@ xdmf_spatial_write_mcrds_parallel(struct xdmf_spatial *xs,
 // ----------------------------------------------------------------------
 // xdmf_parallel_write_m3
 
-static void
-xdmf_parallel_write_m3(struct mrc_io *io, const char *path, struct mrc_fld *m3)
+static void xdmf_parallel_write_m3(struct mrc_io* io, const char* path,
+                                   struct mrc_fld* m3)
 {
-  struct xdmf *xdmf = to_xdmf(io);
-  struct xdmf_file *file = &xdmf->file;
+  struct xdmf* xdmf = to_xdmf(io);
+  struct xdmf_file* file = &xdmf->file;
 
   hid_t group0;
   if (H5Lexists(file->h5_file, path, H5P_DEFAULT) > 0) {
     group0 = H5Gopen(file->h5_file, path, H5P_DEFAULT);
     MHERE;
   } else {
-    group0 = H5Gcreate(file->h5_file, path, H5P_DEFAULT,
-		       H5P_DEFAULT, H5P_DEFAULT); H5_CHK(group0);
+    group0 =
+      H5Gcreate(file->h5_file, path, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
+    H5_CHK(group0);
   }
   int nr_1 = 1;
   H5LTset_attribute_int(group0, ".", "nr_patches", &nr_1, 1);
 
-  struct xdmf_spatial *xs = xdmf_spatial_find(&file->xdmf_spatial_list,
-					      mrc_domain_name(m3->_domain));
+  struct xdmf_spatial* xs =
+    xdmf_spatial_find(&file->xdmf_spatial_list, mrc_domain_name(m3->_domain));
   int gdims[3];
   mrc_domain_get_global_dims(m3->_domain, gdims);
 
   if (!xs) {
     int off[3] = {};
     xs = xdmf_spatial_create_m3_parallel(&file->xdmf_spatial_list,
-					 mrc_domain_name(m3->_domain),
-					 m3->_domain, off, gdims, io);
+                                         mrc_domain_name(m3->_domain),
+                                         m3->_domain, off, gdims, io);
     xdmf_spatial_write_mcrds_parallel(xs, io, m3->_domain);
   }
 
@@ -1201,22 +1277,25 @@ xdmf_parallel_write_m3(struct mrc_io *io, const char *path, struct mrc_fld *m3)
   int nr_patches_max;
   // FIXME, mrc_domain may know / cache
   MPI_Allreduce(&nr_patches, &nr_patches_max, 1, MPI_INT, MPI_MAX,
-		mrc_domain_comm(m3->_domain));
+                mrc_domain_comm(m3->_domain));
 
   for (int m = 0; m < mrc_fld_nr_comps(m3); m++) {
-    xdmf_spatial_save_fld_info(xs, strdup(mrc_fld_comp_name(m3, m)), strdup(path), false, mrc_fld_data_type(m3));
+    xdmf_spatial_save_fld_info(xs, strdup(mrc_fld_comp_name(m3, m)),
+                               strdup(path), false, mrc_fld_data_type(m3));
 
     hid_t group_fld = H5Gcreate(group0, mrc_fld_comp_name(m3, m), H5P_DEFAULT,
-				H5P_DEFAULT, H5P_DEFAULT); H5_CHK(group_fld);
-    hid_t group = H5Gcreate(group_fld, "p0", H5P_DEFAULT,
-			    H5P_DEFAULT, H5P_DEFAULT); H5_CHK(group);
+                                H5P_DEFAULT, H5P_DEFAULT);
+    H5_CHK(group_fld);
+    hid_t group =
+      H5Gcreate(group_fld, "p0", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
+    H5_CHK(group);
     int i0 = 0;
     H5LTset_attribute_int(group, ".", "global_patch", &i0, 1);
 
-    hsize_t fdims[3] = { gdims[2], gdims[1], gdims[0] };
+    hsize_t fdims[3] = {gdims[2], gdims[1], gdims[0]};
     hid_t filespace = H5Screate_simple(3, fdims, NULL);
-    hid_t dset = H5Dcreate(group, "3d", H5T_NATIVE_FLOAT, filespace, H5P_DEFAULT,
-			   H5P_DEFAULT, H5P_DEFAULT);
+    hid_t dset = H5Dcreate(group, "3d", H5T_NATIVE_FLOAT, filespace,
+                           H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
     hid_t dxpl = H5Pcreate(H5P_DATASET_XFER);
 #ifdef H5_HAVE_PARALLEL
     if (xdmf->use_independent_io) {
@@ -1227,33 +1306,36 @@ xdmf_parallel_write_m3(struct mrc_io *io, const char *path, struct mrc_fld *m3)
 #endif
     for (int p = 0; p < nr_patches_max; p++) {
       if (p >= nr_patches) {
-	if (xdmf->use_independent_io)
-	  continue;
+        if (xdmf->use_independent_io)
+          continue;
 
-	// for collective I/O write nothing if no patch left,
-	// but still call H5Dwrite()
-	H5Sselect_none(filespace);
-	hid_t memspace = H5Screate(H5S_NULL);
-	H5Sselect_none(memspace);
-	H5Dwrite(dset, H5T_NATIVE_FLOAT, memspace, filespace, dxpl, NULL);
-	H5Sclose(memspace);
-	continue;
+        // for collective I/O write nothing if no patch left,
+        // but still call H5Dwrite()
+        H5Sselect_none(filespace);
+        hid_t memspace = H5Screate(H5S_NULL);
+        H5Sselect_none(memspace);
+        H5Dwrite(dset, H5T_NATIVE_FLOAT, memspace, filespace, dxpl, NULL);
+        H5Sclose(memspace);
+        continue;
       }
       struct mrc_patch_info info;
       mrc_domain_get_local_patch_info(m3->_domain, p, &info);
-      struct mrc_fld_patch *m3p = mrc_fld_patch_get(m3, p);
+      struct mrc_fld_patch* m3p = mrc_fld_patch_get(m3, p);
 
-      hsize_t mdims[3] = { m3->_ghost_dims[2], m3->_ghost_dims[1], m3->_ghost_dims[0] };
-      hsize_t mcount[3] = { info.ldims[2], info.ldims[1], info.ldims[0] };
-      hsize_t moff[3] = { -m3->_ghost_offs[2], -m3->_ghost_offs[1], -m3->_ghost_offs[0] };
-      hsize_t foff[3] = { info.off[2], info.off[1], info.off[0] };
+      hsize_t mdims[3] = {m3->_ghost_dims[2], m3->_ghost_dims[1],
+                          m3->_ghost_dims[0]};
+      hsize_t mcount[3] = {info.ldims[2], info.ldims[1], info.ldims[0]};
+      hsize_t moff[3] = {-m3->_ghost_offs[2], -m3->_ghost_offs[1],
+                         -m3->_ghost_offs[0]};
+      hsize_t foff[3] = {info.off[2], info.off[1], info.off[0]};
 
       H5Sselect_hyperslab(filespace, H5S_SELECT_SET, foff, NULL, mcount, NULL);
       hid_t memspace = H5Screate_simple(3, mdims, NULL);
       H5Sselect_hyperslab(memspace, H5S_SELECT_SET, moff, NULL, mcount, NULL);
 
       H5Dwrite(dset, H5T_NATIVE_FLOAT, memspace, filespace, dxpl,
-	       &MRC_M3(m3p, m, m3->_ghost_offs[0], m3->_ghost_offs[1], m3->_ghost_offs[2]));
+               &MRC_M3(m3p, m, m3->_ghost_offs[0], m3->_ghost_offs[1],
+                       m3->_ghost_offs[2]));
 
       H5Sclose(memspace);
 
@@ -1269,23 +1351,22 @@ xdmf_parallel_write_m3(struct mrc_io *io, const char *path, struct mrc_fld *m3)
   H5Gclose(group0);
 }
 
-
 // ----------------------------------------------------------------------
 // mrc_io_ops_xdmf_parallel
 
 struct mrc_io_ops mrc_io_xdmf2_parallel_ops = {
-  .name          = "xdmf2_parallel",
-  .size          = sizeof(struct xdmf),
-  .param_descr   = xdmf_parallel_descr,
-  .parallel      = true,
-  .setup         = xdmf_setup,
-  .destroy       = xdmf_destroy,
-  .open          = xdmf_parallel_open,
-  .close         = xdmf_parallel_close,
+  .name = "xdmf2_parallel",
+  .size = sizeof(struct xdmf),
+  .param_descr = xdmf_parallel_descr,
+  .parallel = true,
+  .setup = xdmf_setup,
+  .destroy = xdmf_destroy,
+  .open = xdmf_parallel_open,
+  .close = xdmf_parallel_close,
 #if 0
   .write_attr    = xdmf_write_attr,
 #endif
-  .write_m3      = xdmf_parallel_write_m3,
+  .write_m3 = xdmf_parallel_write_m3,
 };
 
 #endif

--- a/src/libmrc/src/mrc_io_xdmf_collective.c
+++ b/src/libmrc/src/mrc_io_xdmf_collective.c
@@ -110,7 +110,7 @@ static void xdmf_collective_open(struct mrc_io* io, const char* mode)
   xdmf->mode = strdup(mode);
   //  assert(strcmp(mode, "w") == 0);
 
-  char filename[strlen(io->par.outdir) + strlen(io->par.basename) + 20];
+  char filename[strlen(io->par.outdir) + strlen(io->par.basename) + 30];
   sprintf(filename, "%s/%s.%06d_p%06d.h5", io->par.outdir, io->par.basename,
           io->step, 0);
 

--- a/src/libmrc/src/mrc_io_xdmf_lib.c
+++ b/src/libmrc/src/mrc_io_xdmf_lib.c
@@ -12,105 +12,141 @@
 // ======================================================================
 // xdmf writing
 
-static void
-xdmf_write_header(FILE *f)
+static void xdmf_write_header(FILE* f)
 {
   fprintf(f, "<?xml version='1.0' ?>\n");
-  fprintf(f, "<Xdmf xmlns:xi='http://www.w3.org/2001/XInclude' Version='2.0'>\n");
+  fprintf(f,
+          "<Xdmf xmlns:xi='http://www.w3.org/2001/XInclude' Version='2.0'>\n");
 }
 
-static void
-xdmf_write_topology_m1(FILE *f, int im[3], const char *filename, int p)
+static void xdmf_write_topology_m1(FILE* f, int im[3], const char* filename,
+                                   int p)
 {
   // FIXME crd0 hardcoded, should use mrc_m1_name()
-  fprintf(f, "     <Topology TopologyType=\"3DRectMesh\" Dimensions=\"%d %d %d\"/>\n",
-	  1, 1, im[0]);
+  fprintf(
+    f, "     <Topology TopologyType=\"3DRectMesh\" Dimensions=\"%d %d %d\"/>\n",
+    1, 1, im[0]);
 
   fprintf(f, "     <Geometry GeometryType=\"VXVYVZ\">\n");
-  fprintf(f, "     <DataItem Name=\"VX\" DataType=\"Float\" Dimensions=\"%d\" Format=\"HDF\">\n", im[0]);
+  fprintf(f,
+          "     <DataItem Name=\"VX\" DataType=\"Float\" Dimensions=\"%d\" "
+          "Format=\"HDF\">\n",
+          im[0]);
   fprintf(f, "        %s:/crd0/p%d/1d\n", filename, p);
   fprintf(f, "     </DataItem>\n");
-  fprintf(f, "     <DataItem Name=\"VY\" DataType=\"Float\" Dimensions=\"%d\" Format=\"XML\">\n", 1);
+  fprintf(f,
+          "     <DataItem Name=\"VY\" DataType=\"Float\" Dimensions=\"%d\" "
+          "Format=\"XML\">\n",
+          1);
   fprintf(f, "        0\n");
   fprintf(f, "     </DataItem>\n");
-  fprintf(f, "     <DataItem Name=\"VZ\" DataType=\"Float\" Dimensions=\"%d\" Format=\"XML\">\n", 1);
+  fprintf(f,
+          "     <DataItem Name=\"VZ\" DataType=\"Float\" Dimensions=\"%d\" "
+          "Format=\"XML\">\n",
+          1);
   fprintf(f, "        0\n");
   fprintf(f, "     </DataItem>\n");
   fprintf(f, "     </Geometry>\n");
-  fprintf(f, "     <Attribute Name=\"%s\" AttributeType=\"%s\" Center=\"Node\">\n",
-	  "crdx", "Scalar");
-  fprintf(f, "       <DataItem Dimensions=\"%d %d %d%s\" NumberType=\"Float\" Precision=\"4\" Format=\"HDF\">\n",
-	  1, 1, im[0], "");
+  fprintf(f,
+          "     <Attribute Name=\"%s\" AttributeType=\"%s\" Center=\"Node\">\n",
+          "crdx", "Scalar");
+  fprintf(f,
+          "       <DataItem Dimensions=\"%d %d %d%s\" NumberType=\"Float\" "
+          "Precision=\"4\" Format=\"HDF\">\n",
+          1, 1, im[0], "");
   fprintf(f, "        %s:/crd0/p%d/1d\n", filename, p);
   fprintf(f, "       </DataItem>\n");
   fprintf(f, "     </Attribute>\n");
   fprintf(f, "\n");
 }
 
-static void
-xdmf_write_topology_uniform_m3(FILE *f, int im[3], float xl[3], float dx[3], int _sw)
+static void xdmf_write_topology_uniform_m3(FILE* f, int im[3], float xl[3],
+                                           float dx[3], int _sw)
 {
   int sw[3];
   for (int d = 0; d < 3; d++) {
     sw[d] = im[d] > 1 ? _sw : 0;
   }
-  fprintf(f, "     <Topology TopologyType=\"3DCoRectMesh\" Dimensions=\"%d %d %d\"/>\n",
-	  im[2] + 1 + 2*sw[2], im[1] + 1 + 2*sw[1], im[0] + 1 + 2*sw[0]);
+  fprintf(
+    f,
+    "     <Topology TopologyType=\"3DCoRectMesh\" Dimensions=\"%d %d %d\"/>\n",
+    im[2] + 1 + 2 * sw[2], im[1] + 1 + 2 * sw[1], im[0] + 1 + 2 * sw[0]);
 
   fprintf(f, "     <Geometry GeometryType=\"Origin_DxDyDz\">\n");
-  fprintf(f, "     <DataItem Name=\"Origin\" DataType=\"Float\" Dimensions=\"3\" Format=\"XML\">\n");
-  fprintf(f, "        %g %g %g\n", xl[2] - sw[2] * dx[2], xl[1] - sw[1] * dx[1], xl[0] - sw[0] * dx[0]);
+  fprintf(f, "     <DataItem Name=\"Origin\" DataType=\"Float\" "
+             "Dimensions=\"3\" Format=\"XML\">\n");
+  fprintf(f, "        %g %g %g\n", xl[2] - sw[2] * dx[2], xl[1] - sw[1] * dx[1],
+          xl[0] - sw[0] * dx[0]);
   fprintf(f, "     </DataItem>\n");
-  fprintf(f, "     <DataItem Name=\"DxDyDz\" DataType=\"Float\" Dimensions=\"3\" Format=\"XML\">\n");
+  fprintf(f, "     <DataItem Name=\"DxDyDz\" DataType=\"Float\" "
+             "Dimensions=\"3\" Format=\"XML\">\n");
   fprintf(f, "        %g %g %g\n", dx[2], dx[1], dx[0]);
   fprintf(f, "     </DataItem>\n");
   fprintf(f, "     </Geometry>\n");
   fprintf(f, "\n");
 }
 
-static void
-xdmf_write_topology_m3(FILE *f, int im[3], const char *filename, const char *crd_nc_path[3], int p)
+static void xdmf_write_topology_m3(FILE* f, int im[3], const char* filename,
+                                   const char* crd_nc_path[3], int p)
 {
   // FIXME crd[012] hardcoded, should use mrc_m1_name()
-  fprintf(f, "     <Topology TopologyType=\"3DRectMesh\" Dimensions=\"%d %d %d\"/>\n",
-	  im[2] + 1, im[1] + 1, im[0] + 1);
+  fprintf(
+    f, "     <Topology TopologyType=\"3DRectMesh\" Dimensions=\"%d %d %d\"/>\n",
+    im[2] + 1, im[1] + 1, im[0] + 1);
 
   fprintf(f, "     <Geometry GeometryType=\"VXVYVZ\">\n");
-  fprintf(f, "     <DataItem Name=\"VX\" DataType=\"Float\" Dimensions=\"%d\" Format=\"HDF\">\n", im[0] + 1);
+  fprintf(f,
+          "     <DataItem Name=\"VX\" DataType=\"Float\" Dimensions=\"%d\" "
+          "Format=\"HDF\">\n",
+          im[0] + 1);
   fprintf(f, "        %s:/%s/crd_nc[0]/p%d/1d\n", filename, crd_nc_path[0], p);
   fprintf(f, "     </DataItem>\n");
-  fprintf(f, "     <DataItem Name=\"VY\" DataType=\"Float\" Dimensions=\"%d\" Format=\"HDF\">\n", im[1] + 1);
+  fprintf(f,
+          "     <DataItem Name=\"VY\" DataType=\"Float\" Dimensions=\"%d\" "
+          "Format=\"HDF\">\n",
+          im[1] + 1);
   fprintf(f, "        %s:/%s/crd_nc[1]/p%d/1d\n", filename, crd_nc_path[1], p);
   fprintf(f, "     </DataItem>\n");
-  fprintf(f, "     <DataItem Name=\"VZ\" DataType=\"Float\" Dimensions=\"%d\" Format=\"HDF\">\n", im[2] + 1);
+  fprintf(f,
+          "     <DataItem Name=\"VZ\" DataType=\"Float\" Dimensions=\"%d\" "
+          "Format=\"HDF\">\n",
+          im[2] + 1);
   fprintf(f, "        %s:/%s/crd_nc[2]/p%d/1d\n", filename, crd_nc_path[2], p);
   fprintf(f, "     </DataItem>\n");
   fprintf(f, "     </Geometry>\n");
   fprintf(f, "\n");
 }
 
-static void
-xdmf_write_fld_m1(FILE *f, struct xdmf_fld_info *fld_info, int im[3],
-		  const char *filename, int p)
+static void xdmf_write_fld_m1(FILE* f, struct xdmf_fld_info* fld_info,
+                              int im[3], const char* filename, int p)
 {
-  fprintf(f, "     <Attribute Name=\"%s\" AttributeType=\"%s\" Center=\"Node\">\n",
-	  fld_info->name, fld_info->is_vec ? "Vector" : "Scalar");
-  fprintf(f, "       <DataItem Dimensions=\"%d %d %d%s\" NumberType=\"%s\" Precision=\"%d\" Format=\"HDF\">\n",
-	  1, 1, im[0], fld_info->is_vec ? " 3" : "", fld_info->dtype, fld_info->precision);
-  fprintf(f, "        %s:/%s/%s/p%d/1d\n", filename, fld_info->path, fld_info->name, p);
+  fprintf(f,
+          "     <Attribute Name=\"%s\" AttributeType=\"%s\" Center=\"Node\">\n",
+          fld_info->name, fld_info->is_vec ? "Vector" : "Scalar");
+  fprintf(f,
+          "       <DataItem Dimensions=\"%d %d %d%s\" NumberType=\"%s\" "
+          "Precision=\"%d\" Format=\"HDF\">\n",
+          1, 1, im[0], fld_info->is_vec ? " 3" : "", fld_info->dtype,
+          fld_info->precision);
+  fprintf(f, "        %s:/%s/%s/p%d/1d\n", filename, fld_info->path,
+          fld_info->name, p);
   fprintf(f, "       </DataItem>\n");
   fprintf(f, "     </Attribute>\n");
 }
 
-static void
-xdmf_write_fld_m3(FILE *f, struct xdmf_fld_info *fld_info, int im[3],
-		  const char *filename, int p)
+static void xdmf_write_fld_m3(FILE* f, struct xdmf_fld_info* fld_info,
+                              int im[3], const char* filename, int p)
 {
-  fprintf(f, "     <Attribute Name=\"%s\" AttributeType=\"%s\" Center=\"Cell\">\n",
-	  fld_info->name, fld_info->is_vec ? "Vector" : "Scalar");
-  fprintf(f, "       <DataItem Dimensions=\"%d %d %d%s\" NumberType=\"%s\" Precision=\"%d\" Format=\"HDF\">\n",
-	  im[2], im[1], im[0], fld_info->is_vec ? " 3" : "", fld_info->dtype, fld_info->precision);
-  fprintf(f, "        %s:/%s/%s/p%d/3d\n", filename, fld_info->path, fld_info->name, p);
+  fprintf(f,
+          "     <Attribute Name=\"%s\" AttributeType=\"%s\" Center=\"Cell\">\n",
+          fld_info->name, fld_info->is_vec ? "Vector" : "Scalar");
+  fprintf(f,
+          "       <DataItem Dimensions=\"%d %d %d%s\" NumberType=\"%s\" "
+          "Precision=\"%d\" Format=\"HDF\">\n",
+          im[2], im[1], im[0], fld_info->is_vec ? " 3" : "", fld_info->dtype,
+          fld_info->precision);
+  fprintf(f, "        %s:/%s/%s/p%d/3d\n", filename, fld_info->path,
+          fld_info->name, p);
   fprintf(f, "       </DataItem>\n");
   fprintf(f, "     </Attribute>\n");
 }
@@ -118,20 +154,18 @@ xdmf_write_fld_m3(FILE *f, struct xdmf_fld_info *fld_info, int im[3],
 // ======================================================================
 // xdmf_temporal
 
-struct xdmf_temporal *
-xdmf_temporal_create(const char *filename)
+struct xdmf_temporal* xdmf_temporal_create(const char* filename)
 {
-  struct xdmf_temporal *xt = calloc(1, sizeof(*xt));
+  struct xdmf_temporal* xt = calloc(1, sizeof(*xt));
   INIT_LIST_HEAD(&xt->timesteps);
   xt->filename = strdup(filename);
   return xt;
 }
 
-void
-xdmf_temporal_destroy(struct xdmf_temporal *xt)
+void xdmf_temporal_destroy(struct xdmf_temporal* xt)
 {
   while (!list_empty(&xt->timesteps)) {
-    struct xdmf_temporal_step *xt_step =
+    struct xdmf_temporal_step* xt_step =
       list_entry(xt->timesteps.next, struct xdmf_temporal_step, entry);
     list_del(&xt_step->entry);
     free(xt_step);
@@ -140,17 +174,15 @@ xdmf_temporal_destroy(struct xdmf_temporal *xt)
   free(xt);
 }
 
-void
-xdmf_temporal_append(struct xdmf_temporal *xt, const char *fname_spatial)
+void xdmf_temporal_append(struct xdmf_temporal* xt, const char* fname_spatial)
 {
-  struct xdmf_temporal_step *xt_step =
+  struct xdmf_temporal_step* xt_step =
     malloc(sizeof(*xt_step) + strlen(fname_spatial) + 1);
   strcpy(xt_step->filename, fname_spatial);
   list_add_tail(&xt_step->entry, &xt->timesteps);
 }
 
-void
-xdmf_temporal_write(struct xdmf_temporal *xt)
+void xdmf_temporal_write(struct xdmf_temporal* xt)
 {
   // It'd be easier to create those files line by line as time goes by.
   // However, then we won't be able to get the timeseries into Paraview
@@ -159,15 +191,18 @@ xdmf_temporal_write(struct xdmf_temporal *xt)
   // which needs however some way to figure out what times we've written
   // before.
 
-  FILE *f = fopen(xt->filename, "w");
+  FILE* f = fopen(xt->filename, "w");
 
   xdmf_write_header(f);
   fprintf(f, "<Domain>\n");
   fprintf(f, "  <Grid GridType='Collection' CollectionType='Temporal'>\n");
-  struct xdmf_temporal_step *xt_step;
-  __list_for_each_entry(xt_step, &xt->timesteps, entry, struct xdmf_temporal_step) {
-    fprintf(f, "  <xi:include href='%s' xpointer='xpointer(//Xdmf/Domain/Grid)'/>\n",
-	    xt_step->filename);
+  struct xdmf_temporal_step* xt_step;
+  __list_for_each_entry(xt_step, &xt->timesteps, entry,
+                        struct xdmf_temporal_step)
+  {
+    fprintf(
+      f, "  <xi:include href='%s' xpointer='xpointer(//Xdmf/Domain/Grid)'/>\n",
+      xt_step->filename);
   }
   fprintf(f, "  </Grid>\n");
   fprintf(f, "  </Domain>\n");
@@ -178,17 +213,17 @@ xdmf_temporal_write(struct xdmf_temporal *xt)
 // ======================================================================
 // xdmf_spatial -- corresponds to one mrc_domain
 
-void
-xdmf_spatial_open(list_t *xdmf_spatial_list)
+void xdmf_spatial_open(list_t* xdmf_spatial_list)
 {
   INIT_LIST_HEAD(xdmf_spatial_list);
 }
 
-struct xdmf_spatial *
-xdmf_spatial_find(list_t *xdmf_spatial_list, const char *name)
+struct xdmf_spatial* xdmf_spatial_find(list_t* xdmf_spatial_list,
+                                       const char* name)
 {
-  struct xdmf_spatial *xs;
-  __list_for_each_entry(xs, xdmf_spatial_list, entry, struct xdmf_spatial) {
+  struct xdmf_spatial* xs;
+  __list_for_each_entry(xs, xdmf_spatial_list, entry, struct xdmf_spatial)
+  {
     if (strcmp(xs->name, name) == 0) {
       return xs;
     }
@@ -196,13 +231,13 @@ xdmf_spatial_find(list_t *xdmf_spatial_list, const char *name)
   return NULL;
 }
 
-struct xdmf_spatial *
-xdmf_spatial_create_f1(list_t *xdmf_spatial_list, const char *name, 
-		       struct mrc_domain *domain)
+struct xdmf_spatial* xdmf_spatial_create_f1(list_t* xdmf_spatial_list,
+                                            const char* name,
+                                            struct mrc_domain* domain)
 {
   // OPT, we could skip this on procs which aren't writing xdmf
 
-  struct xdmf_spatial *xs = calloc(1, sizeof(*xs));
+  struct xdmf_spatial* xs = calloc(1, sizeof(*xs));
   xs->name = strdup(name);
   xs->dim = 1;
   xs->nr_global_patches = 1; // FIXME wrong when parallel
@@ -217,13 +252,14 @@ xdmf_spatial_create_f1(list_t *xdmf_spatial_list, const char *name,
   return xs;
 }
 
-struct xdmf_spatial *
-xdmf_spatial_create_m3(list_t *xdmf_spatial_list, const char *name, 
-		       struct mrc_domain *domain, struct mrc_io *io, int sw)
+struct xdmf_spatial* xdmf_spatial_create_m3(list_t* xdmf_spatial_list,
+                                            const char* name,
+                                            struct mrc_domain* domain,
+                                            struct mrc_io* io, int sw)
 {
   // OPT, we could skip this on procs which aren't writing xdmf
 
-  struct xdmf_spatial *xs = calloc(1, sizeof(*xs));
+  struct xdmf_spatial* xs = calloc(1, sizeof(*xs));
   xs->name = strdup(name);
   xs->dim = 3;
   xs->sw = sw;
@@ -234,7 +270,7 @@ xdmf_spatial_create_m3(list_t *xdmf_spatial_list, const char *name,
     xs->dx[d] = calloc(xs->nr_global_patches, sizeof(*xs->dx[d]));
   }
 
-  struct mrc_crds *crds = mrc_domain_get_crds(domain);
+  struct mrc_crds* crds = mrc_domain_get_crds(domain);
   double xl[3];
   double dx[3];
   if (strcmp(mrc_crds_type(crds), "amr_uniform") == 0 ||
@@ -253,12 +289,12 @@ xdmf_spatial_create_m3(list_t *xdmf_spatial_list, const char *name,
     if (xs->uniform) {
       int level = xs->patch_infos[gp].level;
       for (int d = 0; d < 3; d++) {
-	float refine = 1.f;
-	if (xs->patch_infos[gp].ldims[d] > 1) {
-	  refine = 1.f / (1 << level);
-	}
-	xs->xl[d][gp] = xl[d] + xs->patch_infos[gp].off[d] * dx[d] * refine;
-	xs->dx[d][gp] = dx[d] * refine;
+        float refine = 1.f;
+        if (xs->patch_infos[gp].ldims[d] > 1) {
+          refine = 1.f / (1 << level);
+        }
+        xs->xl[d][gp] = xl[d] + xs->patch_infos[gp].off[d] * dx[d] * refine;
+        xs->dx[d][gp] = dx[d] * refine;
       }
     }
   }
@@ -267,14 +303,13 @@ xdmf_spatial_create_m3(list_t *xdmf_spatial_list, const char *name,
   return xs;
 }
 
-struct xdmf_spatial *
-xdmf_spatial_create_m3_parallel(list_t *xdmf_spatial_list, const char *name, 
-				struct mrc_domain *domain, int slab_off[3], 
-				int slab_dims[3], struct mrc_io *io)
+struct xdmf_spatial* xdmf_spatial_create_m3_parallel(
+  list_t* xdmf_spatial_list, const char* name, struct mrc_domain* domain,
+  int slab_off[3], int slab_dims[3], struct mrc_io* io)
 {
   // OPT, we could skip this on procs which aren't writing xdmf
 
-  struct xdmf_spatial *xs = calloc(1, sizeof(*xs));
+  struct xdmf_spatial* xs = calloc(1, sizeof(*xs));
   xs->name = strdup(name);
   xs->dim = 3;
   xs->nr_global_patches = 1;
@@ -286,11 +321,11 @@ xdmf_spatial_create_m3_parallel(list_t *xdmf_spatial_list, const char *name,
     xs->dx[d] = calloc(xs->nr_global_patches, sizeof(*xs->dx[d]));
   }
 
-  struct mrc_crds *crds = mrc_domain_get_crds(domain);
+  struct mrc_crds* crds = mrc_domain_get_crds(domain);
   if (strcmp(mrc_crds_type(crds), "amr_uniform") == 0 ||
       strcmp(mrc_crds_type(crds), "uniform") == 0) {
     xs->uniform = true;
-    const double *xl = mrc_crds_lo(crds);
+    const double* xl = mrc_crds_lo(crds);
     double dx[3];
     mrc_crds_get_dx(crds, 0, dx);
 
@@ -309,47 +344,41 @@ xdmf_spatial_create_m3_parallel(list_t *xdmf_spatial_list, const char *name,
   return xs;
 }
 
-void
-xdmf_spatial_save_fld_info(struct xdmf_spatial *xs, char *fld_name,
-			   char *path, bool is_vec, int mrc_dtype)
+void xdmf_spatial_save_fld_info(struct xdmf_spatial* xs, char* fld_name,
+                                char* path, bool is_vec, int mrc_dtype)
 {
   assert(xs->nr_fld_info < MAX_XDMF_FLD_INFO);
-  struct xdmf_fld_info *fld_info = &xs->fld_info[xs->nr_fld_info++];
+  struct xdmf_fld_info* fld_info = &xs->fld_info[xs->nr_fld_info++];
   fld_info->name = fld_name;
   fld_info->path = path;
   fld_info->is_vec = is_vec;
   switch (mrc_dtype) {
-  case MRC_NT_FLOAT: 
-  {
-    fld_info->dtype = strdup("Float");
-    fld_info->precision = 4;
-    break;
-  }
-  case MRC_NT_DOUBLE: 
-  {
-    fld_info->dtype = strdup("Float");
-    fld_info->precision = 8;
-    break;
-  }
-  case MRC_NT_INT: 
-  {
-    fld_info->dtype = strdup("Int");
-    fld_info->precision = 4;
-    break;
-  }
-  default: assert(0);
+    case MRC_NT_FLOAT: {
+      fld_info->dtype = strdup("Float");
+      fld_info->precision = 4;
+      break;
+    }
+    case MRC_NT_DOUBLE: {
+      fld_info->dtype = strdup("Float");
+      fld_info->precision = 8;
+      break;
+    }
+    case MRC_NT_INT: {
+      fld_info->dtype = strdup("Int");
+      fld_info->precision = 4;
+      break;
+    }
+    default: assert(0);
   }
 }
 
-
-void
-xdmf_spatial_write(struct xdmf_spatial *xs, const char *filename,
-		   struct mrc_io *io)
+void xdmf_spatial_write(struct xdmf_spatial* xs, const char* filename,
+                        struct mrc_io* io)
 {
   if (io->rank != 0)
     return;
 
-  FILE *f = fopen(filename, "w");
+  FILE* f = fopen(filename, "w");
   xdmf_write_header(f);
   fprintf(f, "<Domain>\n");
   if (xs->nr_global_patches > 1) {
@@ -357,41 +386,42 @@ xdmf_spatial_write(struct xdmf_spatial *xs, const char *filename,
     fprintf(f, "<Time Type=\"Single\" Value=\"%g\" />\n", io->time);
   }
   for (int s = 0; s < xs->nr_global_patches; s++) {
-    fprintf(f, "   <Grid Name=\"patch-%s-%d\" GridType=\"Uniform\">\n", xs->name, s);
+    fprintf(f, "   <Grid Name=\"patch-%s-%d\" GridType=\"Uniform\">\n",
+            xs->name, s);
     if (xs->nr_global_patches == 1) {
       fprintf(f, "<Time Type=\"Single\" Value=\"%g\" />\n", io->time);
     }
-    
+
     char fname[strlen(io->par.outdir) + strlen(io->par.basename) + 20];
     int rank = xs->patch_infos[s].rank;
     int patch = xs->patch_infos[s].patch;
     sprintf(fname, "%s.%06d_p%06d.h5", io->par.basename, io->step, rank);
-    int *ldims = xs->patch_infos[s].ldims;
+    int* ldims = xs->patch_infos[s].ldims;
     if (xs->dim == 1) {
       if (xs->uniform) {
-	assert(0);
+        assert(0);
       } else {
-	xdmf_write_topology_m1(f, ldims, fname, patch);
+        xdmf_write_topology_m1(f, ldims, fname, patch);
       }
     } else if (xs->dim == 3) {
       if (xs->uniform) {
-	float xl[3] = { xs->xl[0][s], xs->xl[1][s], xs->xl[2][s] };
-	float dx[3] = { xs->dx[0][s], xs->dx[1][s], xs->dx[2][s] };
-	xdmf_write_topology_uniform_m3(f, ldims, xl, dx, xs->sw);
+        float xl[3] = {xs->xl[0][s], xs->xl[1][s], xs->xl[2][s]};
+        float dx[3] = {xs->dx[0][s], xs->dx[1][s], xs->dx[2][s]};
+        xdmf_write_topology_uniform_m3(f, ldims, xl, dx, xs->sw);
       } else {
-	xdmf_write_topology_m3(f, ldims, fname, xs->crd_nc_path, patch);
+        xdmf_write_topology_m3(f, ldims, fname, xs->crd_nc_path, patch);
       }
     } else {
       assert(0);
     }
-    
+
     for (int m = 0; m < xs->nr_fld_info; m++) {
       if (xs->dim == 1) {
-	xdmf_write_fld_m1(f, &xs->fld_info[m], ldims, fname, patch);
+        xdmf_write_fld_m1(f, &xs->fld_info[m], ldims, fname, patch);
       } else if (xs->dim == 3) {
-	xdmf_write_fld_m3(f, &xs->fld_info[m], ldims, fname, patch);
+        xdmf_write_fld_m3(f, &xs->fld_info[m], ldims, fname, patch);
       } else {
-	assert(0);
+        assert(0);
       }
     }
     fprintf(f, "   </Grid>\n");
@@ -404,11 +434,10 @@ xdmf_spatial_write(struct xdmf_spatial *xs, const char *filename,
   fclose(f);
 }
 
-void
-xdmf_spatial_destroy(struct xdmf_spatial *xs)
+void xdmf_spatial_destroy(struct xdmf_spatial* xs)
 {
   for (int m = 0; m < xs->nr_fld_info; m++) {
-    struct xdmf_fld_info *fld_info = &xs->fld_info[m];
+    struct xdmf_fld_info* fld_info = &xs->fld_info[m];
     free(fld_info->name);
     free(fld_info->path);
     free(fld_info->dtype);
@@ -423,15 +452,16 @@ xdmf_spatial_destroy(struct xdmf_spatial *xs)
   free(xs);
 }
 
-void
-xdmf_spatial_close(list_t *xdmf_spatial_list, struct mrc_io *io,
-		   struct xdmf_temporal *xt)
+void xdmf_spatial_close(list_t* xdmf_spatial_list, struct mrc_io* io,
+                        struct xdmf_temporal* xt)
 {
   while (!list_empty(xdmf_spatial_list)) {
-    struct xdmf_spatial *xs = list_entry(xdmf_spatial_list->next, struct xdmf_spatial, entry);
-    
+    struct xdmf_spatial* xs =
+      list_entry(xdmf_spatial_list->next, struct xdmf_spatial, entry);
+
     char fname_spatial[strlen(io->par.outdir) + strlen(io->par.basename) + 20];
-    sprintf(fname_spatial, "%s/%s.%06d.xdmf", io->par.outdir, io->par.basename, io->step);
+    sprintf(fname_spatial, "%s/%s.%06d.xdmf", io->par.outdir, io->par.basename,
+            io->step);
     xdmf_spatial_write(xs, fname_spatial, io);
     xdmf_spatial_destroy(xs);
 
@@ -442,4 +472,3 @@ xdmf_spatial_close(list_t *xdmf_spatial_list, struct mrc_io *io,
     }
   }
 }
-

--- a/src/libmrc/src/mrc_io_xdmf_lib.c
+++ b/src/libmrc/src/mrc_io_xdmf_lib.c
@@ -392,7 +392,7 @@ void xdmf_spatial_write(struct xdmf_spatial* xs, const char* filename,
       fprintf(f, "<Time Type=\"Single\" Value=\"%g\" />\n", io->time);
     }
 
-    char fname[strlen(io->par.outdir) + strlen(io->par.basename) + 20];
+    char fname[strlen(io->par.outdir) + strlen(io->par.basename) + 30];
     int rank = xs->patch_infos[s].rank;
     int patch = xs->patch_infos[s].patch;
     sprintf(fname, "%s.%06d_p%06d.h5", io->par.basename, io->step, rank);

--- a/src/libmrc/src/mrc_io_xdmf_lib.h
+++ b/src/libmrc/src/mrc_io_xdmf_lib.h
@@ -11,27 +11,29 @@ BEGIN_C_DECLS
 
 #define MAX_XDMF_FLD_INFO (100)
 
-struct xdmf_fld_info {
-  char *name;
-  char *path;
+struct xdmf_fld_info
+{
+  char* name;
+  char* path;
   bool is_vec;
-  char *dtype;
+  char* dtype;
   int precision;
 };
 
-struct xdmf_spatial {
-  char *name; //< from domain::name
+struct xdmf_spatial
+{
+  char* name; //< from domain::name
 
   bool crds_done;
   int dim;
   bool uniform; //< uniform coords
 
   int nr_global_patches;
-  struct mrc_patch_info *patch_infos;
-  float *xl[3];
-  float *dx[3];
+  struct mrc_patch_info* patch_infos;
+  float* xl[3];
+  float* dx[3];
   int sw;
-  const char *crd_nc_path[3];
+  const char* crd_nc_path[3];
 
   int nr_fld_info;
   struct xdmf_fld_info fld_info[MAX_XDMF_FLD_INFO];
@@ -39,41 +41,40 @@ struct xdmf_spatial {
   list_t entry; //< on xdmf_file::xdmf_spatial_list
 };
 
-struct xdmf_temporal_step {
+struct xdmf_temporal_step
+{
   list_t entry;
   char filename[0];
 };
 
-struct xdmf_temporal {
-  char *filename;
+struct xdmf_temporal
+{
+  char* filename;
   list_t timesteps;
 };
 
-struct xdmf_temporal *xdmf_temporal_create(const char *filename);
-void xdmf_temporal_destroy(struct xdmf_temporal *xt);
-void xdmf_temporal_append(struct xdmf_temporal *xt,
-			  const char *fname_spatial);
-void xdmf_temporal_write(struct xdmf_temporal *xt);
+struct xdmf_temporal* xdmf_temporal_create(const char* filename);
+void xdmf_temporal_destroy(struct xdmf_temporal* xt);
+void xdmf_temporal_append(struct xdmf_temporal* xt, const char* fname_spatial);
+void xdmf_temporal_write(struct xdmf_temporal* xt);
 
-void xdmf_spatial_open(list_t *xdmf_spatial_list);
-void xdmf_spatial_close(list_t *xdmf_spatial_list, struct mrc_io *io,
-			struct xdmf_temporal *xt);
-struct xdmf_spatial *xdmf_spatial_find(list_t *xdmf_spatial_list,
-				       const char *name);
-struct xdmf_spatial *xdmf_spatial_create_f1(list_t *xdmf_spatial_list,
-					    const char *name, 
-					    struct mrc_domain *domain);
-struct xdmf_spatial *xdmf_spatial_create_m3(list_t *xdmf_spatial_list,
-					    const char *name, 
-					    struct mrc_domain *domain,
-					    struct mrc_io *io, int sw);
-struct xdmf_spatial *xdmf_spatial_create_m3_parallel(list_t *xdmf_spatial_list,
-						     const char *name, 
-						     struct mrc_domain *domain,
-						     int slab_off[3], int slab_dims[3],
-						     struct mrc_io *io);
-void xdmf_spatial_save_fld_info(struct xdmf_spatial *xs, char *fld_name,
-				char *path, bool is_vec, int mrc_dtype);
+void xdmf_spatial_open(list_t* xdmf_spatial_list);
+void xdmf_spatial_close(list_t* xdmf_spatial_list, struct mrc_io* io,
+                        struct xdmf_temporal* xt);
+struct xdmf_spatial* xdmf_spatial_find(list_t* xdmf_spatial_list,
+                                       const char* name);
+struct xdmf_spatial* xdmf_spatial_create_f1(list_t* xdmf_spatial_list,
+                                            const char* name,
+                                            struct mrc_domain* domain);
+struct xdmf_spatial* xdmf_spatial_create_m3(list_t* xdmf_spatial_list,
+                                            const char* name,
+                                            struct mrc_domain* domain,
+                                            struct mrc_io* io, int sw);
+struct xdmf_spatial* xdmf_spatial_create_m3_parallel(
+  list_t* xdmf_spatial_list, const char* name, struct mrc_domain* domain,
+  int slab_off[3], int slab_dims[3], struct mrc_io* io);
+void xdmf_spatial_save_fld_info(struct xdmf_spatial* xs, char* fld_name,
+                                char* path, bool is_vec, int mrc_dtype);
 
 END_C_DECLS
 


### PR DESCRIPTION
If the time step doesn't fit into 6 digits, the string will be longer than anticipated -- this is not great,
but these changes at least avoid a buffer overflow
in the filename string.