### PR TITLE
Move particle injection and change its call signature

### DIFF
--- a/src/include/psc.hxx
+++ b/src/include/psc.hxx
@@ -500,7 +500,7 @@ struct Psc
 
     // === particle injection
     prof_start(pr_inject_prts);
-    inject_particles_(grid(), mprts_);
+    inject_particles_(mprts_, mflds_);
     prof_stop(pr_inject_prts);
 
     // === field propagation B^{n+1/2} -> B^{n+1}

--- a/src/include/psc.hxx
+++ b/src/include/psc.hxx
@@ -484,11 +484,6 @@ struct Psc
       prof_stop(pr_collision);
     }
 
-    // === particle injection
-    prof_start(pr_inject_prts);
-    inject_particles_(grid(), mprts_);
-    prof_stop(pr_inject_prts);
-
     if (checks_.continuity.should_do_check(timestep)) {
       mpi_printf(comm, "***** Checking continuity...\n");
       prof_start(pr_checks);
@@ -502,6 +497,11 @@ struct Psc
     pushp_.push_mprts(mprts_, mflds_);
     prof_stop(pr_push_prts);
     // state is now: x^{n+3/2}, p^{n+1}, E^{n+1/2}, B^{n+1/2}, j^{n+1}
+
+    // === particle injection
+    prof_start(pr_inject_prts);
+    inject_particles_(grid(), mprts_);
+    prof_stop(pr_inject_prts);
 
     // === field propagation B^{n+1/2} -> B^{n+1}
     mpi_printf(comm, "***** Pushing B...\n");

--- a/src/include/psc.hxx
+++ b/src/include/psc.hxx
@@ -748,8 +748,8 @@ protected:
 class InjectParticlesNone
 {
 public:
-  template <typename Mparticles>
-  void operator()(const Grid_t& grid, Mparticles& mprts)
+  template <typename Mparticles, typename MfieldsState>
+  void operator()(Mparticles& mprts, MfieldsState& mflds)
   {}
 };
 

--- a/src/include/psc.hxx
+++ b/src/include/psc.hxx
@@ -486,7 +486,7 @@ struct Psc
 
     // === particle injection
     prof_start(pr_inject_prts);
-    inject_particles();
+    inject_particles_(grid(), mprts_);
     prof_stop(pr_inject_prts);
 
     if (checks_.continuity.should_do_check(timestep)) {
@@ -590,11 +590,6 @@ struct Psc
     step_psc();
 #endif
   }
-
-  // ----------------------------------------------------------------------
-  // inject_particles
-
-  void inject_particles() { return this->inject_particles_(grid(), mprts_); }
 
 private:
   // ----------------------------------------------------------------------

--- a/src/psc_2d_shock.cxx
+++ b/src/psc_2d_shock.cxx
@@ -548,7 +548,9 @@ void run()
   double inject_fac = (g.inject_interval * grid.dt / inject_tau) /
                       (1. + g.inject_interval * grid.dt / inject_tau);
 
-  auto lf_inject_heat = [&](const Grid_t& grid, Mparticles& mprts) {
+  auto lf_inject_heat = [&](Mparticles& mprts, MfieldsState& mflds) {
+    const Grid_t& grid = mprts.grid();
+
     static int pr_inject, pr_heating;
     if (!pr_inject) {
       pr_inject = prof_register("inject", 1., 0, 0);

--- a/src/psc_flatfoil_yz.cxx
+++ b/src/psc_flatfoil_yz.cxx
@@ -617,7 +617,9 @@ void run()
   double inject_fac = (g.inject_interval * grid.dt / inject_tau) /
                       (1. + g.inject_interval * grid.dt / inject_tau);
 
-  auto lf_inject_heat = [&](const Grid_t& grid, Mparticles& mprts) {
+  auto lf_inject_heat = [&](Mparticles& mprts, MfieldsState& mflds) {
+    const Grid_t& grid = mprts.grid();
+
     static int pr_inject, pr_heating;
     if (!pr_inject) {
       pr_inject = prof_register("inject", 1., 0, 0);


### PR DESCRIPTION
Injection moved from before particle push (and continuity precheck) to after push. It remains to check that psc_flatfoil_yz still works as intended.

Also, the call signature was changed from `(grid, mprts)` to `(mprts, mflds)`.