### PR TITLE
Fix adios2cfg

### DIFF
--- a/bits/adios2cfg.xml
+++ b/bits/adios2cfg.xml
@@ -25,6 +25,11 @@
             <parameter key="SubStreams" value="16"/>
         </engine>
     </io>
+    <io name="continuity">
+        <engine type="BP4">
+            <parameter key="SubStreams" value="16"/>
+        </engine>
+    </io>
     <io name="checkpoint">
         <engine type="BP4">
             <parameter key="SubStreams" value="16"/>

--- a/bits/adios2cfg.xml
+++ b/bits/adios2cfg.xml
@@ -20,6 +20,11 @@
             <parameter key="SubStreams" value="16"/>
         </engine>
     </io>
+    <io name="gauss">
+        <engine type="BP4">
+            <parameter key="SubStreams" value="16"/>
+        </engine>
+    </io>
     <io name="checkpoint">
         <engine type="BP4">
             <parameter key="SubStreams" value="16"/>


### PR DESCRIPTION
Adds `continuity` and `gauss` output. Among possibly other things, this causes `time` to be stored as a scalar instead of a length-1 array for those outputs.