### PR TITLE
Cleanup `centering`

### DIFF
--- a/src/include/centering.hxx
+++ b/src/include/centering.hxx
@@ -31,7 +31,7 @@ CC  |   ccc ccc ccc
 */
 
 template <typename PATCH>
-Double3 getPos(PATCH patch, Int3 index, int style, int comp = X)
+Double3 get_pos(PATCH patch, Int3 index, int style, int comp = X)
 {
   Double3 pos;
   for (int a = 0; a < 3; a++) {
@@ -51,9 +51,9 @@ struct Centerer
   Centerer(CenterStyle style) : style(style) {}
 
   template <typename PATCH>
-  inline Double3 getPos(PATCH patch, Int3 index, int comp = X) const
+  inline Double3 get_pos(PATCH patch, Int3 index, int comp = X) const
   {
-    return centering::getPos(patch, index, style, comp);
+    return centering::get_pos(patch, index, style, comp);
   }
 };
 

--- a/src/include/centering.hxx
+++ b/src/include/centering.hxx
@@ -6,7 +6,7 @@
 namespace centering
 {
 
-enum CenterStyle
+enum Centering
 {
   NC, // node-centered
   EC, // edge-centered
@@ -24,16 +24,15 @@ CC  |   ccc ccc ccc
 */
 
 template <typename PATCH>
-Double3 get_pos(PATCH patch, Int3 index, CenterStyle style, int component = -1)
+Double3 get_pos(PATCH patch, Int3 index, Centering c, int component = -1)
 {
   if (component == -1) {
-    assert(style == NC || style == CC);
+    assert(c == NC || c == CC);
   }
 
   Double3 pos;
   for (int d = 0; d < 3; d++) {
-    if (style == CC || (style == FC && d != component) ||
-        (style == EC && d == component)) {
+    if (c == CC || (c == FC && d != component) || (c == EC && d == component)) {
       pos[d] = patch.get_cc(index[d], d);
     } else {
       pos[d] = patch.get_nc(index[d], d);
@@ -44,13 +43,13 @@ Double3 get_pos(PATCH patch, Int3 index, CenterStyle style, int component = -1)
 
 struct Centerer
 {
-  CenterStyle style;
-  Centerer(CenterStyle style) : style(style) {}
+  Centering c;
+  Centerer(Centering c) : c(c) {}
 
   template <typename PATCH>
   inline Double3 get_pos(PATCH patch, Int3 index, int component = -1) const
   {
-    return centering::get_pos(patch, index, style, component);
+    return centering::get_pos(patch, index, c, component);
   }
 };
 

--- a/src/include/centering.hxx
+++ b/src/include/centering.hxx
@@ -3,7 +3,7 @@
 
 #include "kg/Vec3.h"
 
-namespace Centering
+namespace centering
 {
 
 enum CenterStyle
@@ -53,8 +53,8 @@ struct Centerer
   template <typename PATCH>
   inline Double3 getPos(PATCH patch, Int3 index, int comp = X) const
   {
-    return Centering::getPos(patch, index, style, comp);
+    return centering::getPos(patch, index, style, comp);
   }
 };
 
-} // namespace Centering
+} // namespace centering

--- a/src/include/centering.hxx
+++ b/src/include/centering.hxx
@@ -14,13 +14,6 @@ enum CenterStyle
   CC, // cell-centered
 };
 
-enum Component
-{
-  X,
-  Y,
-  Z
-};
-
 /*  Centering Guide
          X   Y   Z
        -------------
@@ -31,15 +24,19 @@ CC  |   ccc ccc ccc
 */
 
 template <typename PATCH>
-Double3 get_pos(PATCH patch, Int3 index, int style, int comp = X)
+Double3 get_pos(PATCH patch, Int3 index, int style, int component = -1)
 {
+  if (component == -1) {
+    assert(style == NC || style == CC);
+  }
+
   Double3 pos;
-  for (int a = 0; a < 3; a++) {
-    if (style == CC || (style == FC && a != comp) ||
-        (style == EC && a == comp)) {
-      pos[a] = patch.get_cc(index[a], a);
+  for (int d = 0; d < 3; d++) {
+    if (style == CC || (style == FC && d != component) ||
+        (style == EC && d == component)) {
+      pos[d] = patch.get_cc(index[d], d);
     } else {
-      pos[a] = patch.get_nc(index[a], a);
+      pos[d] = patch.get_nc(index[d], d);
     }
   }
   return pos;
@@ -51,9 +48,9 @@ struct Centerer
   Centerer(CenterStyle style) : style(style) {}
 
   template <typename PATCH>
-  inline Double3 get_pos(PATCH patch, Int3 index, int comp = X) const
+  inline Double3 get_pos(PATCH patch, Int3 index, int component = -1) const
   {
-    return centering::get_pos(patch, index, style, comp);
+    return centering::get_pos(patch, index, style, component);
   }
 };
 

--- a/src/include/centering.hxx
+++ b/src/include/centering.hxx
@@ -24,7 +24,7 @@ CC  |   ccc ccc ccc
 */
 
 template <typename PATCH>
-Double3 get_pos(PATCH patch, Int3 index, int style, int component = -1)
+Double3 get_pos(PATCH patch, Int3 index, CenterStyle style, int component = -1)
 {
   if (component == -1) {
     assert(style == NC || style == CC);

--- a/src/include/setup_fields.hxx
+++ b/src/include/setup_fields.hxx
@@ -35,11 +35,11 @@ struct SetupFields
 
         for (int c = 0; c < 3; c++) {
           F(HX + c, jx, jy, jz) +=
-            func(HX + c, Centering::getPos(patch, index, Centering::FC, c));
+            func(HX + c, centering::getPos(patch, index, centering::FC, c));
           F(EX + c, jx, jy, jz) +=
-            func(EX + c, Centering::getPos(patch, index, Centering::EC, c));
+            func(EX + c, centering::getPos(patch, index, centering::EC, c));
           F(JXI + c, jx, jy, jz) +=
-            func(JXI + c, Centering::getPos(patch, index, Centering::EC, c));
+            func(JXI + c, centering::getPos(patch, index, centering::EC, c));
         }
       });
     }
@@ -47,7 +47,7 @@ struct SetupFields
 
   template <typename FUNC>
   static void runScalar(Mfields& mf, FUNC&& func,
-                        const Centering::Centerer& centerer)
+                        const centering::Centerer& centerer)
   {
     const auto& grid = mf.grid();
     mpi_printf(grid.comm(), "**** Setting up scalar field...\n");
@@ -77,7 +77,7 @@ void setupFields(MF& mflds, FUNC&& func)
 
 // func signature: (int component, Double3 position) -> double fieldValue
 template <typename MF, typename FUNC>
-void setupScalarField(MF& fld, const Centering::Centerer& centerer, FUNC&& func)
+void setupScalarField(MF& fld, const centering::Centerer& centerer, FUNC&& func)
 {
   detail::SetupFields<MF>::runScalar(fld, std::forward<FUNC>(func), centerer);
 }

--- a/src/include/setup_fields.hxx
+++ b/src/include/setup_fields.hxx
@@ -35,11 +35,11 @@ struct SetupFields
 
         for (int c = 0; c < 3; c++) {
           F(HX + c, jx, jy, jz) +=
-            func(HX + c, centering::getPos(patch, index, centering::FC, c));
+            func(HX + c, centering::get_pos(patch, index, centering::FC, c));
           F(EX + c, jx, jy, jz) +=
-            func(EX + c, centering::getPos(patch, index, centering::EC, c));
+            func(EX + c, centering::get_pos(patch, index, centering::EC, c));
           F(JXI + c, jx, jy, jz) +=
-            func(JXI + c, centering::getPos(patch, index, centering::EC, c));
+            func(JXI + c, centering::get_pos(patch, index, centering::EC, c));
         }
       });
     }
@@ -60,7 +60,7 @@ struct SetupFields
         std::max({mf.ibn()[0], mf.ibn()[1], mf.ibn()[2]}); // FIXME, not pretty
       // FIXME, do we need the ghost points?
       grid.Foreach_3d(n_ghosts, n_ghosts, [&](int jx, int jy, int jz) {
-        F(0, jx, jy, jz) += func(0, centerer.getPos(patch, {jx, jy, jz}));
+        F(0, jx, jy, jz) += func(0, centerer.get_pos(patch, {jx, jy, jz}));
       });
     }
   }

