### PR TITLE
OutputParticles work

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -101,3 +101,4 @@ spack-build-out.txt
 spack-configure-args.txt
 .vscode/
 **/psc*params.txt
+.venv/

--- a/src/include/binary_collision.hxx
+++ b/src/include/binary_collision.hxx
@@ -20,7 +20,7 @@ struct RngC
   {
     real_t ran;
     do {
-      ran = real_t(random()) / RAND_MAX;
+      ran = real_t(random()) / real_t(RAND_MAX);
     } while (ran == real_t(0.f));
 
     return ran;

--- a/src/include/ddc_particles.hxx
+++ b/src/include/ddc_particles.hxx
@@ -246,7 +246,7 @@ inline ddc_particles<MP>::ddc_particles(const Grid_t& grid)
   n_recv_ranks = 0;
   for (int r = 0; r < size; r++) {
     if (info[r].n_recv_entries) {
-      MPI_Irecv(info[r].recv_entry.data(),
+      MPI_Irecv((int*)info[r].recv_entry.data(),
                 sizeof(drecv_entry) / sizeof(int) * info[r].n_recv_entries,
                 MPI_INT, r, 111, comm, &recv_reqs_[n_recv_ranks++]);
     }
@@ -255,7 +255,7 @@ inline ddc_particles<MP>::ddc_particles(const Grid_t& grid)
   n_send_ranks = 0;
   for (int r = 0; r < size; r++) {
     if (info[r].n_send_entries) {
-      MPI_Isend(info[r].send_entry.data(),
+      MPI_Isend((int*)info[r].send_entry.data(),
                 sizeof(dsend_entry) / sizeof(int) * info[r].n_send_entries,
                 MPI_INT, r, 111, comm, &send_reqs_[n_send_ranks++]);
     }

--- a/src/include/writer_adios2.hxx
+++ b/src/include/writer_adios2.hxx
@@ -74,8 +74,9 @@ public:
     int step = grid.timestep();
     double time = grid.timestep() * grid.dt;
 
-    char filename[dir_.size() + pfx_.size() + 20];
-    sprintf(filename, "%s/%s.%09d.bp", dir_.c_str(), pfx_.c_str(), step);
+    int len = dir_.size() + pfx_.size() + 20;
+    char filename[len];
+    snprintf(filename, len, "%s/%s.%09d.bp", dir_.c_str(), pfx_.c_str(), step);
     file_ = io_.open(filename, kg::io::Mode::Write, comm_, pfx_);
     file_.beginStep(kg::io::StepMode::Append);
     file_.put("step", step);
@@ -157,9 +158,9 @@ public:
     Double3 length = grid.domain.length;
     Double3 corner = grid.domain.corner;
 
-    auto write_func = [this, step, time, h_expr = move(h_expr), name,
+    auto write_func = [this, step, time, h_expr = std::move(h_expr), name,
                        comp_names, ldims, gdims, length, corner,
-                       patch_off = move(patch_off)]() {
+                       patch_off = std::move(patch_off)]() {
       // std::this_thread::sleep_for(std::chrono::milliseconds(1000));
 
       prof_start(pr_thread);
@@ -170,8 +171,10 @@ public:
       Int3 ib = {-(im[0] - ldims[0]) / 2, -(im[1] - ldims[1]) / 2,
                  -(im[2] - ldims[2]) / 2};
 
-      char filename[dir_.size() + pfx_.size() + 20];
-      sprintf(filename, "%s/%s.%09d.bp", dir_.c_str(), pfx_.c_str(), step);
+      int len = dir_.size() + pfx_.size() + 20;
+      char filename[len];
+      snprintf(filename, len, "%s/%s.%09d.bp", dir_.c_str(), pfx_.c_str(),
+               step);
       {
         auto launch = kg::io::Mode::Blocking;
 

--- a/src/libpsc/psc_balance/psc_balance_impl.hxx
+++ b/src/libpsc/psc_balance/psc_balance_impl.hxx
@@ -204,7 +204,7 @@ inline void write_loads(const input& input,
                         int timestep)
 {
   char s[20];
-  sprintf(s, "loads2-%06d.asc", timestep);
+  snprintf(s, 20, "loads2-%06d.asc", timestep);
   FILE* f = fopen(s, "w");
 
   int gp = 0;

--- a/src/libpsc/psc_output_particles/output_particles_ascii_impl.hxx
+++ b/src/libpsc/psc_output_particles/output_particles_ascii_impl.hxx
@@ -22,9 +22,10 @@ struct OutputParticlesAscii
 
     int rank;
     MPI_Comm_rank(comm_, &rank);
-    char filename[strlen(data_dir) + strlen(basename) + 21];
-    sprintf(filename, "%s/%s.%06d_p%06d.asc", data_dir, basename,
-            grid.timestep(), rank);
+    int slen = strlen(data_dir) + strlen(basename) + 21;
+    char filename[slen];
+    snprintf(filename, slen, "%s/%s.%06d_p%06d.asc", data_dir, basename,
+             grid.timestep(), rank);
 
     FILE* file = fopen(filename, "w");
     auto accessor = mprts.accessor();

--- a/src/libpsc/psc_output_particles/output_particles_hdf5_impl.hxx
+++ b/src/libpsc/psc_output_particles/output_particles_hdf5_impl.hxx
@@ -227,8 +227,8 @@ struct OutputParticlesHdf5
 
     assert(sizeof(size_t) == sizeof(unsigned long));
     size_t n_total, n_off = 0;
-    MPI_Allreduce(&n_write, &n_total, 1, MPI_LONG, MPI_SUM, comm_);
-    MPI_Exscan(&n_write, &n_off, 1, MPI_LONG, MPI_SUM, comm_);
+    MPI_Allreduce(&n_write, &n_total, 1, MPI_UNSIGNED_LONG, MPI_SUM, comm_);
+    MPI_Exscan(&n_write, &n_off, 1, MPI_UNSIGNED_LONG, MPI_SUM, comm_);
 
     struct hdf5_prt* arr = (struct hdf5_prt*)malloc(n_write * sizeof(*arr));
 
@@ -470,8 +470,8 @@ struct OutputParticlesHdf5
         }
         recv_buf[r] = (size_t*)malloc(2 * remote_sz[r] * sizeof(*recv_buf[r]));
         recv_buf_p[r] = recv_buf[r];
-        MPI_Irecv(recv_buf[r], 2 * remote_sz[r], MPI_LONG, r, 0x4000, comm_,
-                  &recv_req[r]);
+        MPI_Irecv(recv_buf[r], 2 * remote_sz[r], MPI_UNSIGNED_LONG, r, 0x4000,
+                  comm_, &recv_req[r]);
       }
       MPI_Waitall(size, recv_req, MPI_STATUSES_IGNORE);
       free(recv_req);
@@ -530,7 +530,7 @@ struct OutputParticlesHdf5
         l_idx_p += 2 * sz;
       }
 
-      MPI_Send(l_idx, 2 * local_sz, MPI_LONG, 0, 0x4000, comm_);
+      MPI_Send(l_idx, 2 * local_sz, MPI_UNSIGNED_LONG, 0, 0x4000, comm_);
 
       free(l_idx);
     }

--- a/src/libpsc/psc_output_particles/output_particles_hdf5_impl.hxx
+++ b/src/libpsc/psc_output_particles/output_particles_hdf5_impl.hxx
@@ -90,14 +90,8 @@ class OutputParticlesWriterHDF5
 {
 public:
   explicit OutputParticlesWriterHDF5(const Int3& lo, const Int3& hi,
-                                     const Grid_t::Kinds& kinds, MPI_Comm comm,
-                                     hid_t prt_type)
-    : lo_{lo},
-      hi_{hi},
-      wdims_{hi - lo},
-      kinds_{kinds},
-      comm_{comm},
-      prt_type_{prt_type}
+                                     const Grid_t::Kinds& kinds, MPI_Comm comm)
+    : lo_{lo}, hi_{hi}, wdims_{hi - lo}, kinds_{kinds}, comm_{comm}
   {}
 
   void operator()(const gt::gtensor<size_t, 4>& gidx_begin,
@@ -272,7 +266,7 @@ private:
   Int3 wdims_, lo_, hi_;
   Grid_t::Kinds kinds_;
   MPI_Comm comm_;
-  hid_t prt_type_;
+  Hdf5ParticleType prt_type_;
 };
 
 namespace detail
@@ -286,8 +280,7 @@ struct OutputParticlesHdf5
 {
   using Particles = typename Mparticles::Patch;
 
-  OutputParticlesHdf5(const Grid_t& grid, const Int3& lo, const Int3& hi,
-                      hid_t prt_type)
+  OutputParticlesHdf5(const Grid_t& grid, const Int3& lo, const Int3& hi)
     : lo_{lo}, hi_{hi}, wdims_{hi - lo}, kinds_{grid.kinds}, comm_{grid.comm()}
   {}
 
@@ -637,7 +630,7 @@ public:
     : prm_{params},
       lo_{params.lo},
       hi_{adjust_hi(grid, params.hi)},
-      writer_{lo_, hi_, grid.kinds, grid.comm(), prt_type_}
+      writer_{lo_, hi_, grid.kinds, grid.comm()}
   {}
 
   template <typename Mparticles>
@@ -654,7 +647,7 @@ public:
     snprintf(filename, slen, "%s/%s.%06d_p%06d.h5", prm_.data_dir,
              prm_.basename, grid.timestep(), 0);
 
-    detail::OutputParticlesHdf5<Mparticles> impl{grid, lo_, hi_, prt_type_};
+    detail::OutputParticlesHdf5<Mparticles> impl{grid, lo_, hi_};
     impl(mprts, filename, prm_, writer_);
   }
 
@@ -692,7 +685,6 @@ public:
 
 private:
   const OutputParticlesParams prm_;
-  Hdf5ParticleType prt_type_;
   Int3 lo_; // dimensions of the subdomain we're actually writing
   Int3 hi_;
   OutputParticlesWriterHDF5 writer_;

--- a/src/libpsc/psc_output_particles/output_particles_hdf5_impl.hxx
+++ b/src/libpsc/psc_output_particles/output_particles_hdf5_impl.hxx
@@ -202,7 +202,7 @@ struct OutputParticlesHdf5
   hdf5_prt* make_local_particle_array(Mparticles& mprts,
                                       const std::vector<std::vector<int>>& off,
                                       const std::vector<std::vector<int>>& map,
-                                      std::vector<size_t*>& idx,
+                                      std::vector<std::vector<size_t>>& idx,
                                       size_t* p_n_write, size_t* p_n_off,
                                       size_t* p_n_total)
   {
@@ -244,7 +244,7 @@ struct OutputParticlesHdf5
         const auto& patch = grid.patches[p];
         int ilo[3], ihi[3], ld[3];
         int sz = find_patch_bounds(grid.ldims, patch.off, ilo, ihi, ld);
-        idx[p] = (size_t*)malloc(2 * sz * sizeof(size_t));
+        idx[p].resize(2 * sz);
 
         for (int jz = ilo[2]; jz < ihi[2]; jz++) {
           for (int jy = ilo[1]; jy < ihi[1]; jy++) {
@@ -391,7 +391,7 @@ struct OutputParticlesHdf5
 
     std::vector<std::vector<int>> off(mprts.n_patches());
     std::vector<std::vector<int>> map(mprts.n_patches());
-    std::vector<size_t*> idx(mprts.n_patches());
+    std::vector<std::vector<size_t>> idx(mprts.n_patches());
 
     count_sort(mprts, off, map);
 
@@ -516,7 +516,7 @@ struct OutputParticlesHdf5
         const auto& patch = grid.patches[p];
         int ilo[3], ihi[3], ld[3];
         int sz = find_patch_bounds(grid.ldims, patch.off, ilo, ihi, ld);
-        memcpy(l_idx_p, idx[p], 2 * sz * sizeof(*l_idx_p));
+        memcpy(l_idx_p, idx[p].data(), 2 * sz * sizeof(*l_idx_p));
         l_idx_p += 2 * sz;
       }
 
@@ -593,10 +593,6 @@ struct OutputParticlesHdf5
     prof_stop(pr_E);
 
     free(arr);
-
-    for (int p = 0; p < mprts.n_patches(); p++) {
-      free(idx[p]);
-    }
   }
 
 private:

--- a/src/libpsc/psc_output_particles/output_particles_hdf5_impl.hxx
+++ b/src/libpsc/psc_output_particles/output_particles_hdf5_impl.hxx
@@ -123,23 +123,18 @@ struct OutputParticlesHdf5
     const Grid_t& grid = prts.grid();
     const int* ldims = grid.ldims;
 
-    int j0 = prts.cellPosition(prt.x[0], 0);
-    int j1 = prts.cellPosition(prt.x[1], 1);
-    int j2 = prts.cellPosition(prt.x[2], 2);
-    // FIXME, this is hoping that reason is that we were just on the right
-    // bnd...
-    if (j0 == ldims[0])
-      j0--;
-    if (j1 == ldims[1])
-      j1--;
-    if (j2 == ldims[2])
-      j2--;
-    assert(j0 >= 0 && j0 < ldims[0]);
-    assert(j1 >= 0 && j1 < ldims[1]);
-    assert(j2 >= 0 && j2 < ldims[2]);
+    Int3 pos;
+    for (int d = 0; d < 3; d++) {
+      pos[d] = prts.cellPosition(prt.x[d], d);
+      // FIXME, this is hoping that reason is that we were just on the right
+      // bnd...
+      if (pos[d] == ldims[d])
+        pos[d]--;
+      assert(pos[d] >= 0 && pos[d] < ldims[d]);
+    }
     assert(prt.kind < grid.kinds.size());
 
-    return sort_index(ldims, grid.kinds.size(), {j0, j1, j2}, prt.kind);
+    return sort_index(ldims, grid.kinds.size(), pos, prt.kind);
   }
 
   // ----------------------------------------------------------------------

--- a/src/libpsc/psc_output_particles/output_particles_hdf5_impl.hxx
+++ b/src/libpsc/psc_output_particles/output_particles_hdf5_impl.hxx
@@ -43,9 +43,6 @@ struct hdf5_prt
 #define H5_CHK(ierr) assert(ierr >= 0)
 #define CE assert(ierr == 0)
 
-#define MIN(a, b) ((a) < (b) ? (a) : (b))
-#define MAX(a, b) ((a) > (b) ? (a) : (b))
-
 namespace hdf5
 {
 
@@ -387,10 +384,10 @@ struct OutputParticlesHdf5
                         int ihi[3], int ld[3])
   {
     for (int d = 0; d < 3; d++) {
-      ilo[d] = MAX(lo_[d], off[d]) - off[d];
-      ihi[d] = MIN(hi_[d], off[d] + ldims[d]) - off[d];
-      ilo[d] = MIN(ldims[d], ilo[d]);
-      ihi[d] = MAX(0, ihi[d]);
+      ilo[d] = std::max(lo_[d], off[d]) - off[d];
+      ihi[d] = std::min(hi_[d], off[d] + ldims[d]) - off[d];
+      ilo[d] = std::min(ldims[d], ilo[d]);
+      ihi[d] = std::max(0, ihi[d]);
       ld[d] = ihi[d] - ilo[d];
     }
     return kinds_.size() * ld[0] * ld[1] * ld[2];

--- a/src/libpsc/psc_output_particles/output_particles_hdf5_impl.hxx
+++ b/src/libpsc/psc_output_particles/output_particles_hdf5_impl.hxx
@@ -162,7 +162,7 @@ struct OutputParticlesHdf5
       }
       // prefix sum to get offsets
       int o = 0;
-      int* off2 = (int*)malloc((nr_indices + 1) * sizeof(*off2));
+      std::vector<int> off2(nr_indices + 1);
       for (int si = 0; si <= nr_indices; si++) {
         int cnt = off[p][si];
         off[p][si] = o; // this will be saved for later
@@ -177,7 +177,6 @@ struct OutputParticlesHdf5
         int si = get_sort_index(prts, prt);
         map[p][off2[si]++] = n++;
       }
-      free(off2);
     }
   }
 

--- a/src/libpsc/psc_output_particles/output_particles_hdf5_impl.hxx
+++ b/src/libpsc/psc_output_particles/output_particles_hdf5_impl.hxx
@@ -493,8 +493,8 @@ struct OutputParticlesHdf5
         int sz = find_patch_bounds(grid.ldims, patch.off, ilo, ihi, ld);
         local_sz += sz;
       }
-      size_t* l_idx = (size_t*)malloc(2 * local_sz * sizeof(*l_idx));
-      size_t* l_idx_p = (size_t*)l_idx;
+      std::vector<size_t> l_idx(2 * local_sz);
+      size_t* l_idx_p = l_idx.data();
       for (int p = 0; p < mprts.n_patches(); p++) {
         const auto& patch = grid.patches[p];
         int ilo[3], ihi[3], ld[3];
@@ -503,9 +503,7 @@ struct OutputParticlesHdf5
         l_idx_p += 2 * sz;
       }
 
-      MPI_Send(l_idx, 2 * local_sz, MPI_UNSIGNED_LONG, 0, 0x4000, comm_);
-
-      free(l_idx);
+      MPI_Send(l_idx.data(), l_idx.size(), MPI_UNSIGNED_LONG, 0, 0x4000, comm_);
     }
     prof_stop(pr_B);
 

--- a/src/libpsc/psc_output_particles/output_particles_hdf5_impl.hxx
+++ b/src/libpsc/psc_output_particles/output_particles_hdf5_impl.hxx
@@ -415,22 +415,7 @@ struct OutputParticlesHdf5
     int nr_kinds = grid.kinds.size();
 
     // count all particles to be written locally
-    size_t n_write = 0;
-    for (int p = 0; p < mprts.n_patches(); p++) {
-      auto& patch = grid.patches[p];
-      int ilo[3], ihi[3], ld[3];
-      int sz = find_patch_bounds(grid.ldims, patch.off, ilo, ihi, ld);
-      for (int jz = ilo[2]; jz < ihi[2]; jz++) {
-        for (int jy = ilo[1]; jy < ihi[1]; jy++) {
-          for (int jx = ilo[0]; jx < ihi[0]; jx++) {
-            for (int kind = 0; kind < nr_kinds; kind++) {
-              int si = sort_index(grid.ldims, nr_kinds, {jx, jy, jz}, kind);
-              n_write += off[p][si + 1] - off[p][si];
-            }
-          }
-        }
-      }
-    }
+    size_t n_write = mprts.size();
 
     assert(sizeof(size_t) == sizeof(unsigned long));
     size_t n_total, n_off = 0;

--- a/src/libpsc/psc_output_particles/output_particles_hdf5_impl.hxx
+++ b/src/libpsc/psc_output_particles/output_particles_hdf5_impl.hxx
@@ -13,10 +13,26 @@
 #include "mparticles_cuda.hxx"
 #endif
 
-// needs to be changed accordingly
-
 struct hdf5_prt
 {
+  hdf5_prt() = default;
+
+  template <typename Particle, typename Patch>
+  hdf5_prt(const Particle& prt, const Patch& patch)
+  {
+    x = prt.x()[0] + patch.xb[0];
+    y = prt.x()[1] + patch.xb[1];
+    z = prt.x()[2] + patch.xb[2];
+    px = prt.u()[0];
+    py = prt.u()[1];
+    pz = prt.u()[2];
+    q = prt.q();
+    m = prt.m();
+    w = prt.w();
+    id = prt.id();
+    tag = prt.tag();
+  }
+
   float x, y, z;
   float px, py, pz;
   float q, m, w;
@@ -438,18 +454,7 @@ struct OutputParticlesHdf5
                 idx[p](jx - ilo[0], jy - ilo[1], jz - ilo[2], kind, 1) =
                   nn + n_off + off[p][si + 1] - off[p][si];
                 for (int n = off[p][si]; n < off[p][si + 1]; n++, nn++) {
-                  auto prt = prts[map[p][n]];
-                  arr[nn].x = prt.x()[0] + patch.xb[0];
-                  arr[nn].y = prt.x()[1] + patch.xb[1];
-                  arr[nn].z = prt.x()[2] + patch.xb[2];
-                  arr[nn].px = prt.u()[0];
-                  arr[nn].py = prt.u()[1];
-                  arr[nn].pz = prt.u()[2];
-                  arr[nn].q = prt.q();
-                  arr[nn].m = prt.m();
-                  arr[nn].w = prt.w();
-                  arr[nn].id = prt.id();
-                  arr[nn].tag = prt.tag();
+                  arr[nn] = writer_type::particle_type(prts[map[p][n]], patch);
                 }
               }
             }

