### PR TITLE
make curr_cache_t more gtensor friendly

### DIFF
--- a/src/libpsc/cuda/cuda_currmem.cuh
+++ b/src/libpsc/cuda/cuda_currmem.cuh
@@ -143,10 +143,10 @@ public:
     atomicAdd(addr, val);
   }
 
-  __device__ void add(int m, int jx, int jy, int jz, float val, const int* ci0)
+  __device__ void add(int m, int jx, int jy, int jz, float val)
   {
     auto _d_flds = make_Fields3d<dim_xyz>(gt_, ib_);
-    float* addr = &_d_flds(JXI + m, jx + ci0[0], jy + ci0[1], jz + ci0[2]);
+    float* addr = &_d_flds(JXI + m, jx, jy, jz);
     atomicAdd(addr, val);
   }
 };

--- a/src/libpsc/psc_push_particles/inc_curr.c
+++ b/src/libpsc/psc_push_particles/inc_curr.c
@@ -11,36 +11,40 @@ struct CurrentNone;
 // ----------------------------------------------------------------------
 
 template <typename Curr, typename real_t = typename Curr::real_t>
-GT_INLINE void deposit(Curr& curr, const int i[3], const real_t fnq[3],
+GT_INLINE void deposit(Curr& curr, const int _i[3], const real_t fnq[3],
                        const real_t dx[3], const real_t xa[3], real_t h,
                        const int off[3])
 {
+  int i[3];
+  for (int d = 0; d < 3; d++) {
+    i[d] = _i[d] + off[d];
+  }
   curr.add(0, i[0], i[1], i[2],
-           fnq[0] * (dx[0] * (1.f - xa[1]) * (1.f - xa[2]) + h), off);
+           fnq[0] * (dx[0] * (1.f - xa[1]) * (1.f - xa[2]) + h));
   curr.add(0, i[0], i[1] + 1, i[2],
-           fnq[0] * (dx[0] * (xa[1]) * (1.f - xa[2]) - h), off);
+           fnq[0] * (dx[0] * (xa[1]) * (1.f - xa[2]) - h));
   curr.add(0, i[0], i[1], i[2] + 1,
-           fnq[0] * (dx[0] * (1.f - xa[1]) * (xa[2]) - h), off);
+           fnq[0] * (dx[0] * (1.f - xa[1]) * (xa[2]) - h));
   curr.add(0, i[0], i[1] + 1, i[2] + 1,
-           fnq[0] * (dx[0] * (xa[1]) * (xa[2]) + h), off);
+           fnq[0] * (dx[0] * (xa[1]) * (xa[2]) + h));
 
   curr.add(1, i[0], i[1], i[2],
-           fnq[1] * (dx[1] * (1.f - xa[0]) * (1.f - xa[2]) + h), off);
+           fnq[1] * (dx[1] * (1.f - xa[0]) * (1.f - xa[2]) + h));
   curr.add(1, i[0] + 1, i[1], i[2],
-           fnq[1] * (dx[1] * (xa[0]) * (1.f - xa[2]) - h), off);
+           fnq[1] * (dx[1] * (xa[0]) * (1.f - xa[2]) - h));
   curr.add(1, i[0], i[1], i[2] + 1,
-           fnq[1] * (dx[1] * (1.f - xa[0]) * (xa[2]) - h), off);
+           fnq[1] * (dx[1] * (1.f - xa[0]) * (xa[2]) - h));
   curr.add(1, i[0] + 1, i[1], i[2] + 1,
-           fnq[1] * (dx[1] * (xa[0]) * (xa[2]) + h), off);
+           fnq[1] * (dx[1] * (xa[0]) * (xa[2]) + h));
 
   curr.add(2, i[0], i[1], i[2],
-           fnq[2] * (dx[2] * (1.f - xa[0]) * (1.f - xa[1]) + h), off);
+           fnq[2] * (dx[2] * (1.f - xa[0]) * (1.f - xa[1]) + h));
   curr.add(2, i[0] + 1, i[1], i[2],
-           fnq[2] * (dx[2] * (xa[0]) * (1.f - xa[1]) - h), off);
+           fnq[2] * (dx[2] * (xa[0]) * (1.f - xa[1]) - h));
   curr.add(2, i[0], i[1] + 1, i[2],
-           fnq[2] * (dx[2] * (1.f - xa[0]) * (xa[1]) - h), off);
+           fnq[2] * (dx[2] * (1.f - xa[0]) * (xa[1]) - h));
   curr.add(2, i[0] + 1, i[1] + 1, i[2],
-           fnq[2] * (dx[2] * (xa[0]) * (xa[1]) + h), off);
+           fnq[2] * (dx[2] * (xa[0]) * (xa[1]) + h));
 }
 
 #include "inc_curr_1vb_split.c"

--- a/src/libpsc/psc_push_particles/push_config.hxx
+++ b/src/libpsc/psc_push_particles/push_config.hxx
@@ -15,16 +15,18 @@
 #include <psc/gtensor.h>
 
 template <typename fields_t>