--- a/src/include/setup_particles.hxx
+++ b/src/include/setup_particles.hxx
@@ -29,7 +29,7 @@ struct psc_particle_np
 
 namespace
 {
-const Centering::Centerer defaultCenterer(Centering::CC);
+const centering::Centerer defaultCenterer(centering::CC);
 }
 
 struct InitNptFunc
@@ -319,7 +319,7 @@ struct SetupParticles
   bool fractional_n_particles_per_cell = {false};
   bool initial_momentum_gamma_correction = {false};
 
-  Centering::Centerer centerer;
+  centering::Centerer centerer;
 
 private:
   const Grid_t::Kinds kinds_;

--- a/src/include/setup_particles.hxx
+++ b/src/include/setup_particles.hxx
@@ -142,7 +142,7 @@ struct SetupParticles
         for (int jx = ilo[0]; jx < ihi[0]; jx++) {
           Int3 index{jx, jy, jz};
 
-          Double3 pos = centerer.getPos(grid.patches[patch], index);
+          Double3 pos = centerer.get_pos(grid.patches[patch], index);
           // FIXME, the issue really is that (2nd order) particle pushers
           // don't handle the invariant dim right
           for (int a = 0; a < 3; ++a) {

--- a/src/psc_bgk.cxx
+++ b/src/psc_bgk.cxx
@@ -328,7 +328,7 @@ void initializeParticles(Balance& balance, Grid_t*& grid_ptr, Mparticles& mprts,
                          BgkMfields& divGradPhi)
 {
   SetupParticles<Mparticles> setup_particles(*grid_ptr);
-  setup_particles.centerer = Centering::Centerer(Centering::NC);
+  setup_particles.centerer = centering::Centerer(centering::NC);
 
   auto&& qDensity = -psc::mflds::interior(divGradPhi.grid(), divGradPhi.gt());
 
@@ -408,7 +408,7 @@ void fillGhosts(MF& mfld, int compBegin, int compEnd)
 void initializePhi(BgkMfields& phi)
 {
   setupScalarField(
-    phi, Centering::Centerer(Centering::NC), [&](int m, double crd[3]) {
+    phi, centering::Centerer(centering::NC), [&](int m, double crd[3]) {
       double rho = sqrt(sqr(getCoord(crd[1])) + sqr(getCoord(crd[2])));
       return ic_table->get_interpolated("Psi", "rho", rho);
     });

--- a/src/psc_radiation.cxx
+++ b/src/psc_radiation.cxx
@@ -250,7 +250,7 @@ void run()
       auto F = make_Fields3d<Dim>(mflds[p]);
       grid.Foreach_3d(0, 0, [&](int i, int j, int k) {
         Int3 index{i, j, k};
-        auto crd_ec_z = centering::getPos(patch, index, centering::EC, 2);
+        auto crd_ec_z = centering::get_pos(patch, index, centering::EC, 2);
 #if 0
         double r =
           std::sqrt(sqr(crd_ec_z[0]) + sqr(crd_ec_z[1]) + sqr(crd_ec_z[2]));

--- a/src/psc_radiation.cxx
+++ b/src/psc_radiation.cxx
@@ -250,7 +250,7 @@ void run()
       auto F = make_Fields3d<Dim>(mflds[p]);
       grid.Foreach_3d(0, 0, [&](int i, int j, int k) {
         Int3 index{i, j, k};
-        auto crd_ec_z = Centering::getPos(patch, index, Centering::EC, 2);
+        auto crd_ec_z = centering::getPos(patch, index, centering::EC, 2);
 #if 0
         double r =
           std::sqrt(sqr(crd_ec_z[0]) + sqr(crd_ec_z[1]) + sqr(crd_ec_z[2]));

--- a/src/psc_shock.cxx
+++ b/src/psc_shock.cxx
@@ -190,7 +190,7 @@ Grid_t* setupGrid()
 void initializeParticles(Balance& balance, Grid_t*& grid_ptr, Mparticles& mprts)
 {
   SetupParticles<Mparticles> setup_particles(*grid_ptr);
-  setup_particles.centerer = Centering::Centerer(Centering::CC);
+  setup_particles.centerer = centering::Centerer(centering::CC);
   setup_particles.initial_momentum_gamma_correction = true;
 
   auto init_np = [&](int kind, Double3 crd, int p, Int3 idx,


### PR DESCRIPTION
Make naming more consistent with the rest of PSC, and add an assert for when one accidentally uses a default argument that should have been specified.