### PR TITLE
Add gauss output to `adios2cfg.xml`

### DIFF
--- a/bits/adios2cfg.xml
+++ b/bits/adios2cfg.xml
@@ -20,6 +20,11 @@
             <parameter key="SubStreams" value="16"/>
         </engine>
     </io>
+    <io name="gauss">
+        <engine type="BP4">
+            <parameter key="SubStreams" value="16"/>
+        </engine>
+    </io>
     <io name="checkpoint">
         <engine type="BP4">
             <parameter key="SubStreams" value="16"/>


### PR DESCRIPTION
This fixes a discrepancy in how scalars are written. Specifically, `time` and `step` will now be written as scalars instead of length-1 arrays.