### PR TITLE
ci: update clang-format to version 14

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -11,8 +11,9 @@ AlignTrailingComments: true
 AllowAllParametersOfDeclarationOnNextLine: false
 AllowShortBlocksOnASingleLine: false
 AllowShortCaseLabelsOnASingleLine: true
-AllowShortFunctionsOnASingleLine: Inline
+AllowShortFunctionsOnASingleLine: All
 AllowShortIfStatementsOnASingleLine: false
+AllowShortLambdasOnASingleLine: All
 AllowShortLoopsOnASingleLine: false
 AlwaysBreakAfterDefinitionReturnType: None
 AlwaysBreakAfterReturnType: None
@@ -29,7 +30,7 @@ BraceWrapping:
   AfterObjCDeclaration: false
   AfterStruct:     true
   AfterUnion:      true
-  AfterExternBlock: true
+  AfterExternBlock: false
   BeforeCatch:     false
   BeforeElse:      false
   IndentBraces:    false

--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -9,9 +9,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: germasch/clang-format-lint-action@master
+      - uses: DoozyX/clang-format-lint-action@master
         with:
           source: 'src'
           extensions: 'h,c,hxx,cxx,hpp,cpp,cuh,cu'
-          clangFormatVersion: 9
+          clangFormatVersion: 14
           inplace: False

--- a/src/include/psc.hxx
+++ b/src/include/psc.hxx
@@ -69,8 +69,9 @@ struct mem_fraction
 };
 
 template <typename Mparticles>
-struct mem_fraction<Mparticles, gt::meta::void_t<decltype(
-                                  std::declval<Mparticles>().mem_fraction())>>
+struct mem_fraction<
+  Mparticles,
+  gt::meta::void_t<decltype(std::declval<Mparticles>().mem_fraction())>>
 {
   static double get(const Mparticles& mprts)
   {

--- a/src/kg/testing/io/TestIOAdios2.cxx
+++ b/src/kg/testing/io/TestIOAdios2.cxx
@@ -3,10 +3,7 @@
 
 #include <gtest/gtest.h>
 
-TEST(IOAdios2, CtorDtor)
-{
-  auto io = kg::io::IOAdios2{};
-}
+TEST(IOAdios2, CtorDtor) { auto io = kg::io::IOAdios2{}; }
 
 TEST(IOAdios2, OpenWrite)
 {

--- a/src/libpsc/cell_be/spu/spu_2d_main.c
+++ b/src/libpsc/cell_be/spu/spu_2d_main.c
@@ -20,10 +20,7 @@ psc_cell_block_t psc_block;
 
 // Error handler. Want these passed out the
 // PPE to handle.
-static void spu_error(void)
-{
-  spu_write_out_mbox(SPU_ERROR);
-}
+static void spu_error(void) { spu_write_out_mbox(SPU_ERROR); }
 
 static int spu_run_job(unsigned long long ea)
 {

--- a/src/libpsc/cell_be/spu/spu_dma.c
+++ b/src/libpsc/cell_be/spu/spu_dma.c
@@ -193,10 +193,7 @@ void end_wait_particles_stored(void)
   put_tagid(tag_preload);
 }
 
-void wait_for_preload(void)
-{
-  wait_tagid(tag_preload);
-}
+void wait_for_preload(void) { wait_tagid(tag_preload); }
 
 // I'm not quite sure how to integrate these functions,
 // of if they even need to be seperate functions.

--- a/src/libpsc/cell_be/spu/spu_mfcio_c.c
+++ b/src/libpsc/cell_be/spu/spu_mfcio_c.c
@@ -12,10 +12,7 @@
 static int tagmask;
 static int __mask;
 
-void mfc_write_tag_mask(unsigned int mask)
-{
-  __mask = mask;
-}
+void mfc_write_tag_mask(unsigned int mask) { __mask = mask; }
 
 unsigned int mfc_read_tag_status_any()
 {

--- a/src/libpsc/cell_be/spu/spu_test_main.c
+++ b/src/libpsc/cell_be/spu/spu_test_main.c
@@ -18,10 +18,7 @@ psc_cell_block_t psc_block;
 
 // Error handler. Want these passed out the
 // PPE to handle.
-static void spu_error(void)
-{
-  spu_write_out_mbox(SPU_ERROR);
-}
+static void spu_error(void) { spu_write_out_mbox(SPU_ERROR); }
 
 static int spu_run_job(unsigned long long ea)
 {

--- a/src/libpsc/cuda/cuda_base.cu
+++ b/src/libpsc/cuda/cuda_base.cu
@@ -140,11 +140,11 @@ void cuda_base_init(void)
       "  Compute mode:                                  %s\n",
       deviceProp.computeMode == cudaComputeModeDefault
         ? "Default (multiple host threads can use this device simultaneously)"
-        : deviceProp.computeMode == cudaComputeModeExclusive
-            ? "Exclusive (only one host thread at a time can use this device)"
-            : deviceProp.computeMode == cudaComputeModeProhibited
-                ? "Prohibited (no host thread can use this device)"
-                : "Unknown");
+      : deviceProp.computeMode == cudaComputeModeExclusive
+        ? "Exclusive (only one host thread at a time can use this device)"
+      : deviceProp.computeMode == cudaComputeModeProhibited
+        ? "Prohibited (no host thread can use this device)"
+        : "Unknown");
 #endif
   }
 }

--- a/src/libpsc/cuda/cuda_base.cxx
+++ b/src/libpsc/cuda/cuda_base.cxx
@@ -140,11 +140,11 @@ void cuda_base_init(void)
       "  Compute mode:                                  %s\n",
       deviceProp.computeMode == hipComputeModeDefault
         ? "Default (multiple host threads can use this device simultaneously)"
-        : deviceProp.computeMode == hipComputeModeExclusive
-            ? "Exclusive (only one host thread at a time can use this device)"
-            : deviceProp.computeMode == hipComputeModeProhibited
-                ? "Prohibited (no host thread can use this device)"
-                : "Unknown");
+      : deviceProp.computeMode == hipComputeModeExclusive
+        ? "Exclusive (only one host thread at a time can use this device)"
+      : deviceProp.computeMode == hipComputeModeProhibited
+        ? "Prohibited (no host thread can use this device)"
+        : "Unknown");
 #endif
   }
 }

