### PR TITLE
Rework rng and particle initialization

### DIFF
--- a/src/include/distribution.hxx
+++ b/src/include/distribution.hxx
@@ -11,20 +11,10 @@ namespace distribution
 {
 
 // ======================================================================
-// Distribution
-// Base class for distributions
-
-template <typename Real>
-struct Distribution
-{
-  virtual Real get() = 0;
-};
-
-// ======================================================================
 // Uniform
 
 template <typename Real>
-struct Uniform : public Distribution<Real>
+struct Uniform
 {
   Uniform(Real min, Real max)
     : dist(min, max),
@@ -33,7 +23,7 @@ struct Uniform : public Distribution<Real>
 
   Uniform() : Uniform(0, 1) {}
 
-  Real get() override { return dist(gen); }
+  Real get() { return dist(gen); }
 
 private:
   std::default_random_engine gen;
@@ -44,7 +34,7 @@ private:
 // Normal
 
 template <typename Real>
-struct Normal : public Distribution<Real>
+struct Normal
 {
   Normal(Real mean, Real stdev)
     : dist(mean, stdev),
@@ -52,7 +42,7 @@ struct Normal : public Distribution<Real>
   {}
   Normal() : Normal(0, 1) {}
 
-  Real get() override { return dist(gen); }
+  Real get() { return dist(gen); }
   // FIXME remove me, or make standalone func
   Real get(Real mean, Real stdev)
   {
@@ -137,7 +127,7 @@ void findPdfSupport(std::function<Real(Real)>& cdf, Real& xmin, Real& xmax,
 }
 
 template <typename Real>
-struct InvertedCdf : public Distribution<Real>
+struct InvertedCdf
 {
   InvertedCdf(std::function<Real(Real)> cdf, int n_points = 100,
               Real tolerance = .0001, int max_n_iter = 50)

--- a/src/include/distribution.hxx
+++ b/src/include/distribution.hxx
@@ -28,6 +28,8 @@ struct Uniform : public Distribution<Real>
       gen(std::chrono::system_clock::now().time_since_epoch().count())
   {}
 
+  Uniform() : Uniform(0, 1) {}
+
   Real get() override { return dist(gen); }
 
 private:

--- a/src/include/distribution.hxx
+++ b/src/include/distribution.hxx
@@ -1,8 +1,11 @@
+#pragma once
+
 #include <vector>
 #include <cmath>
 #include "stdlib.h"
 #include <random>
 #include <chrono>
+#include <functional>
 
 namespace distribution
 {

--- a/src/include/distribution.hxx
+++ b/src/include/distribution.hxx
@@ -1,0 +1,30 @@
+#include <random>
+
+namespace distribution
+{
+
+// ======================================================================
+// Distribution
+// Base class for distributions
+
+template <typename Real>
+struct Distribution
+{
+  virtual Real get() = 0;
+};
+
+// ======================================================================
+// Uniform
+
+template <typename Real>
+struct Uniform : public Distribution<Real>
+{
+  Uniform(Real min, Real max) : dist{min, max} {}
+  Real get() override { return dist(generator); }
+
+private:
+  std::default_random_engine generator;
+  std::uniform_real_distribution<Real> dist;
+};
+
+} // namespace distribution

--- a/src/include/distribution.hxx
+++ b/src/include/distribution.hxx
@@ -1,4 +1,5 @@
 #include <random>
+#include <cmath>
 
 namespace distribution
 {
@@ -25,6 +26,38 @@ struct Uniform : public Distribution<Real>
 private:
   std::default_random_engine generator;
   std::uniform_real_distribution<Real> dist;
+};
+
+// ======================================================================
+// Normal
+
+template <typename Real>
+struct Normal : public Distribution<Real>
+{
+  Normal(Real mean, Real stdev) : mean{mean}, stdev{stdev} {}
+  Normal() : Normal(0, 1) {}
+
+  Real get() override { return get(mean, stdev); }
+  Real get(Real mean, Real stdev)
+  {
+    if (has_next_value) {
+      has_next_value = false;
+      return next_value;
+    }
+
+    // Box-Muller transform to generate 2 independent values at once
+    Real r = stdev * std::sqrt(-2 * std::log(1 - uniform.get()));
+    Real theta = uniform.get() * 2 * M_PI;
+
+    next_value = r * std::cos(theta) + mean;
+    return r * std::sin(theta) + mean;
+  }
+
+private:
+  Uniform<Real> uniform{0, 1};
+  Real mean, stdev;
+  Real next_value;
+  bool has_next_value;
 };
 
 } // namespace distribution

--- a/src/include/distribution.hxx
+++ b/src/include/distribution.hxx
@@ -68,17 +68,17 @@ template <typename Real>
 struct InvertedCdf : public Distribution<Real>
 {
   InvertedCdf(std::function<Real(Real)> cdf, int n_points = 100,
-              Real eps = .0001)
+              Real eps = .0001, int max_n_iter = 50)
   {
     Real xmin = -1, xmax = 1;
 
-    while (cdf(xmin) < eps)
+    for (int n_iter = 0; cdf(xmin) < eps && n_iter < max_n_iter; ++n_iter)
       xmin += .5;
-    while (cdf(xmin) > eps)
+    for (int n_iter = 0; cdf(xmin) > eps && n_iter < max_n_iter; ++n_iter)
       xmin -= 1 / 16.;
-    while (cdf(xmax) > 1 - eps)
+    for (int n_iter = 0; cdf(xmax) > 1 - eps && n_iter < max_n_iter; ++n_iter)
       xmax -= .5;
-    while (cdf(xmax) < 1 - eps)
+    for (int n_iter = 0; cdf(xmax) < 1 - eps && n_iter < max_n_iter; ++n_iter)
       xmax += 1 / 16.;
 
     x.push_back(xmin);

--- a/src/include/distribution.hxx
+++ b/src/include/distribution.hxx
@@ -97,12 +97,24 @@ struct InvertedCdf : public Distribution<Real>
     Real u = uniform.get();
     int guess_idx = cdf.size() * u;
 
-    while (cdf[guess_idx] > u)
-      --guess_idx;
-    while (cdf[guess_idx] < u)
-      ++guess_idx;
+    while (u < cdf[guess_idx]) {
+      --guess_idx; // decrease cdf
+    }
+    while (u > cdf[guess_idx]) {
+      ++guess_idx; // increase cdf
+    }
 
-    return x[guess_idx];
+    Real d_cdf = cdf[guess_idx] - cdf[guess_idx - 1];
+    if (d_cdf == 0.)
+      return x[guess_idx];
+
+    // now: cdf[guess_idx-1] <= u < cdf[guess_idx]
+    // so linearly interpolate between points
+
+    Real w1 = (cdf[guess_idx] - u) / d_cdf;
+    Real w2 = (u - cdf[guess_idx - 1]) / d_cdf;
+
+    return w1 * x[guess_idx - 1] + w2 * x[guess_idx];
   }
 
 private:

--- a/src/include/psc.hxx
+++ b/src/include/psc.hxx
@@ -782,27 +782,28 @@ Psc<PscConfig, Diagnostics, InjectParticles> makePscIntegrator(
 // ======================================================================
 // partitionAndSetupParticles
 
-template <typename SetupParticles, typename Balance, typename Mparticles>
+template <typename SetupParticles, typename Balance, typename Mparticles,
+          typename InitFunc>
 void partitionAndSetupParticles(SetupParticles& setup_particles,
                                 Balance& balance, Grid_t*& grid_ptr,
-                                Mparticles& mprts, InitNptFunc init_npt)
+                                Mparticles& mprts, InitFunc init_np)
 {
-  partitionParticles(setup_particles, balance, grid_ptr, mprts, init_npt);
-  setupParticles(setup_particles, mprts, init_npt);
+  partitionParticles(setup_particles, balance, grid_ptr, mprts, init_np);
+  setupParticles(setup_particles, mprts, init_np);
 }
 
 // ----------------------------------------------------------------------
 // partitionParticles
 
-template <typename SetupParticles, typename Balance, typename Mparticles>
+template <typename SetupParticles, typename Balance, typename Mparticles,
+          typename InitFunc>
 void partitionParticles(SetupParticles& setup_particles, Balance& balance,
-                        Grid_t*& grid_ptr, Mparticles& mprts,
-                        InitNptFunc init_npt)
+                        Grid_t*& grid_ptr, Mparticles& mprts, InitFunc init_np)
 {
   auto comm = grid_ptr->comm();
   mpi_printf(comm, "**** Partitioning...\n");
 
-  auto n_prts_by_patch = setup_particles.partition(*grid_ptr, init_npt);
+  auto n_prts_by_patch = setup_particles.partition(*grid_ptr, init_np);
 
   balance.initial(grid_ptr, n_prts_by_patch);
   // !!! FIXME! grid is now invalid
@@ -815,12 +816,12 @@ void partitionParticles(SetupParticles& setup_particles, Balance& balance,
 // ----------------------------------------------------------------------
 // setupParticles
 
-template <typename SetupParticles, typename Mparticles>
+template <typename SetupParticles, typename Mparticles, typename InitFunc>
 void setupParticles(SetupParticles& setup_particles, Mparticles& mprts,
-                    InitNptFunc init_npt)
+                    InitFunc init_np)
 {
   mpi_printf(MPI_COMM_WORLD, "**** Setting up particles...\n");
-  setup_particles.setupParticles(mprts, init_npt);
+  setup_particles.setupParticles(mprts, init_np);
 }
 
 // ======================================================================

--- a/src/include/rng.hxx
+++ b/src/include/rng.hxx
@@ -7,7 +7,7 @@
 #include <chrono>
 #include <functional>
 
-namespace distribution
+namespace rng
 {
 
 // ======================================================================
@@ -176,4 +176,4 @@ private:
   Uniform<Real> uniform{0, 1};
 };
 
-} // namespace distribution
+} // namespace rng

--- a/src/include/setup_particles.hxx
+++ b/src/include/setup_particles.hxx
@@ -155,21 +155,15 @@ struct SetupParticles
   psc::particle::Inject setupParticle(const psc_particle_npt& npt, Double3 pos,
                                       double wni)
   {
-    static distribution::Uniform<float> dist(0, 1);
+    static distribution::Normal<double> dist;
     double beta = norm_.beta;
 
     assert(npt.kind >= 0 && npt.kind < kinds_.size());
     double m = kinds_[npt.kind].m;
 
-    double pxi = npt.p[0] + sqrtf(-2.f * npt.T[0] / m * sqr(beta) *
-                                  logf(1.0 - dist.get())) *
-                              cosf(2.f * M_PI * dist.get());
-    double pyi = npt.p[1] + sqrtf(-2.f * npt.T[1] / m * sqr(beta) *
-                                  logf(1.0 - dist.get())) *
-                              cosf(2.f * M_PI * dist.get());
-    double pzi = npt.p[2] + sqrtf(-2.f * npt.T[2] / m * sqr(beta) *
-                                  logf(1.0 - dist.get())) *
-                              cosf(2.f * M_PI * dist.get());
+    double pxi = dist.get(npt.p[0], beta * std::sqrt(npt.T[0] / m));
+    double pyi = dist.get(npt.p[1], beta * std::sqrt(npt.T[1] / m));
+    double pzi = dist.get(npt.p[2], beta * std::sqrt(npt.T[2] / m));
 
     if (initial_momentum_gamma_correction) {
       double gam;

--- a/src/include/setup_particles.hxx
+++ b/src/include/setup_particles.hxx
@@ -134,7 +134,7 @@ struct SetupParticles
               npt.kind = pop;
             }
             init_npt(pop, pos, patch, index, npt);
-            auto np = npt_to_np(npt);
+            psc_particle_np np{npt.kind, npt.n, createMaxwellian(npt), npt.tag};
 
             int n_in_cell;
             if (pop != neutralizing_population) {
@@ -160,14 +160,6 @@ struct SetupParticles
                                       double wni)
   {
     return psc::particle::Inject{pos, np.p(), wni, np.kind, np.tag};
-  }
-
-  // ----------------------------------------------------------------------
-  // npt_to_np
-
-  psc_particle_np npt_to_np(const psc_particle_npt& npt)
-  {
-    return psc_particle_np{npt.kind, npt.n, createMaxwellian(npt), npt.tag};
   }
 
   // ----------------------------------------------------------------------

--- a/src/include/setup_particles.hxx
+++ b/src/include/setup_particles.hxx
@@ -4,6 +4,7 @@
 #include <functional>
 #include <type_traits>
 #include "centering.hxx"
+#include "distribution.hxx"
 
 struct psc_particle_npt
 {
@@ -154,31 +155,21 @@ struct SetupParticles
   psc::particle::Inject setupParticle(const psc_particle_npt& npt, Double3 pos,
                                       double wni)
   {
+    static distribution::Uniform<float> dist(0, 1);
     double beta = norm_.beta;
 
     assert(npt.kind >= 0 && npt.kind < kinds_.size());
     double m = kinds_[npt.kind].m;
 
-    float ran1, ran2, ran3, ran4, ran5, ran6;
-    do {
-      ran1 = random() / ((float)RAND_MAX + 1);
-      ran2 = random() / ((float)RAND_MAX + 1);
-      ran3 = random() / ((float)RAND_MAX + 1);
-      ran4 = random() / ((float)RAND_MAX + 1);
-      ran5 = random() / ((float)RAND_MAX + 1);
-      ran6 = random() / ((float)RAND_MAX + 1);
-    } while (ran1 >= 1.f || ran2 >= 1.f || ran3 >= 1.f || ran4 >= 1.f ||
-             ran5 >= 1.f || ran6 >= 1.f);
-
-    double pxi =
-      npt.p[0] + sqrtf(-2.f * npt.T[0] / m * sqr(beta) * logf(1.0 - ran1)) *
-                   cosf(2.f * M_PI * ran2);
-    double pyi =
-      npt.p[1] + sqrtf(-2.f * npt.T[1] / m * sqr(beta) * logf(1.0 - ran3)) *
-                   cosf(2.f * M_PI * ran4);
-    double pzi =
-      npt.p[2] + sqrtf(-2.f * npt.T[2] / m * sqr(beta) * logf(1.0 - ran5)) *
-                   cosf(2.f * M_PI * ran6);
+    double pxi = npt.p[0] + sqrtf(-2.f * npt.T[0] / m * sqr(beta) *
+                                  logf(1.0 - dist.get())) *
+                              cosf(2.f * M_PI * dist.get());
+    double pyi = npt.p[1] + sqrtf(-2.f * npt.T[1] / m * sqr(beta) *
+                                  logf(1.0 - dist.get())) *
+                              cosf(2.f * M_PI * dist.get());
+    double pzi = npt.p[2] + sqrtf(-2.f * npt.T[2] / m * sqr(beta) *
+                                  logf(1.0 - dist.get())) *
+                              cosf(2.f * M_PI * dist.get());
 
     if (initial_momentum_gamma_correction) {
       double gam;

--- a/src/include/setup_particles.hxx
+++ b/src/include/setup_particles.hxx
@@ -84,17 +84,12 @@ struct SetupParticles
 
   int get_n_in_cell(const psc_particle_npt& npt)
   {
+    static distribution::Uniform<float> dist{0, 1};
     if (npt.n == 0) {
       return 0;
     }
     if (fractional_n_particles_per_cell) {
-      int n_prts = npt.n / norm_.cori;
-      float rmndr = npt.n / norm_.cori - n_prts;
-      float ran = random() / ((float)RAND_MAX + 1);
-      if (ran < rmndr) {
-        n_prts++;
-      }
-      return n_prts;
+      return npt.n / norm_.cori + dist.get();
     }
     return npt.n / norm_.cori + .5;
   }

--- a/src/include/setup_particles.hxx
+++ b/src/include/setup_particles.hxx
@@ -180,16 +180,23 @@ struct SetupParticles
   psc::particle::Inject setupParticle(const psc_particle_npt& npt, Double3 pos,
                                       double wni)
   {
-    assert(npt.kind >= 0 && npt.kind < kinds_.size());
-    return setupParticle(psc_particle_np(npt, kinds_[npt.kind].m, norm_.beta,
-                                         initial_momentum_gamma_correction),
-                         pos, wni);
+    return setupParticle(npt_to_np(npt), pos, wni);
   }
 
   psc::particle::Inject setupParticle(const psc_particle_np& np, Double3 pos,
                                       double wni)
   {
     return psc::particle::Inject{pos, np.p(), wni, np.kind, np.tag};
+  }
+
+  // ----------------------------------------------------------------------
+  // npt_to_np
+
+  psc_particle_np npt_to_np(const psc_particle_npt& npt)
+  {
+    assert(npt.kind >= 0 && npt.kind < kinds_.size());
+    return psc_particle_np(npt, kinds_[npt.kind].m, norm_.beta,
+                           initial_momentum_gamma_correction);
   }
 
   // ----------------------------------------------------------------------

--- a/src/include/setup_particles.hxx
+++ b/src/include/setup_particles.hxx
@@ -4,7 +4,7 @@
 #include <functional>
 #include <type_traits>
 #include "centering.hxx"
-#include "distribution.hxx"
+#include "rng.hxx"
 
 struct psc_particle_npt
 {
@@ -115,7 +115,7 @@ struct SetupParticles
 
   int get_n_in_cell(const psc_particle_np& np)
   {
-    static distribution::Uniform<float> dist{0, 1};
+    static rng::Uniform<float> dist{0, 1};
     if (np.n == 0) {
       return 0;
     }
@@ -194,7 +194,7 @@ struct SetupParticles
     double m = kinds_[npt.kind].m;
 
     return [=]() {
-      static distribution::Normal<double> dist;
+      static rng::Normal<double> dist;
 
       Double3 p;
       for (int i = 0; i < 3; i++)

--- a/src/include/setup_particles.hxx
+++ b/src/include/setup_particles.hxx
@@ -156,21 +156,19 @@ struct SetupParticles
     assert(npt.kind >= 0 && npt.kind < kinds_.size());
     double m = kinds_[npt.kind].m;
 
-    double pxi = dist.get(npt.p[0], beta * std::sqrt(npt.T[0] / m));
-    double pyi = dist.get(npt.p[1], beta * std::sqrt(npt.T[1] / m));
-    double pzi = dist.get(npt.p[2], beta * std::sqrt(npt.T[2] / m));
+    Double3 p;
+    for (int i = 0; i < 3; i++)
+      p[i] = dist.get(npt.p[i], beta * std::sqrt(npt.T[i] / m));
 
     if (initial_momentum_gamma_correction) {
-      double gam;
-      if (sqr(pxi) + sqr(pyi) + sqr(pzi) < 1.) {
-        gam = 1. / sqrt(1. - sqr(pxi) - sqr(pyi) - sqr(pzi));
-        pxi *= gam;
-        pyi *= gam;
-        pzi *= gam;
+      double p_squared = sqr(p[0]) + sqr(p[1]) + sqr(p[2]);
+      if (p_squared < 1.) {
+        double gamma = 1. / sqrt(1. - p_squared);
+        p *= gamma;
       }
     }
 
-    return psc::particle::Inject{pos, {pxi, pyi, pzi}, wni, npt.kind, npt.tag};
+    return psc::particle::Inject{pos, p, wni, npt.kind, npt.tag};
   }
 
   // ----------------------------------------------------------------------

--- a/src/include/setup_particles.hxx
+++ b/src/include/setup_particles.hxx
@@ -177,12 +177,6 @@ struct SetupParticles
   // ----------------------------------------------------------------------
   // setupParticle
 
-  psc::particle::Inject setupParticle(const psc_particle_npt& npt, Double3 pos,
-                                      double wni)
-  {
-    return setupParticle(npt_to_np(npt), pos, wni);
-  }
-
   psc::particle::Inject setupParticle(const psc_particle_np& np, Double3 pos,
                                       double wni)
   {
@@ -236,7 +230,7 @@ struct SetupParticles
                       } else {
                         wni = npt.n / (n_in_cell * norm_.cori);
                       }
-                      auto prt = setupParticle(npt, pos, wni);
+                      auto prt = setupParticle(npt_to_np(npt), pos, wni);
                       injector(prt);
                     }
                   });

--- a/src/include/setup_particles.hxx
+++ b/src/include/setup_particles.hxx
@@ -214,6 +214,11 @@ struct SetupParticles
   // ----------------------------------------------------------------------
   // setup_particles
 
+  void operator()(Mparticles& mprts, InitNpFunc init_np)
+  {
+    setupParticles(mprts, init_np);
+  }
+
   void operator()(Mparticles& mprts, InitNptFunc init_npt)
   {
     setupParticles(mprts, init_npt);
@@ -240,6 +245,11 @@ struct SetupParticles
 
   void setupParticles(Mparticles& mprts, InitNptFunc init_npt)
   {
+    setupParticles(mprts, initNpt_to_initNp(init_npt));
+  }
+
+  void setupParticles(Mparticles& mprts, InitNpFunc init_np)
+  {
     static int pr;
     if (!pr) {
       pr = prof_register("setupp", 1., 0, 0);
@@ -255,7 +265,7 @@ struct SetupParticles
     for (int p = 0; p < mprts.n_patches(); ++p) {
       auto injector = inj[p];
 
-      op_cellwise(grid, p, initNpt_to_initNp(init_npt),
+      op_cellwise(grid, p, init_np,
                   [&](int n_in_cell, psc_particle_np& np, Double3& pos) {
                     for (int cnt = 0; cnt < n_in_cell; cnt++) {
                       real_t wni;
@@ -278,10 +288,15 @@ struct SetupParticles
 
   std::vector<uint> partition(const Grid_t& grid, InitNptFunc init_npt)
   {
+    return partition(grid, initNpt_to_initNp(init_npt));
+  }
+
+  std::vector<uint> partition(const Grid_t& grid, InitNpFunc init_np)
+  {
     std::vector<uint> n_prts_by_patch(grid.n_patches());
 
     for (int p = 0; p < grid.n_patches(); ++p) {
-      op_cellwise(grid, p, initNpt_to_initNp(init_npt),
+      op_cellwise(grid, p, init_np,
                   [&](int n_in_cell, psc_particle_np&, Double3&) {
                     n_prts_by_patch[p] += n_in_cell;
                   });

--- a/src/psc_bgk.cxx
+++ b/src/psc_bgk.cxx
@@ -220,7 +220,7 @@ void initializeParticles(Balance& balance, Grid_t*& grid_ptr, Mparticles& mprts,
 
   auto&& qDensity = -psc::mflds::interior(divGradPhi.grid(), divGradPhi.gt());
 
-  auto npt_init = [&](int kind, double crd[3], int p, Int3 idx,
+  auto npt_init = [&](int kind, Double3 crd, int p, Int3 idx,
                       psc_particle_npt& npt) {
     double y = getCoord(crd[1]);
     double z = getCoord(crd[2]);
@@ -255,9 +255,8 @@ void initializeParticles(Balance& balance, Grid_t*& grid_ptr, Mparticles& mprts,
     }
   };
 
-  partitionParticlesGeneralInit(setup_particles, balance, grid_ptr, mprts,
-                                npt_init);
-  setupParticlesGeneralInit(setup_particles, mprts, npt_init);
+  partitionAndSetupParticles(setup_particles, balance, grid_ptr, mprts,
+                             npt_init);
 }
 
 // ======================================================================


### PR DESCRIPTION
This pr does two things:
1. move rng to `src/include/rng.hxx`, which is based on the `<random>` library
2. rework `setup_particles.hxx` to support arbitrary momentum-space distribution functions

The changes shouldn't require refactoring of existing cases, and may be more ergonomic.

Original pr: #313 
