### PR TITLE
io/adios2: adapt to changed adios2 API (no more DebugOn)

### DIFF
--- a/src/kg/include/kg/io/IOAdios2.inl
+++ b/src/kg/include/kg/io/IOAdios2.inl
@@ -4,9 +4,7 @@ namespace kg
 namespace io
 {
 
-inline IOAdios2::IOAdios2()
-  : ad_{"adios2cfg.xml", MPI_COMM_WORLD, adios2::DebugON}
-{}
+inline IOAdios2::IOAdios2() : ad_{"adios2cfg.xml", MPI_COMM_WORLD} {}
 
 inline File IOAdios2::openFile(const std::string& name, const Mode mode,
                                MPI_Comm comm, const std::string& io_name)


### PR DESCRIPTION
I guess it would have been nicer for ADIOS2 to not break their API some time after 2.4, but it's easy enough to deal with.