--- a/src/libpsc/cuda/tests/test_cuda_base.cu
+++ b/src/libpsc/cuda/tests/test_cuda_base.cu
@@ -6,7 +6,4 @@
 // ======================================================================
 // test cuda_base_init
 
-TEST(CudaBase, Init)
-{
-  cuda_base_init();
-}
+TEST(CudaBase, Init) { cuda_base_init(); }

--- a/src/libpsc/psc_balance/psc_balance_impl.hxx
+++ b/src/libpsc/psc_balance/psc_balance_impl.hxx
@@ -21,10 +21,7 @@
 
 extern double* psc_balance_comp_time_by_patch;
 
-static double capability_default(int p)
-{
-  return 1.;
-}
+static double capability_default(int p) { return 1.; }
 
 // ======================================================================
 

--- a/src/libpsc/psc_bnd_particles/psc_bnd_particles_open.cxx
+++ b/src/libpsc/psc_bnd_particles/psc_bnd_particles_open.cxx
@@ -8,10 +8,7 @@ static const int debug_every_step = 10;
 static inline bool at_lo_boundary(int p, int d);
 static inline bool at_hi_boundary(int p, int d);
 
-static inline double random1()
-{
-  return random() / (double)RAND_MAX;
-}
+static inline double random1() { return random() / (double)RAND_MAX; }
 
 static void copy_to_mrc_fld(struct mrc_fld* m3, struct psc_mfields* mflds)
 {

--- a/src/libpsc/rngpool.cxx
+++ b/src/libpsc/rngpool.cxx
@@ -11,25 +11,13 @@ using RngPool = PscRngPool<Rng>;
 // ----------------------------------------------------------------------
 // RngPool
 
-RngPool* RngPool_create()
-{
-  return new RngPool;
-}
+RngPool* RngPool_create() { return new RngPool; }
 
-void RngPool_delete(RngPool* rngpool)
-{
-  delete rngpool;
-}
+void RngPool_delete(RngPool* rngpool) { delete rngpool; }
 
-void RngPool_seed(RngPool* rngpool, int base)
-{
-  rngpool->seed(base, 0);
-}
+void RngPool_seed(RngPool* rngpool, int base) { rngpool->seed(base, 0); }
 
-Rng* RngPool_get(RngPool* rngpool, int n)
-{
-  return (*rngpool)[n];
-}
+Rng* RngPool_get(RngPool* rngpool, int n) { return (*rngpool)[n]; }
 
 // ----------------------------------------------------------------------
 // Rng

--- a/src/libpsc/sse2/psc_fields_sse2.c
+++ b/src/libpsc/sse2/psc_fields_sse2.c
@@ -13,10 +13,7 @@ void fields_sse2_alloc(fields_sse2_t* pf)
   pf->flds = calloc(NR_FIELDS * psc.fld_size, sizeof(*pf->flds));
 }
 
