### PR TITLE
Patch accessor stores `mprts`

### DIFF
--- a/src/include/const_accessor_simple.hxx
+++ b/src/include/const_accessor_simple.hxx
@@ -1,4 +1,3 @@
-
 #pragma once
 
 // ======================================================================
@@ -181,20 +180,20 @@ struct ConstAccessorPatchSimple
     uint n_;
   };
 
-  ConstAccessorPatchSimple(const ConstAccessorSimple& accessor, int p)
-    : accessor_{accessor}, p_{p}
+  ConstAccessorPatchSimple(const Mparticles& mprts, int p)
+    : mprts_{mprts}, p_{p}
   {}
 
   const_iterator begin() const { return {*this, 0}; }
   const_iterator end() const { return {*this, size()}; }
   ConstParticleProxy operator[](int n) const
   {
-    return {accessor_.data(p_)[n], accessor_.mprts(), p_};
+    return {mprts_[p_].begin()[n], mprts_, p_};
   }
-  uint size() const { return accessor_.size(p_); }
+  uint size() const { return mprts_[p_].size(); }
 
 private:
-  const ConstAccessorSimple& accessor_;
+  const Mparticles& mprts_;
   const int p_;
 };
 
@@ -210,7 +209,7 @@ struct ConstAccessorSimple
 
   ConstAccessorSimple(Mparticles& mprts) : mprts_{mprts} {}
 
-  Patch operator[](int p) const { return {*this, p}; }
+  Patch operator[](int p) const { return {mprts_, p}; }
   const Mparticles& mprts() const { return mprts_; }
   uint size(int p) const { return mprts_[p].size(); }
   typename Mparticles::Patch::iterator data(int p) const

--- a/src/libpsc/cuda/mparticles_patch_cuda.hxx
+++ b/src/libpsc/cuda/mparticles_patch_cuda.hxx
@@ -27,7 +27,7 @@ struct ConstAccessorCuda
       off_{mprts.get_offsets()}
   {}
 
-  Patch operator[](int p) const { return {*this, p}; }
+  Patch operator[](int p) const { return {mprts_, p}; }
   Mparticles& mprts() const { return mprts_; }
   const _Particle* data(int p) const { return &data_[off_[p]]; }
   uint size(int p) const { return off_[p + 1] - off_[p]; }


### PR DESCRIPTION
This makes it safe to do `mprts.accessor()[p]` without having to worry about the result of `mprts.accessor()` being dropped.