--- a/src/libpsc/psc_output_particles/output_particles_hdf5_impl.hxx
+++ b/src/libpsc/psc_output_particles/output_particles_hdf5_impl.hxx
@@ -307,7 +307,8 @@ struct OutputParticlesHdf5
     CE;
   }
 
-  void write_idx(const size_t* gidx_begin, const size_t* gidx_end, hid_t group,
+  void write_idx(const gt::gtensor<size_t, 4>& gidx_begin,
+                 const gt::gtensor<size_t, 4>& gidx_end, hid_t group,
                  hid_t dxpl)
   {
     herr_t ierr;
@@ -336,8 +337,8 @@ struct OutputParticlesHdf5
     hid_t dset = H5Dcreate(group, "idx_begin", H5T_NATIVE_HSIZE, filespace,
                            H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
     H5_CHK(dset);
-    ierr =
-      H5Dwrite(dset, H5T_NATIVE_HSIZE, memspace, filespace, dxpl, gidx_begin);
+    ierr = H5Dwrite(dset, H5T_NATIVE_HSIZE, memspace, filespace, dxpl,
+                    gidx_begin.data());
     CE;
     ierr = H5Dclose(dset);
     CE;
@@ -345,8 +346,8 @@ struct OutputParticlesHdf5
     dset = H5Dcreate(group, "idx_end", H5T_NATIVE_HSIZE, filespace, H5P_DEFAULT,
                      H5P_DEFAULT, H5P_DEFAULT);
     H5_CHK(dset);
-    ierr =
-      H5Dwrite(dset, H5T_NATIVE_HSIZE, memspace, filespace, dxpl, gidx_end);
+    ierr = H5Dwrite(dset, H5T_NATIVE_HSIZE, memspace, filespace, dxpl,
+                    gidx_end.data());
     CE;
     ierr = H5Dclose(dset);
     CE;
@@ -554,7 +555,7 @@ struct OutputParticlesHdf5
     prof_stop(pr_C);
 
     prof_start(pr_D);
-    write_idx(gidx_begin.data(), gidx_end.data(), groupp, dxpl);
+    write_idx(gidx_begin, gidx_end, groupp, dxpl);
     prof_stop(pr_D);
 
     prof_start(pr_E);

--- a/src/libpsc/psc_output_particles/output_particles_hdf5_impl.hxx
+++ b/src/libpsc/psc_output_particles/output_particles_hdf5_impl.hxx
@@ -653,9 +653,10 @@ public:
       return;
     }
 
-    char filename[strlen(prm_.data_dir) + strlen(prm_.basename) + 20];
-    sprintf(filename, "%s/%s.%06d_p%06d.h5", prm_.data_dir, prm_.basename,
-            grid.timestep(), 0);
+    int slen = strlen(prm_.data_dir) + strlen(prm_.basename) + 20;
+    char filename[slen];
+    snprintf(filename, slen, "%s/%s.%06d_p%06d.h5", prm_.data_dir,
+             prm_.basename, grid.timestep(), 0);
 
     detail::OutputParticlesHdf5<Mparticles> impl{grid, lo_, hi_, wdims_,
                                                  prt_type_};

--- a/src/libpsc/psc_output_particles/output_particles_hdf5_impl.hxx
+++ b/src/libpsc/psc_output_particles/output_particles_hdf5_impl.hxx
@@ -392,7 +392,7 @@ struct OutputParticlesHdf5
     std::vector<int*> map(mprts.n_patches());
     std::vector<size_t*> idx(mprts.n_patches());
 
-    count_sort(mprts, map, off);
+    count_sort(mprts, off, map);
 
     size_t *gidx_begin = NULL, *gidx_end = NULL;
     if (rank == 0) {
@@ -417,7 +417,7 @@ struct OutputParticlesHdf5
 
     // find local particle and idx arrays
     size_t n_write, n_off, n_total;
-    hdf5_prt* arr = make_local_particle_array(mprts, map, off, idx, &n_write,
+    hdf5_prt* arr = make_local_particle_array(mprts, off, map, idx, &n_write,
                                               &n_off, &n_total);
     prof_stop(pr_A);
 

--- a/src/libpsc/psc_output_particles/output_particles_hdf5_impl.hxx
+++ b/src/libpsc/psc_output_particles/output_particles_hdf5_impl.hxx
@@ -97,10 +97,10 @@ struct OutputParticlesHdf5
   using Particles = typename Mparticles::Patch;
 
   OutputParticlesHdf5(const Grid_t& grid, const Int3& lo, const Int3& hi,
-                      const Int3& wdims, hid_t prt_type)
+                      hid_t prt_type)
     : lo_{lo},
       hi_{hi},
-      wdims_{wdims},
+      wdims_{hi - lo},
       kinds_{grid.kinds},
       comm_{grid.comm()},
       prt_type_{prt_type}
@@ -641,7 +641,6 @@ public:
       assert(lo_[d] >= 0);
       assert(hi_[d] <= grid.domain.gdims[d]);
     }
-    wdims_ = hi_ - lo_;
   }
 
   template <typename Mparticles>
@@ -658,8 +657,7 @@ public:
     snprintf(filename, slen, "%s/%s.%06d_p%06d.h5", prm_.data_dir,
              prm_.basename, grid.timestep(), 0);
 
-    detail::OutputParticlesHdf5<Mparticles> impl{grid, lo_, hi_, wdims_,
-                                                 prt_type_};
+    detail::OutputParticlesHdf5<Mparticles> impl{grid, lo_, hi_, prt_type_};
     impl(mprts, filename, prm_);
   }
 