-void fields_sse2_free(fields_sse2_t* pf)
-{
-  free(pf->flds);
-}
+void fields_sse2_free(fields_sse2_t* pf) { free(pf->flds); }
 
 void psc_mfields_sse2_get_from(fields_sse2_t* pf, int mb, int me)
 {

--- a/src/libpsc/sse2/push_part_ps_1vb_yz.c
+++ b/src/libpsc/sse2/push_part_ps_1vb_yz.c
@@ -24,10 +24,7 @@ static void fields_ip_alloc(fields_ip_t* pf, int ib[3], int ie[3], int nr_comp,
   pf->flds = calloc(nr_comp * size, sizeof(*pf->flds));
 }
 
-static void fields_ip_free(fields_ip_t* pf)
-{
-  free(pf->flds);
-}
+static void fields_ip_free(fields_ip_t* pf) { free(pf->flds); }
 
 #if SIMD_BITS == 0
 

--- a/src/libpsc/sse2/simd_0.h
+++ b/src/libpsc/sse2/simd_0.h
@@ -11,70 +11,34 @@ static const v4s vOne = 1.f;
 static const v4s vTwo = 2.f;
 static const v4si iZero = 0;
 static const v4s v4s_signmask = -0.f;
-static inline v4s v4s_splat(float x)
-{
-  return x;
-}
+static inline v4s v4s_splat(float x) { return x; }
 
-static inline v4si v4si_splat(int x)
-{
-  return x;
-}
+static inline v4si v4si_splat(int x) { return x; }
 
-static inline v4s v4s_load(float* p)
-{
-  return *p;
-}
+static inline v4s v4s_load(float* p) { return *p; }
 
-static inline void v4s_store(float* p, v4s v)
-{
-  *p = v;
-}
+static inline void v4s_store(float* p, v4s v) { *p = v; }
 
-static inline v4si v4si_load(int* p)
-{
-  return *p;
-}
+static inline v4si v4si_load(int* p) { return *p; }
 
-static inline void v4si_store(int* p, v4si v)
-{
-  *p = v;
-}
+static inline void v4si_store(int* p, v4si v) { *p = v; }
 
 static inline void v4s_prefetch(float* p)
 {
   _mm_prefetch((const char*)p, _MM_HINT_T0);
 }
 
-static inline v4s v4s_insert(v4s v, float s, int m)
-{
-  return s;
-}
+static inline v4s v4s_insert(v4s v, float s, int m) { return s; }
 
-static inline v4si v4si_insert(v4si v, int s, int m)
-{
-  return s;
-}
+static inline v4si v4si_insert(v4si v, int s, int m) { return s; }
 
-static inline float v4s_extract(v4s v, int m)
-{
-  return v;
-}
+static inline float v4s_extract(v4s v, int m) { return v; }
 
-static inline int v4si_extract(v4si v, int m)
-{
-  return v;
-}
+static inline int v4si_extract(v4si v, int m) { return v; }
 
-static inline v4s v4s_sqrt(v4s v)
-{
-  return sqrtf(v);
-}
+static inline v4s v4s_sqrt(v4s v) { return sqrtf(v); }
 
-static inline v4s v4s_rsqrt(v4s v)
-{
-  return 1.f / sqrtf(v);
-}
+static inline v4s v4s_rsqrt(v4s v) { return 1.f / sqrtf(v); }
 
 static inline v4s v4s_recip(v4s v)
 {
@@ -87,105 +51,48 @@ static inline v4s v4s_recip(v4s v)
 #endif
 }
 
-static inline v4si v4s_fint(v4s v)
-{
-  return (int)(v + 10.f) - 10;
-}
+static inline v4si v4s_fint(v4s v) { return (int)(v + 10.f) - 10; }
 
-static inline v4s v4si_to_v4s(v4si v)
-{
-  return (v4s)v;
-}
+static inline v4s v4si_to_v4s(v4si v) { return (v4s)v; }
 
-static inline v4si v4s_cmpge(v4s a, v4s b)
-{
-  return (a >= b) ? -1 : 0;
-}
+static inline v4si v4s_cmpge(v4s a, v4s b) { return (a >= b) ? -1 : 0; }
 
-static inline v4si v4s_cmpeq(v4s a, v4s b)
-{
-  return (a == b) ? -1 : 0;
-}
+static inline v4si v4s_cmpeq(v4s a, v4s b) { return (a == b) ? -1 : 0; }
 
-static inline v4si v4si_cmpeq(v4si a, v4si b)
-{
-  return (a == b) ? -1 : 0;
-}
+static inline v4si v4si_cmpeq(v4si a, v4si b) { return (a == b) ? -1 : 0; }
 
-static inline v4si v4si_cmplt(v4si a, v4si b)
-{
-  return (a < b) ? -1 : 0;
-}
+static inline v4si v4si_cmplt(v4si a, v4si b) { return (a < b) ? -1 : 0; }
 
-static inline v4si v4si_cmpge(v4si a, v4si b)
-{
-  return (a >= b) ? -1 : 0;
-}
+static inline v4si v4si_cmpge(v4si a, v4si b) { return (a >= b) ? -1 : 0; }
 
-static inline v4s v4s_blend(v4si mask, v4s a, v4s b)
-{
-  return mask ? a : b;
-}
+static inline v4s v4s_blend(v4si mask, v4s a, v4s b) { return mask ? a : b; }
 
 static inline v4si v4si_blend(v4si mask, v4si a, v4si b)
 {
   return mask ? a : b;
 }
 
-static inline v4si v4si_and(v4si a, v4si b)
-{
-  return a & b;
-}
+static inline v4si v4si_and(v4si a, v4si b) { return a & b; }
 
-static inline v4si v4si_or(v4si a, v4si b)
-{
-  return a | b;
-}
+static inline v4si v4si_or(v4si a, v4si b) { return a | b; }
 
-static inline v4si v4si_andnot(v4si a, v4si b)
-{
-  return ~a & b;
-}
+static inline v4si v4si_andnot(v4si a, v4si b) { return ~a & b; }
 
-static inline v4si v4si_add(v4si a, v4si b)
-{
-  return a + b;
-}
+static inline v4si v4si_add(v4si a, v4si b) { return a + b; }
 
-static inline v4si v4si_sub(v4si a, v4si b)
-{
-  return a - b;
-}
+static inline v4si v4si_sub(v4si a, v4si b) { return a - b; }
 
-static inline v4si v4si_mul(v4si a, v4si b)
-{
-  return a * b;
-}
+static inline v4si v4si_mul(v4si a, v4si b) { return a * b; }
 
-static inline v4si v4si_abs(v4si a)
-{
-  return a < 0 ? -a : a;
-}
+static inline v4si v4si_abs(v4si a) { return a < 0 ? -a : a; }
 
-static inline v4s v4s_floor(v4s a)
-{
-  return floorf(a);
-}
+static inline v4s v4s_floor(v4s a) { return floorf(a); }
 
-static inline v4si v4s_to_v4si(v4s a)
-{
-  return a;
-}
+static inline v4si v4s_to_v4si(v4s a) { return a; }
 
-static inline v4s v4s_gather(real* __restrict pp, v4si off)
-{
-  return pp[off];
-}
+static inline v4s v4s_gather(real* __restrict pp, v4si off) { return pp[off]; }
 
-static inline v4si v4si_sll(v4si a, int count)
-{
-  return a << count;
-}
+static inline v4si v4si_sll(v4si a, int count) { return a << count; }
 
 static inline v4si v4si_cast(v4s s)
 {
@@ -219,7 +126,4 @@ static inline v4s v4s_and(v4s a, v4s b)
   return v4s_cast(v4si_cast(a) & v4si_cast(b));
 }
 
-static inline v4s v4s_abs(v4s a)
-{
-  return fabsf(a);
-}
+static inline v4s v4s_abs(v4s a) { return fabsf(a); }

--- a/src/libpsc/sse2/simd_2.h
+++ b/src/libpsc/sse2/simd_2.h
@@ -45,10 +45,7 @@ static inline v4si v4si_insert(v4si v, int s, int m)
   return rv;
 }
 
