### PR TITLE
Fix doc links to include Marvin guide

### DIFF
--- a/docs/guide/installation/installation.rst
+++ b/docs/guide/installation/installation.rst
@@ -97,6 +97,7 @@ Legacy Build Instructions
    generic
    summit
    trillian
+   marvin
    viscid
 
 

--- a/docs/guide/installation/marvin.rst
+++ b/docs/guide/installation/marvin.rst
@@ -1,6 +1,6 @@
 
-Installing on Marvin
-********************
+Building and Running on Marvin/Plasma (at UNH)
+**********************************************
 
 There are two main approaches using Spack. The first option is using Spack to directly install psc (i.e., ``spack install psc``) after a few preparatory steps, and then later manually loading PSC's immediate dependencies to actually compile (e.g., ``spack load cmake``). The second approach is outlined below and results in a Spack environment in which PSC can be compiled.
 


### PR DESCRIPTION
Maybe I misunderstand how the docs are generated, but my hope is that this will actually make [psc.readthedocs.io/en/latest/installation/marvin.html](https://psc.readthedocs.io/en/latest/installation/marvin.html) exist and be reachable from [psc.readthedocs.io/en/latest/installation/installation.html](https://psc.readthedocs.io/en/latest/installation/installation.html)