### PR TITLE
Rework rng and particle initialization

### DIFF
--- a/python/psc/psc.py
+++ b/python/psc/psc.py
@@ -51,11 +51,14 @@ def FieldToComponent(species):
     map['d_rho'] = {'d_rho': 0}
     map['div_j'] = {'div_j': 0}
 
+    # keeping 'all_1st' for backwards compatibility
     map['all_1st'] = {}
+    map['all_1st_cc'] = {}
     moments = ['rho', 'jx', 'jy', 'jz', 'px', 'py',
                'pz', 'txx', 'tyy', 'tzz', 'txy', 'tyz', 'tzx']
     for i_sp, sp in enumerate(species):
         for i_mom, mom in enumerate(moments):
             map['all_1st'][f"{mom}_{sp}"] = i_mom + 13 * i_sp
+            map['all_1st_cc'][f"{mom}_{sp}"] = i_mom + 13 * i_sp
 
     return map

--- a/src/include/binary_collision.hxx
+++ b/src/include/binary_collision.hxx
@@ -2,6 +2,7 @@
 #pragma once
 
 #include "cuda_compat.h"
+#include "distribution.hxx"
 
 #include <cmath>
 
@@ -14,17 +15,9 @@ struct RngC
   // ----------------------------------------------------------------------
   // uniform
   //
-  // returns random number in ]0:1]
+  // returns random number in [0:1[
 
-  real_t uniform()
-  {
-    real_t ran;
-    do {
-      ran = real_t(random()) / RAND_MAX;
-    } while (ran == real_t(0.f));
-
-    return ran;
-  }
+  real_t uniform() { return distribution::Uniform<real_t>{}.get(); }
 };
 
 // ======================================================================

--- a/src/include/binary_collision.hxx
+++ b/src/include/binary_collision.hxx
@@ -2,7 +2,7 @@
 #pragma once
 
 #include "cuda_compat.h"
-#include "distribution.hxx"
+#include "rng.hxx"
 
 #include <cmath>
 
@@ -17,7 +17,7 @@ struct RngC
   //
   // returns random number in [0:1[
 
-  real_t uniform() { return distribution::Uniform<real_t>{}.get(); }
+  real_t uniform() { return rng::Uniform<real_t>{}.get(); }
 };
 
 // ======================================================================