-static inline int v4si_extract(v4si v, int m)
-{
-  return v.v[m];
-}
+static inline int v4si_extract(v4si v, int m) { return v.v[m]; }
 
 static inline v4si v4s_fint(v4s v)
 {
@@ -277,10 +274,7 @@ static inline v4si v4s_fint(v4s v)
                              (__m128i)v4si_splat(10));
 }
 
-static inline v4s v4si_to_v4s(v4si v)
-{
-  return _mm_cvtepi32_ps((__m128i)v);
-}
+static inline v4s v4si_to_v4s(v4si v) { return _mm_cvtepi32_ps((__m128i)v); }
 
 static inline v4si v4s_cmpge(v4s a, v4s b)
 {
@@ -342,10 +336,7 @@ static inline v4si v4si_mul(v4si a, v4si b)
   return (v4si)_mm_mullo_epi32((__m128i)a, (__m128i)b);
 }
 
-static inline v4si v4si_abs(v4si a)
-{
-  return (v4si)_mm_abs_epi32((__m128i)a);
-}
+static inline v4si v4si_abs(v4si a) { return (v4si)_mm_abs_epi32((__m128i)a); }
 
 static inline v4si v4si_sll(v4si a, int count)
 {
@@ -371,15 +362,9 @@ static inline v4s v4s_gather(real* __restrict pp, v4si _off)
   return (v4s)res;
 }
 
