### PR TITLE
Write length and corner in gauss output

### DIFF
--- a/src/include/writer_adios2.hxx
+++ b/src/include/writer_adios2.hxx
@@ -80,6 +80,8 @@ public:
     file_.beginStep(kg::io::StepMode::Append);
     file_.put("step", step);
     file_.put("time", time);
+    file_.put("length", grid.domain.length);
+    file_.put("corner", grid.domain.corner);
     file_.performPuts();
   }
 

--- a/src/include/writer_adios2.hxx
+++ b/src/include/writer_adios2.hxx
@@ -71,11 +71,9 @@ public:
 
   void begin_step(const Grid_t& grid)
   {
-    begin_step(grid.timestep(), grid.timestep() * grid.dt);
-  }
+    int step = grid.timestep();
+    double time = grid.timestep() * grid.dt;
 
-  void begin_step(int step, double time)
-  {
     char filename[dir_.size() + pfx_.size() + 20];
     sprintf(filename, "%s/%s.%09d.bp", dir_.c_str(), pfx_.c_str(), step);
     file_ = io_.open(filename, kg::io::Mode::Write, comm_, pfx_);

--- a/src/libpsc/psc_checks/checks_impl.hxx
+++ b/src/libpsc/psc_checks/checks_impl.hxx
@@ -94,7 +94,7 @@ public:
       if (!writer_) {
         writer_.open("continuity");
       }
-      writer_.begin_step(grid.timestep(), grid.timestep() * grid.dt);
+      writer_.begin_step(grid);
       writer_.write(dt_divj, grid, "dt_divj", {"dt_divj"});
       writer_.write(d_rho, grid, "d_rho", {"d_rho"});
       writer_.end_step();
@@ -173,7 +173,7 @@ public:
       if (!writer_) {
         writer_.open("gauss");
       }
-      writer_.begin_step(grid.timestep(), grid.timestep() * grid.dt);
+      writer_.begin_step(grid);
       writer_.write(rho, grid, "rho", {"rho"});
       writer_.write(dive, grid, "dive", {"dive"});
       writer_.end_step();


### PR DESCRIPTION
pfd and pfd_moments outputs have included `length` and `corner` since #309, but that PR missed this second way of writing .bp files that is used by gauss output. Perhaps the two methods could be consolidated in a future PR.