@@ -700,5 +698,4 @@ private:
   detail::Hdf5ParticleType prt_type_;
   Int3 lo_; // dimensions of the subdomain we're actually writing
   Int3 hi_;
-  Int3 wdims_;
 };

--- a/src/libpsc/psc_output_particles/output_particles_hdf5_impl.hxx
+++ b/src/libpsc/psc_output_particles/output_particles_hdf5_impl.hxx
@@ -412,7 +412,7 @@ struct OutputParticlesHdf5
     if (rank == 0) {
       int nr_global_patches = grid.nGlobalPatches();
 
-      int* remote_sz = (int*)calloc(size, sizeof(*remote_sz));
+      std::vector<int> remote_sz(size);
       for (int p = 0; p < nr_global_patches; p++) {
         info = grid.globalPatchInfo(p);
         if (info.rank == rank) { // skip local patches
@@ -453,7 +453,7 @@ struct OutputParticlesHdf5
         }
         recv_buf[r].resize(2 * remote_sz[r]);
         recv_buf_p[r] = recv_buf[r].data();
-        MPI_Irecv(recv_buf[r].data(), 2 * remote_sz[r], MPI_UNSIGNED_LONG, r,
+        MPI_Irecv(recv_buf[r].data(), recv_buf[r].size(), MPI_UNSIGNED_LONG, r,
                   0x4000, comm_, &recv_req[r]);
       }
       MPI_Waitall(size, recv_req.data(), MPI_STATUSES_IGNORE);
@@ -484,8 +484,6 @@ struct OutputParticlesHdf5
         }
         recv_buf_p[info.rank] += 2 * sz;
       }