-static inline v4s v4s_cast(v4si a)
-{
-  return (v4s)(__m128)(__m128i)a;
-}
+static inline v4s v4s_cast(v4si a) { return (v4s)(__m128)(__m128i)a; }
 
-static inline v4si v4si_cast(v4s a)
-{
-  return (v4si)(__m128i)(__m128)a;
-}
+static inline v4si v4si_cast(v4s a) { return (v4si)(__m128i)(__m128)a; }
 
 #endif
 
@@ -396,25 +381,16 @@ static inline v4s v4s_splat(float x)
   return rv;
 }
 
-static inline v4s v4s_load(float* p)
-{
-  return (v4s)_mm_load_ps(p);
-}
+static inline v4s v4s_load(float* p) { return (v4s)_mm_load_ps(p); }
 
 static inline void v4s_prefetch(float* p)
 {
   _mm_prefetch((const char*)p, _MM_HINT_T0);
 }
 
-static inline void v4s_store(float* p, v4s v)
-{
-  _mm_store_ps(p, (__m128)v);
-}
+static inline void v4s_store(float* p, v4s v) { _mm_store_ps(p, (__m128)v); }
 
-static inline void v4s_stream(float* p, v4s v)
-{
-  _mm_stream_ps(p, (__m128)v);
-}
+static inline void v4s_stream(float* p, v4s v) { _mm_stream_ps(p, (__m128)v); }
 
 static inline v4s v4s_insert(v4s v, float s, int m)
 {
@@ -434,10 +410,7 @@ static inline float v4s_extract(v4s v, int m)
   return rv;
 }
 
-static inline v4s v4s_sqrt(v4s v)
-{
-  return _mm_sqrt_ps(v);
-}
+static inline v4s v4s_sqrt(v4s v) { return _mm_sqrt_ps(v); }
 
 static inline v4s v4s_rsqrt(v4s v)
 {
@@ -460,10 +433,7 @@ static inline v4s v4s_recip(v4s v)
 #endif
 }
 