--- a/src/include/distribution.hxx
+++ b/src/include/distribution.hxx
@@ -11,20 +11,10 @@ namespace distribution
 {
 
 // ======================================================================
-// Distribution
-// Base class for distributions
-
-template <typename Real>
-struct Distribution
-{
-  virtual Real get() = 0;
-};
-
-// ======================================================================
 // Uniform
 
 template <typename Real>
-struct Uniform : public Distribution<Real>
+struct Uniform
 {
   Uniform(Real min, Real max)
     : dist(min, max),
@@ -33,7 +23,7 @@ struct Uniform : public Distribution<Real>
 
   Uniform() : Uniform(0, 1) {}
 
-  Real get() override { return dist(gen); }
+  Real get() { return dist(gen); }
 
 private:
   std::default_random_engine gen;
@@ -44,7 +34,7 @@ private:
 // Normal
 
 template <typename Real>
-struct Normal : public Distribution<Real>
+struct Normal
 {
   Normal(Real mean, Real stdev)
     : dist(mean, stdev),
@@ -52,7 +42,7 @@ struct Normal : public Distribution<Real>
   {}
   Normal() : Normal(0, 1) {}
 
-  Real get() override { return dist(gen); }
+  Real get() { return dist(gen); }
   // FIXME remove me, or make standalone func
   Real get(Real mean, Real stdev)
   {
@@ -137,7 +127,7 @@ void findPdfSupport(std::function<Real(Real)>& cdf, Real& xmin, Real& xmax,
 }
 
 template <typename Real>
-struct InvertedCdf : public Distribution<Real>
+struct InvertedCdf
 {
   InvertedCdf(std::function<Real(Real)> cdf, int n_points = 100,
               Real tolerance = .0001, int max_n_iter = 50)

--- a/src/include/distribution.hxx
+++ b/src/include/distribution.hxx
@@ -28,6 +28,8 @@ struct Uniform : public Distribution<Real>
       gen(std::chrono::system_clock::now().time_since_epoch().count())
   {}
 
+  Uniform() : Uniform(0, 1) {}
+
   Real get() override { return dist(gen); }
 
 private:

--- a/src/include/distribution.hxx
+++ b/src/include/distribution.hxx
@@ -1,8 +1,11 @@
+#pragma once
+
 #include <vector>
 #include <cmath>
 #include "stdlib.h"
 #include <random>
 #include <chrono>
+#include <functional>
 
 namespace distribution
 {

--- a/src/include/distribution.hxx
+++ b/src/include/distribution.hxx
@@ -1,0 +1,30 @@
+#include <random>
+
+namespace distribution
+{
+
+// ======================================================================
+// Distribution
+// Base class for distributions
+
+template <typename Real>
+struct Distribution
+{
+  virtual Real get() = 0;
+};
+
+// ======================================================================
+// Uniform
+
+template <typename Real>
+struct Uniform : public Distribution<Real>
+{
+  Uniform(Real min, Real max) : dist{min, max} {}
+  Real get() override { return dist(generator); }
+
+private:
+  std::default_random_engine generator;
+  std::uniform_real_distribution<Real> dist;
+};
+
+} // namespace distribution

--- a/src/include/distribution.hxx
+++ b/src/include/distribution.hxx
@@ -1,4 +1,5 @@
 #include <random>
+#include <cmath>
 
 namespace distribution
 {
@@ -25,6 +26,38 @@ struct Uniform : public Distribution<Real>
 private:
   std::default_random_engine generator;
   std::uniform_real_distribution<Real> dist;
+};
+
+// ======================================================================
+// Normal
+
+template <typename Real>
+struct Normal : public Distribution<Real>
+{
+  Normal(Real mean, Real stdev) : mean{mean}, stdev{stdev} {}
+  Normal() : Normal(0, 1) {}
+
+  Real get() override { return get(mean, stdev); }
+  Real get(Real mean, Real stdev)
+  {
+    if (has_next_value) {
+      has_next_value = false;
+      return next_value;
+    }
+
+    // Box-Muller transform to generate 2 independent values at once
+    Real r = stdev * std::sqrt(-2 * std::log(1 - uniform.get()));
+    Real theta = uniform.get() * 2 * M_PI;
+
+    next_value = r * std::cos(theta) + mean;
+    return r * std::sin(theta) + mean;
+  }
+
+private:
+  Uniform<Real> uniform{0, 1};
+  Real mean, stdev;
+  Real next_value;
+  bool has_next_value;
 };
 
 } // namespace distribution

--- a/src/include/distribution.hxx
+++ b/src/include/distribution.hxx
@@ -68,17 +68,17 @@ template <typename Real>
 struct InvertedCdf : public Distribution<Real>
 {
   InvertedCdf(std::function<Real(Real)> cdf, int n_points = 100,
-              Real eps = .0001)
+              Real eps = .0001, int max_n_iter = 50)
   {
     Real xmin = -1, xmax = 1;
 
-    while (cdf(xmin) < eps)
+    for (int n_iter = 0; cdf(xmin) < eps && n_iter < max_n_iter; ++n_iter)
       xmin += .5;
-    while (cdf(xmin) > eps)
+    for (int n_iter = 0; cdf(xmin) > eps && n_iter < max_n_iter; ++n_iter)
       xmin -= 1 / 16.;
-    while (cdf(xmax) > 1 - eps)
+    for (int n_iter = 0; cdf(xmax) > 1 - eps && n_iter < max_n_iter; ++n_iter)
       xmax -= .5;
-    while (cdf(xmax) < 1 - eps)
+    for (int n_iter = 0; cdf(xmax) < 1 - eps && n_iter < max_n_iter; ++n_iter)
       xmax += 1 / 16.;
 
     x.push_back(xmin);

--- a/src/include/distribution.hxx
+++ b/src/include/distribution.hxx
@@ -97,12 +97,24 @@ struct InvertedCdf : public Distribution<Real>
     Real u = uniform.get();
     int guess_idx = cdf.size() * u;
 
-    while (cdf[guess_idx] > u)
-      --guess_idx;
-    while (cdf[guess_idx] < u)
-      ++guess_idx;
+    while (u < cdf[guess_idx]) {
+      --guess_idx; // decrease cdf
+    }
+    while (u > cdf[guess_idx]) {
+      ++guess_idx; // increase cdf
+    }
 
-    return x[guess_idx];
+    Real d_cdf = cdf[guess_idx] - cdf[guess_idx - 1];
+    if (d_cdf == 0.)
+      return x[guess_idx];
+
+    // now: cdf[guess_idx-1] <= u < cdf[guess_idx]
+    // so linearly interpolate between points
+
+    Real w1 = (cdf[guess_idx] - u) / d_cdf;
+    Real w2 = (u - cdf[guess_idx - 1]) / d_cdf;
+
+    return w1 * x[guess_idx - 1] + w2 * x[guess_idx];
   }
 
 private:

--- a/src/include/psc.hxx
+++ b/src/include/psc.hxx
@@ -782,27 +782,28 @@ Psc<PscConfig, Diagnostics, InjectParticles> makePscIntegrator(
 // ======================================================================
 // partitionAndSetupParticles
 
-template <typename SetupParticles, typename Balance, typename Mparticles>
+template <typename SetupParticles, typename Balance, typename Mparticles,
+          typename InitFunc>
 void partitionAndSetupParticles(SetupParticles& setup_particles,
                                 Balance& balance, Grid_t*& grid_ptr,
-                                Mparticles& mprts, InitNptFunc init_npt)
+                                Mparticles& mprts, InitFunc init_np)
 {
-  partitionParticles(setup_particles, balance, grid_ptr, mprts, init_npt);
-  setupParticles(setup_particles, mprts, init_npt);
+  partitionParticles(setup_particles, balance, grid_ptr, mprts, init_np);
+  setupParticles(setup_particles, mprts, init_np);
 }
 
 // ----------------------------------------------------------------------
 // partitionParticles
 
-template <typename SetupParticles, typename Balance, typename Mparticles>
+template <typename SetupParticles, typename Balance, typename Mparticles,
+          typename InitFunc>
 void partitionParticles(SetupParticles& setup_particles, Balance& balance,
-                        Grid_t*& grid_ptr, Mparticles& mprts,
-                        InitNptFunc init_npt)
+                        Grid_t*& grid_ptr, Mparticles& mprts, InitFunc init_np)
 {
   auto comm = grid_ptr->comm();
   mpi_printf(comm, "**** Partitioning...\n");
 
-  auto n_prts_by_patch = setup_particles.partition(*grid_ptr, init_npt);
+  auto n_prts_by_patch = setup_particles.partition(*grid_ptr, init_np);
 
   balance.initial(grid_ptr, n_prts_by_patch);
   // !!! FIXME! grid is now invalid
@@ -815,12 +816,12 @@ void partitionParticles(SetupParticles& setup_particles, Balance& balance,
 // ----------------------------------------------------------------------
 // setupParticles
 
-template <typename SetupParticles, typename Mparticles>
+template <typename SetupParticles, typename Mparticles, typename InitFunc>
 void setupParticles(SetupParticles& setup_particles, Mparticles& mprts,
-                    InitNptFunc init_npt)
+                    InitFunc init_np)
 {
   mpi_printf(MPI_COMM_WORLD, "**** Setting up particles...\n");
-  setup_particles.setupParticles(mprts, init_npt);
+  setup_particles.setupParticles(mprts, init_np);
 }
 
 // ======================================================================

--- a/src/include/rng.hxx
+++ b/src/include/rng.hxx
@@ -7,7 +7,7 @@
 #include <chrono>
 #include <functional>
 
-namespace distribution
+namespace rng
 {
 
 // ======================================================================
@@ -176,4 +176,4 @@ private:
   Uniform<Real> uniform{0, 1};
 };
 
-} // namespace distribution
+} // namespace rng

--- a/src/include/setup_particles.hxx
+++ b/src/include/setup_particles.hxx
@@ -155,21 +155,15 @@ struct SetupParticles
   psc::particle::Inject setupParticle(const psc_particle_npt& npt, Double3 pos,
                                       double wni)
   {
-    static distribution::Uniform<float> dist(0, 1);
+    static distribution::Normal<double> dist;
     double beta = norm_.beta;
 
     assert(npt.kind >= 0 && npt.kind < kinds_.size());
     double m = kinds_[npt.kind].m;
 
-    double pxi = npt.p[0] + sqrtf(-2.f * npt.T[0] / m * sqr(beta) *
-                                  logf(1.0 - dist.get())) *
-                              cosf(2.f * M_PI * dist.get());
-    double pyi = npt.p[1] + sqrtf(-2.f * npt.T[1] / m * sqr(beta) *
-                                  logf(1.0 - dist.get())) *
-                              cosf(2.f * M_PI * dist.get());
-    double pzi = npt.p[2] + sqrtf(-2.f * npt.T[2] / m * sqr(beta) *
-                                  logf(1.0 - dist.get())) *
-                              cosf(2.f * M_PI * dist.get());
+    double pxi = dist.get(npt.p[0], beta * std::sqrt(npt.T[0] / m));
+    double pyi = dist.get(npt.p[1], beta * std::sqrt(npt.T[1] / m));
+    double pzi = dist.get(npt.p[2], beta * std::sqrt(npt.T[2] / m));
 
     if (initial_momentum_gamma_correction) {
       double gam;

--- a/src/include/setup_particles.hxx
+++ b/src/include/setup_particles.hxx
@@ -112,16 +112,16 @@ struct SetupParticles
   //
   // helper function for partition / particle setup
 
-  int get_n_in_cell(const psc_particle_npt& npt)
+  int get_n_in_cell(const psc_particle_np& np)
   {
     static distribution::Uniform<float> dist{0, 1};
-    if (npt.n == 0) {
+    if (np.n == 0) {
       return 0;
     }
     if (fractional_n_particles_per_cell) {
-      return npt.n / norm_.cori + dist.get();
+      return np.n / norm_.cori + dist.get();
     }
-    return npt.n / norm_.cori + .5;
+    return np.n / norm_.cori + .5;
   }
 
   // ----------------------------------------------------------------------
@@ -156,18 +156,18 @@ struct SetupParticles
               npt.kind = pop;
             }
             init_npt(pop, pos, patch, index, npt);
+            auto np = npt_to_np(npt);
 
             int n_in_cell;
             if (pop != neutralizing_population) {
-              n_in_cell = get_n_in_cell(npt);
-              n_q_in_cell += kinds_[npt.kind].q * n_in_cell;
+              n_in_cell = get_n_in_cell(np);
+              n_q_in_cell += kinds_[np.kind].q * n_in_cell;
             } else {
               // FIXME, should handle the case where not the last population
               // is neutralizing
               assert(neutralizing_population == n_populations_ - 1);
-              n_in_cell = -n_q_in_cell / kinds_[npt.kind].q;
+              n_in_cell = -n_q_in_cell / kinds_[np.kind].q;
             }
-            auto np = npt_to_np(npt);
             op(n_in_cell, np, pos);
           }
         }

--- a/src/include/setup_particles.hxx
+++ b/src/include/setup_particles.hxx
@@ -134,7 +134,7 @@ struct SetupParticles
               npt.kind = pop;
             }
             init_npt(pop, pos, patch, index, npt);
-            auto np = npt_to_np(npt);
+            psc_particle_np np{npt.kind, npt.n, createMaxwellian(npt), npt.tag};
 
             int n_in_cell;
             if (pop != neutralizing_population) {
@@ -160,14 +160,6 @@ struct SetupParticles
                                       double wni)
   {
     return psc::particle::Inject{pos, np.p(), wni, np.kind, np.tag};
-  }
-
-  // ----------------------------------------------------------------------
-  // npt_to_np
-
-  psc_particle_np npt_to_np(const psc_particle_npt& npt)
-  {
-    return psc_particle_np{npt.kind, npt.n, createMaxwellian(npt), npt.tag};
   }
 
   // ----------------------------------------------------------------------

--- a/src/include/setup_particles.hxx
+++ b/src/include/setup_particles.hxx
@@ -127,7 +127,7 @@ struct SetupParticles
   // ----------------------------------------------------------------------
   // op_cellwise
   // Performs a given operation in each cell.
-  // op signature: (int n_in_cell, npt, Double3 pos) -> void
+  // op signature: (int n_in_cell, np, Double3 pos) -> void
 
   template <typename OpFunc>
   void op_cellwise(const Grid_t& grid, int patch, InitNptFunc init_npt,
@@ -167,7 +167,8 @@ struct SetupParticles
               assert(neutralizing_population == n_populations_ - 1);
               n_in_cell = -n_q_in_cell / kinds_[npt.kind].q;
             }
-            op(n_in_cell, npt, pos);
+            auto np = npt_to_np(npt);
+            op(n_in_cell, np, pos);
           }
         }
       }