-
-      free(remote_sz);
     } else { // rank != 0: send to rank 0
       // FIXME, alloc idx[] as one array in the first place
       int local_sz = 0;

--- a/src/libpsc/psc_output_particles/output_particles_hdf5_impl.hxx
+++ b/src/libpsc/psc_output_particles/output_particles_hdf5_impl.hxx
@@ -116,9 +116,8 @@ public:
   {}
 
   void operator()(const gt::gtensor<size_t, 4>& gidx_begin,
-                  const gt::gtensor<size_t, 4>& gidx_end, size_t n_write,
-                  size_t n_off, size_t n_total, const particles_type& arr,
-                  int timestep)
+                  const gt::gtensor<size_t, 4>& gidx_end, size_t n_off,
+                  size_t n_total, const particles_type& arr, int timestep)
   {
     int ierr;
 
@@ -191,7 +190,7 @@ public:
     prof_stop(pr_D);
 
     prof_start(pr_E);
-    write_particles(n_write, n_off, n_total, arr, groupp, dxpl);
+    write_particles(n_off, n_total, arr, groupp, dxpl);
     prof_stop(pr_E);
 
     ierr = H5Pclose(dxpl);
@@ -256,12 +255,12 @@ private:
     CE;
   }
 
-  void write_particles(size_t n_write, size_t n_off, size_t n_total,
-                       const particles_type& arr, hid_t group, hid_t dxpl)
+  void write_particles(size_t n_off, size_t n_total, const particles_type& arr,
+                       hid_t group, hid_t dxpl)
   {
     herr_t ierr;
 
-    hsize_t mdims[1] = {n_write};
+    hsize_t mdims[1] = {arr.size()};
     hsize_t fdims[1] = {n_total};
     hsize_t foff[1] = {n_off};
     hid_t memspace = H5Screate_simple(1, mdims, NULL);
@@ -408,8 +407,8 @@ struct OutputParticlesHdf5
   writer_particles_type make_local_particle_array(
     Mparticles& mprts, const std::vector<std::vector<int>>& off,
     const std::vector<std::vector<int>>& map,
-    std::vector<gt::gtensor<size_t, 5>>& idx, size_t* p_n_write,
-    size_t* p_n_off, size_t* p_n_total)
+    std::vector<gt::gtensor<size_t, 5>>& idx, size_t* p_n_off,
+    size_t* p_n_total)
   {
     const auto& grid = mprts.grid();
     int nr_kinds = grid.kinds.size();
@@ -453,7 +452,6 @@ struct OutputParticlesHdf5
         }
       }
     }
