### PR TITLE
Shock: add `mirror_domain` param

### DIFF
--- a/src/psc_shock.cxx
+++ b/src/psc_shock.cxx
@@ -229,7 +229,7 @@ void initializeFields(MfieldsState& mflds)
     switch (component) {
       case EX: return e_x;
       case EY: return e_y;
-      case EZ: return (coords[1] > ny ? -1 : coords[1] == ny ? 0 : 1) * e_z;
+      case EZ: return (coords[1] > len_y ? -1 : 1) * e_z;
       case HX: return b_x;
       case HY: return b_y;
       case HZ: return b_z;

--- a/src/psc_shock.cxx
+++ b/src/psc_shock.cxx
@@ -25,7 +25,6 @@ using PscConfig = PscConfig1vbecDouble<Dim>;
 
 // ----------------------------------------------------------------------
 
-using BgkMfields = PscConfig::Mfields;
 using MfieldsState = PscConfig::MfieldsState;
 using Mparticles = PscConfig::Mparticles;
 using Balance = PscConfig::Balance;
@@ -258,9 +257,6 @@ static void run(int argc, char** argv)
   auto& grid = *grid_ptr;
   MfieldsState mflds{grid};
   Mparticles mprts{grid};
-  BgkMfields phi{grid, 1, mflds.ibn()};
-  BgkMfields gradPhi{grid, 3, mflds.ibn()};
-  BgkMfields divGradPhi{grid, 1, mflds.ibn()};
 
   // ----------------------------------------------------------------------
   // Set up various objects needed to run this case

--- a/src/psc_shock.cxx
+++ b/src/psc_shock.cxx
@@ -276,8 +276,7 @@ static void run(int argc, char** argv)
   // -- Checks
   ChecksParams checks_params{};
   checks_params.gauss.check_interval = out_interval;
-  // checks_params.gauss.dump_always = true;
-  checks_params.gauss.err_threshold = 1e-5;
+  checks_params.continuity.check_interval = out_interval;
 
   Checks checks{grid, MPI_COMM_WORLD, checks_params};
 

--- a/src/psc_shock.cxx
+++ b/src/psc_shock.cxx
@@ -72,6 +72,8 @@ double len_z;
 
 int out_interval;
 
+bool mirrored_domain;
+
 } // namespace
 
 // ======================================================================
@@ -129,6 +131,8 @@ void setupParameters(int argc, char** argv)
 
   int n_writes = parsedParams.getOrDefault<int>("n_writes", 100);
   out_interval = psc_params.nmax / n_writes;
+
+  mirrored_domain = parsedParams.getOrDefault<bool>("mirrored_domain", false);
 
   std::ifstream src(path_to_params, std::ios::binary);
   std::ofstream dst("params_record.txt", std::ios::binary);


### PR DESCRIPTION
Set `mirror_domain true` to double the domain size and put an antisymmetric stream of particles in the right half