-struct curr_cache_t : fields_t
+class curr_cache_t
 {
+public:
   using real_t = typename fields_t::value_type;
+  using value_type = typename fields_t::value_type;
+  using storage_type = typename fields_t::Storage;
 
-  curr_cache_t(fields_t& f) : fields_t(f.ib(), f.storage()) {}
+  curr_cache_t(fields_t& f) : storage_(f.storage()), ib_(f.ib()) {}
 
   void add(int m, int i, int j, int k, real_t val)
   {
-    this->storage()(i - this->ib()[0], j - this->ib()[1], k - this->ib()[2],
-                    JXI + m) += val;
+    storage_(i - ib_[0], j - ib_[1], k - ib_[2], JXI + m) += val;
   }
 
   GT_INLINE void add(int m, int i, int j, int k, real_t val, const int off[3])
@@ -32,6 +34,10 @@ struct curr_cache_t : fields_t
     assert(off[0] == 0 && off[1] == 0 && off[2] == 0);
     add(m, i, j, k, val);
   }
+
+private:
+  storage_type storage_;
+  Int3 ib_;
 };
 
 template <typename _Mparticles, typename _MfieldsState,

--- a/src/libpsc/psc_push_particles/push_config.hxx
+++ b/src/libpsc/psc_push_particles/push_config.hxx
@@ -23,9 +23,8 @@ struct curr_cache_t : fields_t
 
   void add(int m, int i, int j, int k, real_t val)
   {
-    Fields3d<typename fields_t::Storage, dim_curr> J(this->storage(),
-                                                     this->ib());
-    J(JXI + m, i, j, k) += val;
+    this->storage()(i - this->ib()[0], j - this->ib()[1], k - this->ib()[2],
+                    JXI + m) += val;
   }
 
   GT_INLINE void add(int m, int i, int j, int k, real_t val, const int off[3])

--- a/src/libpsc/psc_push_particles/push_config.hxx
+++ b/src/libpsc/psc_push_particles/push_config.hxx
@@ -14,7 +14,7 @@
 
 #include <psc/gtensor.h>
 
-template <typename fields_t, typename dim_curr>
+template <typename fields_t>
 struct curr_cache_t : fields_t
 {
   using real_t = typename fields_t::value_type;
@@ -51,8 +51,7 @@ struct PushpConfigEsirkepov
 
 template <typename _Mparticles, typename _MfieldsState, typename _InterpolateEM,
           typename _Dim, typename _Order,
-          template <typename, typename, typename> class _Current,
-          typename dim_curr = dim_xyz>
+          template <typename, typename, typename> class _Current>
 struct PushpConfigVb
 {
   using Mparticles = _Mparticles;
@@ -60,8 +59,7 @@ struct PushpConfigVb
   using Dim = _Dim;
   using InterpolateEM_t = _InterpolateEM;
   using Current_t =
-    _Current<_Order, _Dim,
-             curr_cache_t<typename _MfieldsState::fields_view_t, dim_curr>>;
+    _Current<_Order, _Dim, curr_cache_t<typename _MfieldsState::fields_view_t>>;
   using AdvanceParticle_t = AdvanceParticle<typename Mparticles::real_t, Dim>;
 };
 
@@ -107,9 +105,9 @@ using Config1vbecSingleXZ = PushpConfigVb<
   MparticlesSingle, MfieldsStateSingle,
   InterpolateEM1vbec<
     Fields3d<MfieldsStateSingle::fields_view_t::Storage, dim_xz>, dim_xyz>,
-  dim_xyz, opt_order_1st, Current1vbSplit, dim_xz>;
+  dim_xyz, opt_order_1st, Current1vbSplit>;
 using Config1vbecSingle1 = PushpConfigVb<
   MparticlesSingle, MfieldsStateSingle,
   InterpolateEM1vbec<
     Fields3d<MfieldsStateSingle::fields_view_t::Storage, dim_1>, dim_1>,
-  dim_1, opt_order_1st, Current1vbVar1, dim_1>;
+  dim_1, opt_order_1st, Current1vbVar1>;

--- a/src/libpsc/psc_push_particles/push_config.hxx
+++ b/src/libpsc/psc_push_particles/push_config.hxx
@@ -29,12 +29,6 @@ public:
     storage_(i - ib_[0], j - ib_[1], k - ib_[2], JXI + m) += val;
   }
 
-  GT_INLINE void add(int m, int i, int j, int k, real_t val, const int off[3])
-  {
-    assert(off[0] == 0 && off[1] == 0 && off[2] == 0);
-    add(m, i, j, k, val);
-  }
-
 private:
   storage_type storage_;
   Int3 ib_;

--- a/src/libpsc/tests/test_deposit.cxx
+++ b/src/libpsc/tests/test_deposit.cxx
@@ -225,7 +225,7 @@ public:
   using real_t = R;
   using dim_t = D;
   using fields_view_t = SArrayView<real_t, gt::space::host>;
-  using fields_t = curr_cache_t<fields_view_t, dim_xyz>;
+  using fields_t = curr_cache_t<fields_view_t>;
   using Current = C<opt_order_1st, dim_t, fields_t>;
 };
 


### PR DESCRIPTION
It's still handling the `ib` shift, but it's doing itself now, and uses gtensor-like storage.