-    *p_n_write = n_write;
     *p_n_off = n_off;
     *p_n_total = n_total;
     return arr;
@@ -497,9 +495,9 @@ struct OutputParticlesHdf5
     }
 
     // find local particle and idx arrays
-    size_t n_write, n_off, n_total;
-    auto arr = make_local_particle_array(mprts, off, map, idx, &n_write, &n_off,
-                                         &n_total);
+    size_t n_off, n_total;
+    auto arr =
+      make_local_particle_array(mprts, off, map, idx, &n_off, &n_total);
     prof_stop(pr_A);
 
     prof_start(pr_B);
@@ -601,7 +599,7 @@ struct OutputParticlesHdf5
     }
     prof_stop(pr_B);
 
-    writer(gidx_begin, gidx_end, n_write, n_off, n_total, arr, grid.timestep());
+    writer(gidx_begin, gidx_end, n_off, n_total, arr, grid.timestep());
   }
 
 private:

--- a/src/libpsc/psc_output_particles/output_particles_hdf5_impl.hxx
+++ b/src/libpsc/psc_output_particles/output_particles_hdf5_impl.hxx
@@ -395,16 +395,13 @@ struct OutputParticlesHdf5
 
     count_sort(mprts, off, map);
 
-    std::vector<size_t> gidx_begin, gidx_end;
+    gt::gtensor<size_t, 4> gidx_begin, gidx_end;
     if (rank == 0) {
       // alloc global idx array
-      gidx_begin.resize(nr_kinds * wdims_[0] * wdims_[1] * wdims_[2],
-                        size_t(-1));
-      gidx_end.resize(nr_kinds * wdims_[0] * wdims_[1] * wdims_[2], size_t(-1));
+      gidx_begin =
+        gt::empty<size_t>({wdims_[0], wdims_[1], wdims_[2], nr_kinds});
+      gidx_end = gt::empty<size_t>({wdims_[0], wdims_[1], wdims_[2], nr_kinds});
     }
-    auto gidx_shape = gt::shape(wdims_[0], wdims_[1], wdims_[2], nr_kinds);
-    auto _gidx_begin = gt::adapt(gidx_begin.data(), gidx_shape);
-    auto _gidx_end = gt::adapt(gidx_end.data(), gidx_shape);
 
     // find local particle and idx arrays
     size_t n_write, n_off, n_total;
@@ -443,10 +440,8 @@ struct OutputParticlesHdf5
                 int jj =
                   ((kind * ld[2] + jz - ilo[2]) * ld[1] + jy - ilo[1]) * ld[0] +
                   jx - ilo[0];
-                int ii =
-                  ((kind * wdims_[2] + iz) * wdims_[1] + iy) * wdims_[0] + ix;
-                gidx_begin[ii] = idx[p][jj];
-                gidx_end[ii] = idx[p][jj + sz];
+                gidx_begin(ix, iy, iz, kind) = idx[p][jj];
+                gidx_end(ix, iy, iz, kind) = idx[p][jj + sz];
               }
             }
           }
@@ -487,10 +482,8 @@ struct OutputParticlesHdf5
                 int jj =
                   ((kind * ld[2] + jz - ilo[2]) * ld[1] + jy - ilo[1]) * ld[0] +
                   jx - ilo[0];
-                int ii =
-                  ((kind * wdims_[2] + iz) * wdims_[1] + iy) * wdims_[0] + ix;
-                gidx_begin[ii] = recv_buf_p[info.rank][jj];
-                gidx_end[ii] = recv_buf_p[info.rank][jj + sz];
+                gidx_begin(ix, iy, iz, kind) = recv_buf_p[info.rank][jj];
+                gidx_end(ix, iy, iz, kind) = recv_buf_p[info.rank][jj + sz];
               }
             }
           }