-static inline v4s v4s_floor(v4s a)
-{
-  return (v4s)_mm_floor_ps((__m128)a);
-}
+static inline v4s v4s_floor(v4s a) { return (v4s)_mm_floor_ps((__m128)a); }
 
 static inline v4s v4s_abs(v4s x)
 {

--- a/src/libpsc/sse2/sse2_push_part_xz.c
+++ b/src/libpsc/sse2/sse2_push_part_xz.c
@@ -44,7 +44,7 @@ static void do_push_part_xz(particles_sse2_t* pp, fields_sse2_t* pf)
   //---------------------------------------------
   // An implementation of Will's 'squished' currents
   // that excludes the x direction all together
-  sse2_real *restrict s_jxi, *restrict s_jyi, *restrict s_jzi;
+  sse2_real* restrict s_jxi, * restrict s_jyi, * restrict s_jzi;
   s_jxi = calloc((psc.img[0] * psc.img[2]), sizeof(sse2_real));
   s_jyi = calloc((psc.img[0] * psc.img[2]), sizeof(sse2_real));
   s_jzi = calloc((psc.img[0] * psc.img[2]), sizeof(sse2_real));

--- a/src/libpsc/sse2/sse2_push_part_yz.c
+++ b/src/libpsc/sse2/sse2_push_part_yz.c
@@ -284,7 +284,7 @@ static void do_push_part_yz(particles_sse2_t* pp, fields_sse2_t* pf)
   //---------------------------------------------
   // An implementation of Will's 'squished' currents
   // that excludes the x direction all together
-  sse2_real *restrict s_jxi, *restrict s_jyi, *restrict s_jzi;
+  sse2_real* restrict s_jxi, * restrict s_jyi, * restrict s_jzi;
   int jsz =
     ((patch->ldims[1] + 2 * psc.ibn[1]) * (patch->ldims[2] + 2 * psc.ibn[2]));
   s_jxi = calloc(jsz, sizeof(sse2_real));

--- a/src/libpsc/tests/test_mparticles.cxx
+++ b/src/libpsc/tests/test_mparticles.cxx
@@ -125,10 +125,7 @@ private:
 // -----------------------------------------------------------------------
 // Constructor
 
-TYPED_TEST(MparticlesTest, Constructor)
-{
-  auto mprts = this->mk_mprts();
-}
+TYPED_TEST(MparticlesTest, Constructor) { auto mprts = this->mk_mprts(); }
 
 // ----------------------------------------------------------------------
 // Inject

--- a/src/libpsc/vpic/PscParticlesBase.h
+++ b/src/libpsc/vpic/PscParticlesBase.h
@@ -16,12 +16,12 @@ struct PscParticle
 {
   float dx, dy, dz; // Particle position in cell coordinates (on [-1,1])
   int32_t i;        // Voxel containing the particle.  Note that
-  /**/                // particled awaiting processing by boundary_p
-  /**/                // have actually set this to 8*voxel + face where
-  /**/                // face is the index of the face they interacted
-  /**/                // with (on 0:5).  This limits the local number of
-  /**/                // voxels to 2^28 but emitter handling already
-  /**/                // has a stricter limit on this (2^26).
+  /**/              // particled awaiting processing by boundary_p
+  /**/              // have actually set this to 8*voxel + face where
+  /**/              // face is the index of the face they interacted
+  /**/              // with (on 0:5).  This limits the local number of
+  /**/              // voxels to 2^28 but emitter handling already
+  /**/              // has a stricter limit on this (2^26).
   float ux, uy, uz; // Particle normalized momentum
   float w;          // Particle weight (number of physical particles)
 };
@@ -115,26 +115,26 @@ struct PscSpecies
   int sort_interval;           // How often to sort the species
   int sort_out_of_place;       // Sort method
   int* ALIGNED(128) partition; // Static array indexed 0:
-  /**/                           // (nx+2)*(ny+2)*(nz+2).  Each value
-  /**/                           // corresponds to the associated particle
-  /**/                           // array index of the first particle in
-  /**/                           // the cell.  Array is allocated and
-  /**/                           // values computed in sort_p.  Purpose is
-  /**/                           // for implementing collision models
-  /**/                           // This is given in terms of the
-  /**/                           // underlying's grids space filling
-  /**/                           // curve indexing.  Thus, immediately
-  /**/                           // after a sort:
-  /**/                           //   sp->p[sp->partition[g->sfc[i]  ]:
-  /**/                           //         sp->partition[g->sfc[i]+1]-1]
-  /**/                           // are all the particles in voxel
-  /**/                           // with local index i, while:
-  /**/                           //   sp->p[ sp->partition[ j   ]:
-  /**/                           //          sp->partition[ j+1 ] ]
-  /**/                           // are all the particles in voxel
-  /**/                           // with space filling curve index j.
-  /**/                           // Note: SFC NOT IN USE RIGHT NOW THUS
-  /**/                           // g->sfc[i]=i ABOVE.
+  /**/                         // (nx+2)*(ny+2)*(nz+2).  Each value
+  /**/                         // corresponds to the associated particle
+  /**/                         // array index of the first particle in
+  /**/                         // the cell.  Array is allocated and
+  /**/                         // values computed in sort_p.  Purpose is
+  /**/                         // for implementing collision models
+  /**/                         // This is given in terms of the
+  /**/                         // underlying's grids space filling
+  /**/                         // curve indexing.  Thus, immediately
+  /**/                         // after a sort:
+  /**/                         //   sp->p[sp->partition[g->sfc[i]  ]:
+  /**/                         //         sp->partition[g->sfc[i]+1]-1]
+  /**/                         // are all the particles in voxel
+  /**/                         // with local index i, while:
+  /**/                         //   sp->p[ sp->partition[ j   ]:
+  /**/                         //          sp->partition[ j+1 ] ]
+  /**/                         // are all the particles in voxel
+  /**/                         // with space filling curve index j.
+  /**/                         // Note: SFC NOT IN USE RIGHT NOW THUS
+  /**/                         // g->sfc[i]=i ABOVE.
 private:
   Grid* grid_; // Underlying grid
 

--- a/src/libpsc/vpic/PscParticlesOps.h
+++ b/src/libpsc/vpic/PscParticlesOps.h
@@ -185,7 +185,7 @@ struct PscParticlesOps
 
       v4 = q * sdr; // v4  = q ux,        q uy,        q uz,        D/C
       v1 = v4 * shuffle<1, 2, 0, 3>(v5);
-      /**/            // v1  = q ux dy,     q uy dz,     q uz dx,     D/C
+      /**/          // v1  = q ux dy,     q uy dz,     q uz dx,     D/C
       v0 = v4 - v1; // v0  = q ux(1-dy),  q uy(1-dz),  q uz(1-dx),  D/C
       v1 += v4;     // v1  = q ux(1+dy),  q uy(1+dz),  q uz(1+dx),  D/C
 
@@ -200,7 +200,7 @@ struct PscParticlesOps
       // v4  = ((q3*splat(sdr,0))*splat(sdr,1))*splat(sdr,2);
       v4 = ((q3 * splat<0>(sdr)) * splat<1>(sdr)) * splat<2>(sdr);
       // FIXME: splat ambiguity in v4 prevents flattening
-      /**/        // v4  = q ux uy uz/3,q ux uy uz/3,q ux uy uz/3,D/C
+      /**/      // v4  = q ux uy uz/3,q ux uy uz/3,q ux uy uz/3,D/C
       v0 += v4; // v0  = q ux[(1-dy)(1-dz)+uy uz/3], ...,       D/C
       v1 -= v4; // v1  = q ux[(1+dy)(1-dz)-uy uz/3], ...,       D/C
       v2 -= v4; // v2  = q ux[(1-dy)(1+dz)-uy uz/3], ...,       D/C
@@ -407,7 +407,7 @@ struct PscParticlesOps
       // particle coordinate system and keep moving the particle.
 
       p->i = neighbor - g.rangel; // Compute local index of neighbor
-      /**/                          // Note: neighbor - g.rangel < 2^31 / 6
+      /**/                        // Note: neighbor - g.rangel < 2^31 / 6
       (&(p->dx))[axis] = -v0;     // Convert coordinate system
     }
 