@@ -222,14 +223,13 @@ struct SetupParticles
       auto injector = inj[p];
 
       op_cellwise(grid, p, init_npt,
-                  [&](int n_in_cell, psc_particle_npt& npt, Double3& pos) {
-                    auto np = npt_to_np(npt);
+                  [&](int n_in_cell, psc_particle_np& np, Double3& pos) {
                     for (int cnt = 0; cnt < n_in_cell; cnt++) {
                       real_t wni;
                       if (fractional_n_particles_per_cell) {
                         wni = 1.;
                       } else {
-                        wni = npt.n / (n_in_cell * norm_.cori);
+                        wni = np.n / (n_in_cell * norm_.cori);
                       }
                       auto prt = setupParticle(np, pos, wni);
                       injector(prt);
@@ -249,7 +249,7 @@ struct SetupParticles
 
     for (int p = 0; p < grid.n_patches(); ++p) {
       op_cellwise(grid, p, init_npt,
-                  [&](int n_in_cell, psc_particle_npt&, Double3&) {
+                  [&](int n_in_cell, psc_particle_np&, Double3&) {
                     n_prts_by_patch[p] += n_in_cell;
                   });
     }

--- a/src/include/setup_particles.hxx
+++ b/src/include/setup_particles.hxx
@@ -4,6 +4,7 @@
 #include <functional>
 #include <type_traits>
 #include "centering.hxx"
+#include "distribution.hxx"
 
 struct psc_particle_npt
 {
@@ -154,31 +155,21 @@ struct SetupParticles
   psc::particle::Inject setupParticle(const psc_particle_npt& npt, Double3 pos,
                                       double wni)
   {
+    static distribution::Uniform<float> dist(0, 1);
     double beta = norm_.beta;
 
     assert(npt.kind >= 0 && npt.kind < kinds_.size());
     double m = kinds_[npt.kind].m;
 
-    float ran1, ran2, ran3, ran4, ran5, ran6;
-    do {
-      ran1 = random() / ((float)RAND_MAX + 1);
-      ran2 = random() / ((float)RAND_MAX + 1);
-      ran3 = random() / ((float)RAND_MAX + 1);
-      ran4 = random() / ((float)RAND_MAX + 1);
-      ran5 = random() / ((float)RAND_MAX + 1);
-      ran6 = random() / ((float)RAND_MAX + 1);
-    } while (ran1 >= 1.f || ran2 >= 1.f || ran3 >= 1.f || ran4 >= 1.f ||
-             ran5 >= 1.f || ran6 >= 1.f);
-
-    double pxi =
-      npt.p[0] + sqrtf(-2.f * npt.T[0] / m * sqr(beta) * logf(1.0 - ran1)) *
-                   cosf(2.f * M_PI * ran2);
-    double pyi =
-      npt.p[1] + sqrtf(-2.f * npt.T[1] / m * sqr(beta) * logf(1.0 - ran3)) *
-                   cosf(2.f * M_PI * ran4);
-    double pzi =
-      npt.p[2] + sqrtf(-2.f * npt.T[2] / m * sqr(beta) * logf(1.0 - ran5)) *
-                   cosf(2.f * M_PI * ran6);
+    double pxi = npt.p[0] + sqrtf(-2.f * npt.T[0] / m * sqr(beta) *
+                                  logf(1.0 - dist.get())) *
+                              cosf(2.f * M_PI * dist.get());
+    double pyi = npt.p[1] + sqrtf(-2.f * npt.T[1] / m * sqr(beta) *
+                                  logf(1.0 - dist.get())) *
+                              cosf(2.f * M_PI * dist.get());
+    double pzi = npt.p[2] + sqrtf(-2.f * npt.T[2] / m * sqr(beta) *
+                                  logf(1.0 - dist.get())) *
+                              cosf(2.f * M_PI * dist.get());
 
     if (initial_momentum_gamma_correction) {
       double gam;

--- a/src/include/setup_particles.hxx
+++ b/src/include/setup_particles.hxx
@@ -84,17 +84,12 @@ struct SetupParticles
 
   int get_n_in_cell(const psc_particle_npt& npt)
   {
+    static distribution::Uniform<float> dist{0, 1};
     if (npt.n == 0) {
       return 0;
     }
     if (fractional_n_particles_per_cell) {
-      int n_prts = npt.n / norm_.cori;
-      float rmndr = npt.n / norm_.cori - n_prts;
-      float ran = random() / ((float)RAND_MAX + 1);
-      if (ran < rmndr) {
-        n_prts++;
-      }
-      return n_prts;
+      return npt.n / norm_.cori + dist.get();
     }
     return npt.n / norm_.cori + .5;
   }

--- a/src/include/setup_particles.hxx
+++ b/src/include/setup_particles.hxx
@@ -180,16 +180,23 @@ struct SetupParticles
   psc::particle::Inject setupParticle(const psc_particle_npt& npt, Double3 pos,
                                       double wni)
   {
-    assert(npt.kind >= 0 && npt.kind < kinds_.size());
-    return setupParticle(psc_particle_np(npt, kinds_[npt.kind].m, norm_.beta,
-                                         initial_momentum_gamma_correction),
-                         pos, wni);
+    return setupParticle(npt_to_np(npt), pos, wni);
   }
 
   psc::particle::Inject setupParticle(const psc_particle_np& np, Double3 pos,
                                       double wni)
   {
     return psc::particle::Inject{pos, np.p(), wni, np.kind, np.tag};
+  }
+
+  // ----------------------------------------------------------------------
+  // npt_to_np
+
+  psc_particle_np npt_to_np(const psc_particle_npt& npt)
+  {
+    assert(npt.kind >= 0 && npt.kind < kinds_.size());
+    return psc_particle_np(npt, kinds_[npt.kind].m, norm_.beta,
+                           initial_momentum_gamma_correction);
   }
 
   // ----------------------------------------------------------------------

--- a/src/include/setup_particles.hxx
+++ b/src/include/setup_particles.hxx
@@ -223,6 +223,7 @@ struct SetupParticles
 
       op_cellwise(grid, p, init_npt,
                   [&](int n_in_cell, psc_particle_npt& npt, Double3& pos) {
+                    auto np = npt_to_np(npt);
                     for (int cnt = 0; cnt < n_in_cell; cnt++) {
                       real_t wni;
                       if (fractional_n_particles_per_cell) {
@@ -230,7 +231,7 @@ struct SetupParticles
                       } else {
                         wni = npt.n / (n_in_cell * norm_.cori);
                       }
-                      auto prt = setupParticle(npt_to_np(npt), pos, wni);
+                      auto prt = setupParticle(np, pos, wni);
                       injector(prt);
                     }
                   });

--- a/src/include/setup_particles.hxx
+++ b/src/include/setup_particles.hxx
@@ -4,7 +4,7 @@
 #include <functional>
 #include <type_traits>
 #include "centering.hxx"
-#include "distribution.hxx"
+#include "rng.hxx"
 
 struct psc_particle_npt
 {
@@ -115,7 +115,7 @@ struct SetupParticles
 
   int get_n_in_cell(const psc_particle_np& np)
   {
-    static distribution::Uniform<float> dist{0, 1};
+    static rng::Uniform<float> dist{0, 1};
     if (np.n == 0) {
       return 0;
     }
@@ -194,7 +194,7 @@ struct SetupParticles
     double m = kinds_[npt.kind].m;
 
     return [=]() {
-      static distribution::Normal<double> dist;
+      static rng::Normal<double> dist;
 
       Double3 p;
       for (int i = 0; i < 3; i++)

--- a/src/include/setup_particles.hxx
+++ b/src/include/setup_particles.hxx
@@ -156,21 +156,19 @@ struct SetupParticles
     assert(npt.kind >= 0 && npt.kind < kinds_.size());
     double m = kinds_[npt.kind].m;
 
-    double pxi = dist.get(npt.p[0], beta * std::sqrt(npt.T[0] / m));
-    double pyi = dist.get(npt.p[1], beta * std::sqrt(npt.T[1] / m));
-    double pzi = dist.get(npt.p[2], beta * std::sqrt(npt.T[2] / m));
+    Double3 p;
+    for (int i = 0; i < 3; i++)
+      p[i] = dist.get(npt.p[i], beta * std::sqrt(npt.T[i] / m));
 
     if (initial_momentum_gamma_correction) {
-      double gam;
-      if (sqr(pxi) + sqr(pyi) + sqr(pzi) < 1.) {
-        gam = 1. / sqrt(1. - sqr(pxi) - sqr(pyi) - sqr(pzi));
-        pxi *= gam;
-        pyi *= gam;
-        pzi *= gam;
+      double p_squared = sqr(p[0]) + sqr(p[1]) + sqr(p[2]);
+      if (p_squared < 1.) {
+        double gamma = 1. / sqrt(1. - p_squared);
+        p *= gamma;
       }
     }
 
-    return psc::particle::Inject{pos, {pxi, pyi, pzi}, wni, npt.kind, npt.tag};
+    return psc::particle::Inject{pos, p, wni, npt.kind, npt.tag};
   }
 
   // ----------------------------------------------------------------------

--- a/src/include/setup_particles.hxx
+++ b/src/include/setup_particles.hxx
@@ -177,12 +177,6 @@ struct SetupParticles
   // ----------------------------------------------------------------------
   // setupParticle
 
-  psc::particle::Inject setupParticle(const psc_particle_npt& npt, Double3 pos,
-                                      double wni)
-  {
-    return setupParticle(npt_to_np(npt), pos, wni);
-  }
-
   psc::particle::Inject setupParticle(const psc_particle_np& np, Double3 pos,
                                       double wni)
   {
@@ -236,7 +230,7 @@ struct SetupParticles
                       } else {
                         wni = npt.n / (n_in_cell * norm_.cori);
                       }
-                      auto prt = setupParticle(npt, pos, wni);
+                      auto prt = setupParticle(npt_to_np(npt), pos, wni);
                       injector(prt);
                     }
                   });

--- a/src/include/setup_particles.hxx
+++ b/src/include/setup_particles.hxx
@@ -214,6 +214,11 @@ struct SetupParticles
   // ----------------------------------------------------------------------
   // setup_particles
 
+  void operator()(Mparticles& mprts, InitNpFunc init_np)
+  {
+    setupParticles(mprts, init_np);
+  }
+
   void operator()(Mparticles& mprts, InitNptFunc init_npt)
   {
     setupParticles(mprts, init_npt);
@@ -240,6 +245,11 @@ struct SetupParticles
 
   void setupParticles(Mparticles& mprts, InitNptFunc init_npt)
   {
+    setupParticles(mprts, initNpt_to_initNp(init_npt));
+  }
+
+  void setupParticles(Mparticles& mprts, InitNpFunc init_np)
+  {
     static int pr;
     if (!pr) {
       pr = prof_register("setupp", 1., 0, 0);
@@ -255,7 +265,7 @@ struct SetupParticles
     for (int p = 0; p < mprts.n_patches(); ++p) {
       auto injector = inj[p];
 
-      op_cellwise(grid, p, initNpt_to_initNp(init_npt),
+      op_cellwise(grid, p, init_np,
                   [&](int n_in_cell, psc_particle_np& np, Double3& pos) {
                     for (int cnt = 0; cnt < n_in_cell; cnt++) {
                       real_t wni;
@@ -278,10 +288,15 @@ struct SetupParticles
 
   std::vector<uint> partition(const Grid_t& grid, InitNptFunc init_npt)
   {
+    return partition(grid, initNpt_to_initNp(init_npt));
+  }
+
+  std::vector<uint> partition(const Grid_t& grid, InitNpFunc init_np)
+  {
     std::vector<uint> n_prts_by_patch(grid.n_patches());
 
     for (int p = 0; p < grid.n_patches(); ++p) {
-      op_cellwise(grid, p, initNpt_to_initNp(init_npt),
+      op_cellwise(grid, p, init_np,
                   [&](int n_in_cell, psc_particle_np&, Double3&) {
                     n_prts_by_patch[p] += n_in_cell;
                   });

--- a/src/libpsc/cuda/cuda_heating.cxx
+++ b/src/libpsc/cuda/cuda_heating.cxx
@@ -8,6 +8,7 @@
 #include "heating_cuda_impl.hxx"
 #include "balance.hxx"
 #include "rng_state.hxx"
+#include "distribution.hxx"
 
 #include <thrust/host_vector.h>
 #include <thrust/device_vector.h>
@@ -19,23 +20,6 @@
 extern std::size_t mem_heating;
 
 using Float3 = Vec3<float>;
-
-// ----------------------------------------------------------------------
-// bm_normal2
-
-static inline float2 bm_normal2(void)
-{
-  float u1, u2;
-  do {
-    u1 = random() * (1.f / RAND_MAX);
-    u2 = random() * (1.f / RAND_MAX);
-  } while (u1 <= 0.f);
-
-  float2 rv;
-  rv.x = sqrtf(-2.f * logf(u1)) * cosf(2.f * M_PI * u2);
-  rv.y = sqrtf(-2.f * logf(u1)) * sinf(2.f * M_PI * u2);
-  return rv;
-}
 
 // ----------------------------------------------------------------------
 // d_particle_kick
@@ -176,14 +160,13 @@ struct cuda_heating_foil
 
 __host__ void particle_kick(DParticleCuda& prt, float H, float heating_dt)
 {
-  float2 r01 = bm_normal2();
-  float2 r23 = bm_normal2();
+  distribution::Normal<float> standard_normal_distr;
 
   float Dp = sqrtf(H * heating_dt);
 
-  prt.x[0] += Dp * r01.x;
-  prt.x[1] += Dp * r01.y;
-  prt.x[2] += Dp * r23.x;
+  prt.x[0] += Dp * standard_normal_distr.get();
+  prt.x[1] += Dp * standard_normal_distr.get();
+  prt.x[2] += Dp * standard_normal_distr.get();
 }
 
 // ----------------------------------------------------------------------

--- a/src/libpsc/cuda/cuda_heating.cxx
+++ b/src/libpsc/cuda/cuda_heating.cxx
@@ -8,7 +8,7 @@
 #include "heating_cuda_impl.hxx"
 #include "balance.hxx"
 #include "rng_state.hxx"
-#include "distribution.hxx"
+#include "rng.hxx"
 
 #include <thrust/host_vector.h>
 #include <thrust/device_vector.h>
@@ -160,7 +160,7 @@ struct cuda_heating_foil
 
 __host__ void particle_kick(DParticleCuda& prt, float H, float heating_dt)
 {
-  distribution::Normal<float> standard_normal_distr;
+  rng::Normal<float> standard_normal_distr;
 
   float Dp = sqrtf(H * heating_dt);
 

--- a/src/libpsc/psc_bnd_particles/psc_bnd_particles_open.cxx
+++ b/src/libpsc/psc_bnd_particles/psc_bnd_particles_open.cxx
@@ -1,5 +1,5 @@
 
-#include "distribution.hxx"
+#include "rng.hxx"
 #include "fields.hxx"
 
 using real_t = mparticles_t::real_t;
@@ -471,7 +471,7 @@ static inline double inject_particles(int p, struct psc_mparticles* mprts,
       do {
         nnm++;
         // FIXME, shouldn't have to loop here
-        distribution::Uniform<double> uniform_distr;
+        rng::Uniform<double> uniform_distr;
         do {
           double sr = uniform_distr.get();
 

--- a/src/libpsc/psc_bnd_particles/psc_bnd_particles_open.cxx
+++ b/src/libpsc/psc_bnd_particles/psc_bnd_particles_open.cxx
@@ -1,4 +1,5 @@
 
+#include "distribution.hxx"
 #include "fields.hxx"
 
 using real_t = mparticles_t::real_t;
@@ -7,8 +8,6 @@ static const int debug_every_step = 10;
 
 static inline bool at_lo_boundary(int p, int d);
 static inline bool at_hi_boundary(int p, int d);
-
-static inline double random1() { return random() / (double)RAND_MAX; }
 
 static void copy_to_mrc_fld(struct mrc_fld* m3, struct psc_mfields* mflds)
 {
@@ -472,8 +471,9 @@ static inline double inject_particles(int p, struct psc_mparticles* mprts,
       do {
         nnm++;
         // FIXME, shouldn't have to loop here
+        distribution::Uniform<double> uniform_distr;
         do {
-          double sr = random1();
+          double sr = uniform_distr.get();
 
           pxi[Z] = 0.;
           for (int k = 0; k < nvdx - 1; k++) {
@@ -485,26 +485,24 @@ static inline double inject_particles(int p, struct psc_mparticles* mprts,
           }
         } while (pxi[Z] == 0);
 
-        double sr = random1();
         double yya = 0.;
         double yy0;
         int icount = 0;
         do {
           icount++;
           yy0 = yya;
-          yya = yy0 - (erf(yy0) - (2. * sr - 1.)) /
+          yya = yy0 - (erf(yy0) - (2. * uniform_distr.get() - 1.)) /
                         (2. / sqrt(M_PI) * exp(-sqr(yy0)));
         } while (fabs(yya - yy0) > 1.e-15 && icount != 100);
         pxi[X] = v[X] + yya * sqrt(W[YY] / (W[XX] * W[YY] - sqr(W[XY]))) +
                  (pxi[Z] - v[Z]) * vv[ZX] / vv[ZZ];
 
-        sr = random1();
         yya = 0.0;
         icount = 0;
         do {
           icount++;
           yy0 = yya;
-          yya = yy0 - (erf(yy0) - (2. * sr - 1.)) /
+          yya = yy0 - (erf(yy0) - (2. * uniform_distr.get() - 1.)) /
                         (2. / sqrt(M_PI) * exp(-sqr(yy0)));
         } while (fabs(yya - yy0) > 1.e-15 && icount != 100);
         pxi[Y] = v[Y] + 1. / W[YY] *
@@ -517,11 +515,11 @@ static inline double inject_particles(int p, struct psc_mparticles* mprts,
         }
       } while (sqr(pxi[X]) + sqr(pxi[Y]) + sqr(pxi[Z]) > 1.);
 
-      double xr = random1();
+      double xr = uniform_distr.get();
       xi[X] = pos[X] + xr * grid.dx[X];
-      double yr = random1();
+      double yr = uniform_distr.get();
       xi[Y] = pos[Y] + yr * grid.dx[Y];
-      double zr = random1();
+      double zr = uniform_distr.get();
       double dz = dir * zr * pxi[Z] * ppsc->dt;
       xi[Z] = pos[Z] + dz;
 

--- a/src/libpsc/psc_heating/psc_heating_impl.hxx
+++ b/src/libpsc/psc_heating/psc_heating_impl.hxx
@@ -1,6 +1,6 @@
 
 #include "heating.hxx"
-#include "distribution.hxx"
+#include "rng.hxx"
 
 #include <functional>
 #include <stdlib.h>
@@ -29,7 +29,7 @@ struct Heating__ : HeatingBase
 
   void kick_particle(Particle& prt, real_t H)
   {
-    distribution::Normal<real_t> standard_normal_distr;
+    rng::Normal<real_t> standard_normal_distr;
 
     real_t Dpxi = sqrtf(H * heating_dt_);
     real_t Dpyi = sqrtf(H * heating_dt_);

--- a/src/libpsc/psc_heating/psc_heating_impl.hxx
+++ b/src/libpsc/psc_heating/psc_heating_impl.hxx
@@ -1,5 +1,6 @@
 
 #include "heating.hxx"
+#include "distribution.hxx"
 
 #include <functional>
 #include <stdlib.h>
@@ -28,28 +29,15 @@ struct Heating__ : HeatingBase
 
   void kick_particle(Particle& prt, real_t H)
   {
-    float ran1, ran2, ran3, ran4, ran5, ran6;
-    do {
-      ran1 = random() / ((float)RAND_MAX + 1);
-      ran2 = random() / ((float)RAND_MAX + 1);
-      ran3 = random() / ((float)RAND_MAX + 1);
-      ran4 = random() / ((float)RAND_MAX + 1);
-      ran5 = random() / ((float)RAND_MAX + 1);
-      ran6 = random() / ((float)RAND_MAX + 1);
-    } while (ran1 >= 1.f || ran2 >= 1.f || ran3 >= 1.f || ran4 >= 1.f ||
-             ran5 >= 1.f || ran6 >= 1.f);
-
-    real_t ranx = sqrtf(-2.f * logf(1.0 - ran1)) * cosf(2.f * M_PI * ran2);
-    real_t rany = sqrtf(-2.f * logf(1.0 - ran3)) * cosf(2.f * M_PI * ran4);
-    real_t ranz = sqrtf(-2.f * logf(1.0 - ran5)) * cosf(2.f * M_PI * ran6);
+    distribution::Normal<real_t> standard_normal_distr;
 
     real_t Dpxi = sqrtf(H * heating_dt_);
     real_t Dpyi = sqrtf(H * heating_dt_);
     real_t Dpzi = sqrtf(H * heating_dt_);
 
-    prt.u[0] += Dpxi * ranx;
-    prt.u[1] += Dpyi * rany;
-    prt.u[2] += Dpzi * ranz;
+    prt.u[0] += Dpxi * standard_normal_distr.get();
+    prt.u[1] += Dpyi * standard_normal_distr.get();
+    prt.u[2] += Dpzi * standard_normal_distr.get();
   }
 
   void operator()(Mparticles& mprts)

--- a/src/libpsc/tests/test_push_fields.cxx
+++ b/src/libpsc/tests/test_push_fields.cxx
@@ -106,7 +106,7 @@ TYPED_TEST(PushFieldsTest, Pushf2)
 // need separate init_phi to work around device lambda limitations
 
 template <typename E>
-inline void init_phi(E&& mphi, Int3 bnd, const Grid_t& grid, double kz)
+inline void init_phi(E&& mphi, const Int3 bnd, const Grid_t& grid, double kz)
 {
   auto&& k_mphi = mphi.to_kernel();
   double dz = grid.domain.dx[2];

--- a/src/psc_bgk.cxx
+++ b/src/psc_bgk.cxx
@@ -220,7 +220,7 @@ void initializeParticles(Balance& balance, Grid_t*& grid_ptr, Mparticles& mprts,
 
   auto&& qDensity = -psc::mflds::interior(divGradPhi.grid(), divGradPhi.gt());
 
-  auto npt_init = [&](int kind, double crd[3], int p, Int3 idx,
+  auto npt_init = [&](int kind, Double3 crd, int p, Int3 idx,
                       psc_particle_npt& npt) {
     double y = getCoord(crd[1]);
     double z = getCoord(crd[2]);
@@ -255,9 +255,8 @@ void initializeParticles(Balance& balance, Grid_t*& grid_ptr, Mparticles& mprts,
     }
   };
 
-  partitionParticlesGeneralInit(setup_particles, balance, grid_ptr, mprts,
-                                npt_init);
-  setupParticlesGeneralInit(setup_particles, mprts, npt_init);
+  partitionAndSetupParticles(setup_particles, balance, grid_ptr, mprts,
+                             npt_init);
 }
 
 // ======================================================================

--- a/src/psc_bgk_util/input_parser.hxx
+++ b/src/psc_bgk_util/input_parser.hxx
@@ -4,6 +4,9 @@
 #include <string>
 #include <fstream>
 #include <sstream>
+#include <iterator>
+#include <algorithm>
+#include <cassert>
 
 // ======================================================================
 // parsing util


### PR DESCRIPTION
This pr does two things:
1. move rng to src/include/distribution.hxx, which is based on the <random> library
2. rework setup_particles.hxx to support arbitrary momentum-space distribution functions

The changes shouldn't require refactoring of existing cases, and maybe more ergonomic.