--- a/src/libpsc/psc_output_particles/output_particles_hdf5_impl.hxx
+++ b/src/libpsc/psc_output_particles/output_particles_hdf5_impl.hxx
@@ -385,12 +385,11 @@ struct OutputParticlesHdf5
     struct mrc_patch_info info;
     int nr_kinds = mprts.grid().kinds.size();
 
-    int** off = (int**)malloc(mprts.n_patches() * sizeof(*off));
-    int** map = (int**)malloc(mprts.n_patches() * sizeof(*off));
+    std::vector<int*> off(mprts.n_patches());
+    std::vector<int*> map(mprts.n_patches());
+    std::vector<size_t*> idx(mprts.n_patches());
 
-    count_sort(mprts, map, off);
-
-    size_t** idx = (size_t**)malloc(mprts.n_patches() * sizeof(*idx));
+    count_sort(mprts, map.data(), off.data());
 
     size_t *gidx_begin = NULL, *gidx_end = NULL;
     if (rank == 0) {
@@ -415,8 +414,8 @@ struct OutputParticlesHdf5
 
     // find local particle and idx arrays
     size_t n_write, n_off, n_total;
-    hdf5_prt* arr = make_local_particle_array(mprts, map, off, idx, &n_write,
-                                              &n_off, &n_total);
+    hdf5_prt* arr = make_local_particle_array(
+      mprts, map.data(), off.data(), idx.data(), &n_write, &n_off, &n_total);
     prof_stop(pr_A);
 
     prof_start(pr_B);
@@ -611,9 +610,6 @@ struct OutputParticlesHdf5
       free(map[p]);
       free(idx[p]);
     }
-    free(off);
-    free(map);
-    free(idx);
   }
 
 private:

--- a/src/libpsc/psc_output_particles/output_particles_hdf5_impl.hxx
+++ b/src/libpsc/psc_output_particles/output_particles_hdf5_impl.hxx
@@ -325,11 +325,11 @@ struct OutputParticlesHdf5
            kind;
   };
 
-  template <typename Particle>
-  static inline int get_sort_index(Particles& prts, const Particle& prt)
+  static inline int get_sort_index(Particles& prts, int n)
   {
     const Grid_t& grid = prts.grid();
     const int* ldims = grid.ldims;
+    const auto& prt = prts[n];
 
     Int3 pos;
     for (int d = 0; d < 3; d++) {
@@ -361,8 +361,8 @@ struct OutputParticlesHdf5
       unsigned int n_prts = prts.size();
 
       // counting sort to get map
-      for (const auto& prt : prts) {
-        int si = get_sort_index(prts, prt);
+      for (int n = 0; n < n_prts; n++) {
+        int si = get_sort_index(prts, n);
         off[p][si]++;
       }
       // prefix sum to get offsets
@@ -377,10 +377,9 @@ struct OutputParticlesHdf5
 
       // sort a map only, not the actual particles
       map[p].resize(n_prts);
-      int n = 0;
-      for (const auto& prt : prts) {
-        int si = get_sort_index(prts, prt);
-        map[p][off2[si]++] = n++;
+      for (int n = 0; n < n_prts; n++) {
+        int si = get_sort_index(prts, n);
+        map[p][off2[si]++] = n;
       }
     }
   }

--- a/src/libpsc/psc_output_particles/output_particles_hdf5_impl.hxx
+++ b/src/libpsc/psc_output_particles/output_particles_hdf5_impl.hxx
@@ -313,8 +313,8 @@ struct OutputParticlesHdf5
     CE;
   }
 
-  void write_idx(const std::vector<size_t>& gidx_begin,
-                 const std::vector<size_t>& gidx_end, hid_t group, hid_t dxpl)
+  void write_idx(const size_t* gidx_begin, const size_t* gidx_end, hid_t group,
+                 hid_t dxpl)
   {
     herr_t ierr;
 
@@ -342,8 +342,8 @@ struct OutputParticlesHdf5
     hid_t dset = H5Dcreate(group, "idx_begin", H5T_NATIVE_HSIZE, filespace,
                            H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
     H5_CHK(dset);
-    ierr = H5Dwrite(dset, H5T_NATIVE_HSIZE, memspace, filespace, dxpl,
-                    gidx_begin.data());
+    ierr =
+      H5Dwrite(dset, H5T_NATIVE_HSIZE, memspace, filespace, dxpl, gidx_begin);
     CE;
     ierr = H5Dclose(dset);
     CE;
@@ -351,8 +351,8 @@ struct OutputParticlesHdf5
     dset = H5Dcreate(group, "idx_end", H5T_NATIVE_HSIZE, filespace, H5P_DEFAULT,
                      H5P_DEFAULT, H5P_DEFAULT);
     H5_CHK(dset);
-    ierr = H5Dwrite(dset, H5T_NATIVE_HSIZE, memspace, filespace, dxpl,
-                    gidx_end.data());
+    ierr =
+      H5Dwrite(dset, H5T_NATIVE_HSIZE, memspace, filespace, dxpl, gidx_end);
     CE;
     ierr = H5Dclose(dset);
     CE;
@@ -581,7 +581,7 @@ struct OutputParticlesHdf5
     prof_stop(pr_C);
 
     prof_start(pr_D);
-    write_idx(gidx_begin, gidx_end, groupp, dxpl);
+    write_idx(gidx_begin.data(), gidx_end.data(), groupp, dxpl);
     prof_stop(pr_D);
 
     prof_start(pr_E);

--- a/src/libpsc/psc_output_particles/output_particles_hdf5_impl.hxx
+++ b/src/libpsc/psc_output_particles/output_particles_hdf5_impl.hxx
@@ -293,7 +293,8 @@ struct OutputParticlesHdf5
       wdims_{hi - lo},
       kinds_{grid.kinds},
       comm_{grid.comm()},
-      prt_type_{prt_type}
+      prt_type_{prt_type},
+      writer_{wdims_, lo_, hi_, kinds_, comm_, prt_type_}
   {}
 
   // ----------------------------------------------------------------------
@@ -609,10 +610,8 @@ struct OutputParticlesHdf5
     }
     prof_stop(pr_B);
 
-    OutputParticlesWriterHDF5 writer(wdims_, lo_, hi_, kinds_, comm_,
-                                     prt_type_);
-    writer(gidx_begin, gidx_end, n_write, n_off, n_total, arr, filename,
-           params);
+    writer_(gidx_begin, gidx_end, n_write, n_off, n_total, arr, filename,
+            params);
   }
 
 private:
@@ -622,6 +621,7 @@ private:
   hid_t prt_type_;
   Grid_t::Kinds kinds_;
   MPI_Comm comm_;
+  OutputParticlesWriterHDF5 writer_;
 };
 
 } // namespace detail