--- a/src/libpsc/vpic/VpicDiag.h
+++ b/src/libpsc/vpic/VpicDiag.h
@@ -623,15 +623,17 @@ struct VpicDiagMixin
 
       for (size_t v(0); v < numvars; v++) {
         for (size_t k(0); k < nzout + 2; k++) {
-          const size_t koff =
-            (k == 0) ? 0 : (k == nzout + 1) ? grid->nz + 1 : k * kstride - 1;
+          const size_t koff = (k == 0)           ? 0
+                              : (k == nzout + 1) ? grid->nz + 1
+                                                 : k * kstride - 1;
           for (size_t j(0); j < nyout + 2; j++) {
-            const size_t joff =
-              (j == 0) ? 0 : (j == nyout + 1) ? grid->ny + 1 : j * jstride - 1;
+            const size_t joff = (j == 0)           ? 0
+                                : (j == nyout + 1) ? grid->ny + 1
+                                                   : j * jstride - 1;
             for (size_t i(0); i < nxout + 2; i++) {
-              const size_t ioff =
-                (i == 0) ? 0
-                         : (i == nxout + 1) ? grid->nx + 1 : i * istride - 1;
+              const size_t ioff = (i == 0)           ? 0
+                                  : (i == nxout + 1) ? grid->nx + 1
+                                                     : i * istride - 1;
               const uint32_t* fref =
                 reinterpret_cast<uint32_t*>(&F(ioff, joff, koff));
               fileIO.write(&fref[varlist[v]], 1);
@@ -743,15 +745,17 @@ struct VpicDiagMixin
 
       for (size_t v(0); v < numvars; v++)
         for (size_t k(0); k < nzout + 2; k++) {
-          const size_t koff =
-            (k == 0) ? 0 : (k == nzout + 1) ? grid->nz + 1 : k * kstride - 1;
+          const size_t koff = (k == 0)           ? 0
+                              : (k == nzout + 1) ? grid->nz + 1
+                                                 : k * kstride - 1;
           for (size_t j(0); j < nyout + 2; j++) {
-            const size_t joff =
-              (j == 0) ? 0 : (j == nyout + 1) ? grid->ny + 1 : j * jstride - 1;
+            const size_t joff = (j == 0)           ? 0
+                                : (j == nyout + 1) ? grid->ny + 1
+                                                   : j * jstride - 1;
             for (size_t i(0); i < nxout + 2; i++) {
-              const size_t ioff =
-                (i == 0) ? 0
-                         : (i == nxout + 1) ? grid->nx + 1 : i * istride - 1;
+              const size_t ioff = (i == 0)           ? 0
+                                  : (i == nxout + 1) ? grid->nx + 1
+                                                     : i * istride - 1;
               const uint32_t* href =
                 reinterpret_cast<uint32_t*>(&H(ioff, joff, koff));
               fileIO.write(&href[varlist[v]], 1);

--- a/src/libpsc/vpic/wrapper_empty.cxx
+++ b/src/libpsc/vpic/wrapper_empty.cxx
@@ -3,15 +3,9 @@
 
 #include <cassert>
 
-void vpic_simulation::user_initialization(int argc, char** argv)
-{
-  assert(0);
-}
+void vpic_simulation::user_initialization(int argc, char** argv) { assert(0); }
 
-void vpic_simulation::user_diagnostics()
-{
-  assert(0);
-}
+void vpic_simulation::user_diagnostics() { assert(0); }
 
 void vpic_simulation::user_field_injection()
 {

--- a/src/psc_es1.cxx
+++ b/src/psc_es1.cxx
@@ -159,10 +159,7 @@ static double psc_es1_init_field(struct psc* psc, double x[3], int m)
 //
 // return random number between 0 and 1
 
-static double ranf()
-{
-  return (double)random() / RAND_MAX;
-}
+static double ranf() { return (double)random() / RAND_MAX; }
 
 // ----------------------------------------------------------------------
 // psc_es1_init_species
@@ -364,7 +361,4 @@ struct psc_ops psc_es1_ops = {
 // ======================================================================
 // main
 
-int main(int argc, char** argv)
-{
-  return psc_main(&argc, &argv, &psc_es1_ops);
-}
+int main(int argc, char** argv) { return psc_main(&argc, &argv, &psc_es1_ops); }

--- a/src/psc_kelvin_helmholtz.cxx
+++ b/src/psc_kelvin_helmholtz.cxx
@@ -265,7 +265,4 @@ struct psc_ops psc_kh_ops = {
 // ======================================================================
 // main
 
-int main(int argc, char** argv)
-{
-  return psc_main(&argc, &argv, &psc_kh_ops);
-}
+int main(int argc, char** argv) { return psc_main(&argc, &argv, &psc_kh_ops); }

--- a/src/psc_kelvin_helmholtz_double.cxx
+++ b/src/psc_kelvin_helmholtz_double.cxx
@@ -173,7 +173,4 @@ struct psc_ops psc_kh_ops = {
 // ======================================================================
 // main
 
-int main(int argc, char** argv)
-{
-  return psc_main(&argc, &argv, &psc_kh_ops);
-}
+int main(int argc, char** argv) { return psc_main(&argc, &argv, &psc_kh_ops); }

--- a/src/psc_test_twoparticles.cxx
+++ b/src/psc_test_twoparticles.cxx
@@ -195,7 +195,4 @@ struct psc_ops psc_es1_ops = {
 // ======================================================================
 // main
 
-int main(int argc, char** argv)
-{
-  return psc_main(&argc, &argv, &psc_es1_ops);
-}
+int main(int argc, char** argv) { return psc_main(&argc, &argv, &psc_es1_ops); }


### PR DESCRIPTION
It doesn't seem there's a way to keep compatibility between v14 and v9, so let's go to v14, make the `.clang-format` closer to what gtensor has, and keep fingers crossed that later versions won't cause trouble again. 