--- a/src/libpsc/psc_output_particles/output_particles_hdf5_impl.hxx
+++ b/src/libpsc/psc_output_particles/output_particles_hdf5_impl.hxx
@@ -143,15 +143,15 @@ struct OutputParticlesHdf5
   // ----------------------------------------------------------------------
   // count_sort
 
-  static void count_sort(Mparticles& mprts, std::vector<int*>& off,
-                         std::vector<int*>& map)
+  static void count_sort(Mparticles& mprts, std::vector<std::vector<int>>& off,
+                         std::vector<std::vector<int>>& map)
   {
     int nr_kinds = mprts.grid().kinds.size();
 
     for (int p = 0; p < mprts.n_patches(); p++) {
       const int* ldims = mprts.grid().ldims;
       int nr_indices = ldims[0] * ldims[1] * ldims[2] * nr_kinds;
-      off[p] = (int*)calloc(nr_indices + 1, sizeof(*off[p]));
+      off[p].resize(nr_indices + 1);
       auto&& prts = mprts[p];
       unsigned int n_prts = prts.size();
 
@@ -171,7 +171,7 @@ struct OutputParticlesHdf5
       }
 
       // sort a map only, not the actual particles
-      map[p] = (int*)malloc(n_prts * sizeof(*map[p]));
+      map[p].resize(n_prts);
       int n = 0;
       for (const auto& prt : prts) {
         int si = get_sort_index(prts, prt);
@@ -200,8 +200,8 @@ struct OutputParticlesHdf5
   // make_local_particle_array
 
   hdf5_prt* make_local_particle_array(Mparticles& mprts,
-                                      const std::vector<int*>& off,
-                                      const std::vector<int*>& map,
+                                      const std::vector<std::vector<int>>& off,
+                                      const std::vector<std::vector<int>>& map,
                                       std::vector<size_t*>& idx,
                                       size_t* p_n_write, size_t* p_n_off,
                                       size_t* p_n_total)
@@ -388,8 +388,8 @@ struct OutputParticlesHdf5
     struct mrc_patch_info info;
     int nr_kinds = mprts.grid().kinds.size();
 
-    std::vector<int*> off(mprts.n_patches());
-    std::vector<int*> map(mprts.n_patches());
+    std::vector<std::vector<int>> off(mprts.n_patches());
+    std::vector<std::vector<int>> map(mprts.n_patches());
     std::vector<size_t*> idx(mprts.n_patches());
 
     count_sort(mprts, off, map);
@@ -609,8 +609,6 @@ struct OutputParticlesHdf5
     free(gidx_end);
 
     for (int p = 0; p < mprts.n_patches(); p++) {
-      free(off[p]);
-      free(map[p]);
       free(idx[p]);
     }
   }

--- a/src/libpsc/psc_output_particles/output_particles_hdf5_impl.hxx
+++ b/src/libpsc/psc_output_particles/output_particles_hdf5_impl.hxx
@@ -30,29 +30,34 @@ struct hdf5_prt
 #define MIN(a, b) ((a) < (b) ? (a) : (b))
 #define MAX(a, b) ((a) > (b) ? (a) : (b))
 
+namespace hdf5
+{
+
 // ----------------------------------------------------------------------
 // ToHdf5Type helper class
 
 template <typename T>
-struct ToHdf5Type;
+struct H5Type;
 
 template <>
-struct ToHdf5Type<int>
+struct H5Type<int>
 {
-  static hid_t H5Type() { return H5T_NATIVE_INT; }
+  static hid_t value() { return H5T_NATIVE_INT; }
 };
 
 template <>
-struct ToHdf5Type<unsigned long>
+struct H5Type<unsigned long>
 {
-  static hid_t H5Type() { return H5T_NATIVE_ULONG; }
+  static hid_t value() { return H5T_NATIVE_ULONG; }
 };
 
 template <>
-struct ToHdf5Type<unsigned long long>
+struct H5Type<unsigned long long>
 {
-  static hid_t H5Type() { return H5T_NATIVE_ULLONG; }
+  static hid_t value() { return H5T_NATIVE_ULLONG; }
 };
+
+} // namespace hdf5
 
 // ======================================================================
 // Hdf5ParticleType
@@ -73,9 +78,9 @@ public:
     H5Tinsert(id_, "m", HOFFSET(struct hdf5_prt, m), H5T_NATIVE_FLOAT);
     H5Tinsert(id_, "w", HOFFSET(struct hdf5_prt, w), H5T_NATIVE_FLOAT);
     H5Tinsert(id_, "id", HOFFSET(struct hdf5_prt, id),
-              ToHdf5Type<psc::particle::Id>::H5Type());
+              hdf5::H5Type<psc::particle::Id>::value());
     H5Tinsert(id_, "tag", HOFFSET(struct hdf5_prt, tag),
-              ToHdf5Type<psc::particle::Tag>::H5Type());
+              hdf5::H5Type<psc::particle::Tag>::value());
   }
 
   ~Hdf5ParticleType() { H5Tclose(id_); }

--- a/src/libpsc/psc_output_particles/output_particles_hdf5_impl.hxx
+++ b/src/libpsc/psc_output_particles/output_particles_hdf5_impl.hxx
@@ -89,12 +89,12 @@ private:
 class OutputParticlesWriterHDF5
 {
 public:
-  explicit OutputParticlesWriterHDF5(const Int3& wdims, const Int3& lo,
-                                     const Int3& hi, const Grid_t::Kinds& kinds,
-                                     MPI_Comm comm, hid_t prt_type)
-    : wdims_{wdims},
-      lo_{lo},
+  explicit OutputParticlesWriterHDF5(const Int3& lo, const Int3& hi,
+                                     const Grid_t::Kinds& kinds, MPI_Comm comm,
+                                     hid_t prt_type)
+    : lo_{lo},
       hi_{hi},
+      wdims_{hi - lo},
       kinds_{kinds},
       comm_{comm},
       prt_type_{prt_type}
@@ -293,8 +293,7 @@ struct OutputParticlesHdf5
       wdims_{hi - lo},
       kinds_{grid.kinds},
       comm_{grid.comm()},
-      prt_type_{prt_type},
-      writer_{wdims_, lo_, hi_, kinds_, comm_, prt_type_}
+      writer_{lo_, hi_, kinds_, comm_, prt_type}
   {}
 
   // ----------------------------------------------------------------------
@@ -618,7 +617,6 @@ private:
   Int3 lo_;
   Int3 hi_;
   Int3 wdims_;
-  hid_t prt_type_;
   Grid_t::Kinds kinds_;
   MPI_Comm comm_;
   OutputParticlesWriterHDF5 writer_;

--- a/src/libpsc/psc_output_particles/output_particles_hdf5_impl.hxx
+++ b/src/libpsc/psc_output_particles/output_particles_hdf5_impl.hxx
@@ -398,20 +398,9 @@ struct OutputParticlesHdf5
     std::vector<size_t> gidx_begin, gidx_end;
     if (rank == 0) {
       // alloc global idx array
-      gidx_begin.resize(nr_kinds * wdims_[0] * wdims_[1] * wdims_[2]);
-      gidx_end.resize(nr_kinds * wdims_[0] * wdims_[1] * wdims_[2]);
-      for (int jz = 0; jz < wdims_[2]; jz++) {
-        for (int jy = 0; jy < wdims_[1]; jy++) {
-          for (int jx = 0; jx < wdims_[0]; jx++) {
-            for (int kind = 0; kind < nr_kinds; kind++) {
-              int ii =
-                ((kind * wdims_[2] + jz) * wdims_[1] + jy) * wdims_[0] + jx;
-              gidx_begin[ii] = size_t(-1);
-              gidx_end[ii] = size_t(-1);
-            }
-          }
-        }
-      }
+      gidx_begin.resize(nr_kinds * wdims_[0] * wdims_[1] * wdims_[2],
+                        size_t(-1));
+      gidx_end.resize(nr_kinds * wdims_[0] * wdims_[1] * wdims_[2], size_t(-1));
     }
 
     // find local particle and idx arrays

--- a/src/libpsc/tests/test_output_particles.cxx
+++ b/src/libpsc/tests/test_output_particles.cxx
@@ -64,14 +64,14 @@ private:
   Int3 ibn = {2, 2, 2};
 };
 
-using OutputParticlesTestTypes =
-  ::testing::Types<Config<dim_xyz, MparticlesSingle, OutputParticlesAscii>
+using OutputParticlesTestTypes = ::testing::Types<
+  Config<dim_xyz, MparticlesSingle, OutputParticlesAscii>
 #ifdef H5_HAVE_PARALLEL
-                   ,
-                   Config<dim_xyz, MparticlesSingle, OutputParticlesHdf5>,
-                   Config<dim_xyz, MparticlesDouble, OutputParticlesHdf5>
+  ,
+  Config<dim_xyz, MparticlesSingle, OutputParticlesHdf5<ParticleSelectorAll>>,
+  Config<dim_xyz, MparticlesDouble, OutputParticlesHdf5<ParticleSelectorAll>>
 #endif
-                   >;
+  >;
 
 TYPED_TEST_SUITE(OutputParticlesTest, OutputParticlesTestTypes);
 

--- a/src/libpsc/tests/test_output_particles.cxx
+++ b/src/libpsc/tests/test_output_particles.cxx
@@ -93,7 +93,7 @@ TYPED_TEST(OutputParticlesTest, Test1)
   {
     auto injector = mprts.injector();
     injector[0]({{1., 0., 0.}, {}, 1., 0});
-    injector[0]({{2., 0., 0.}, {}, 1., 1});
+    injector[0]({{40., 0., 0.}, {}, 1., 1});
   }
 
   auto params = OutputParticlesParams{};

--- a/src/libpsc/tests/test_output_particles.cxx
+++ b/src/libpsc/tests/test_output_particles.cxx
@@ -38,7 +38,8 @@ struct OutputParticlesTest : ::testing::Test
       ibn[2] = 0;
     }
 
-    auto grid_domain = Grid_t::Domain{gdims, {L, L, L}};
+    auto grid_domain =
+      Grid_t::Domain{gdims, {L, L, L}, {0., 0., 0.}, {2, 1, 1}};
     auto grid_bc =
       psc::grid::BC{{BND_FLD_PERIODIC, BND_FLD_PERIODIC, BND_FLD_PERIODIC},
                     {BND_FLD_PERIODIC, BND_FLD_PERIODIC, BND_FLD_PERIODIC},
@@ -92,8 +93,15 @@ TYPED_TEST(OutputParticlesTest, Test1)
   Mparticles mprts{grid};
   {
     auto injector = mprts.injector();
-    injector[0]({{1., 0., 0.}, {}, 1., 0});
-    injector[0]({{40., 0., 0.}, {}, 1., 1});
+    for (int p = 0; p < grid.n_patches(); p++) {
+      auto info = grid.mrc_domain().localPatchInfo(p);
+      if (info.global_patch == 0) {
+        injector[p]({{1., 0., 0.}, {}, 1., 0});
+      }
+      if (info.global_patch == 1) {
+        injector[p]({{121., 0., 0.}, {}, 1., 1});
+      }
+    }
   }
 
   auto params = OutputParticlesParams{};

--- a/src/psc_config.hxx
+++ b/src/psc_config.hxx
@@ -31,7 +31,7 @@
 
 #include "../libpsc/vpic/fields_item_vpic.hxx"
 
-using OutputParticlesDefault = OutputParticlesHdf5;
+using OutputParticlesDefault = OutputParticlesHdf5<ParticleSelectorAll>;
 
 struct SimulationNone
 {
@@ -252,7 +252,7 @@ struct PscConfigVpicPsc
   using BndParticles = BndParticlesVpic<Mparticles>;
   using Checks = ChecksVpic<Mparticles, MfieldsState>;
   using Marder = MarderVpic<Mparticles, MfieldsState>;
-  using OutputParticles = OutputParticlesHdf5;
+  using OutputParticles = OutputParticlesHdf5<ParticleSelectorAll>;
   using OutputHydro = OutputHydroQ<Mparticles, MfieldsHydro,
                                    typename VpicConfig::MfieldsInterpolator>;
   using Dim = dim_xz;

--- a/src/psc_flatfoil_yz.cxx
+++ b/src/psc_flatfoil_yz.cxx
@@ -537,9 +537,14 @@ void run()
 
   // -- output particles
   OutputParticlesParams outp_params{};
+#if CASE == CASE_2D_SMALL
+  outp_params.every_step = 4;
+#else
   outp_params.every_step = -400;
+#endif
   outp_params.data_dir = ".";
   outp_params.basename = "prt";
+  outp_params.lo = {0, 0, grid.domain.gdims[2] / 2};
   OutputParticles outp{grid, outp_params};
 
   int oute_interval = -100;

--- a/src/psc_flatfoil_yz.cxx
+++ b/src/psc_flatfoil_yz.cxx
@@ -226,7 +226,11 @@ using Balance = PscConfig::Balance;
 using Collision = PscConfig::Collision;
 using Checks = PscConfig::Checks;
 using Marder = PscConfig::Marder;
+#if CASE == CASE_2D_SMALL
+using OutputParticles = OutputParticlesHdf5<ParticleSelectorEveryNth<10>>;
+#else
 using OutputParticles = PscConfig::OutputParticles;
+#endif
 using Moment_n = typename Moment_n_Selector<Mparticles, Dim>::type;
 using Heating = typename HeatingSelector<Mparticles>::Heating;
 


### PR DESCRIPTION
Besides general cleanup / modernization and preparation for output formats other than HDF5 (ie., ADIOS2), this adds the capability to select a subset of particles to be written. For now, other than selecting all particles, a simple `ParticleSelectorEveryNth<N>` is provided to cut down on the number of particles written.